### PR TITLE
Little bit cleaner reuse.

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -124,38 +124,8 @@ Backbone.Marionette = (function(Backbone, _, $){
     }
   });
 
-  // Helpers
-  // -------
-
-  // The 'inherits' and 'extend' functions are taken directly from:
-  // Backbone.js 0.5.3
-  // (c) 2010 Jeremy Ashkenas, DocumentCloud Inc.
-  // http://documentcloud.github.com/backbone
-
-  var extend = function (protoProps, classProps) {
-    var child = inherits(this, protoProps, classProps);
-    child.extend = this.extend;
-    return child;
-  };
-
-  var ctor = function(){};
-  var inherits = function(parent, protoProps, staticProps) {
-    var child;
-    if (protoProps && protoProps.hasOwnProperty('constructor')) {
-      child = protoProps.constructor;
-    } else {
-      child = function(){ return parent.apply(this, arguments); };
-    }
-    _.extend(child, parent);
-    ctor.prototype = parent.prototype;
-    child.prototype = new ctor();
-    if (protoProps) _.extend(child.prototype, protoProps);
-    if (staticProps) _.extend(child, staticProps);
-    child.prototype.constructor = child;
-    child.__super__ = parent.prototype;
-    return child;
-  };
-
+  // Copy the `extend` function used by Backbone's classes
+  var extend = Backbone.View.extend;
   Marionette.RegionManager.extend = extend;
   Marionette.Application.extend = extend;
 


### PR DESCRIPTION
Just saw this as I was reading your code and thought I'd send in a quick pull request.

There's no need to copy-paste the `extend` and `inherits` utility functions when you can just copy the `extend` function directly from Backbone.View (or Model or Collection or Router). :)
