### PR TITLE
added support for Zepto and ender

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -406,4 +406,4 @@ Backbone.Marionette = (function(Backbone, _, $){
   _.extend(Marionette.Application.prototype, Marionette.BindTo);
 
   return Marionette;
-})(Backbone, _, window.jQuery || window.ender);
+})(Backbone, _, window.jQuery || window.Zepto || window.ender);


### PR DESCRIPTION
it's a simple change since these libs are using a jQuery-like interface. And, the only use case in Marionette is to ask an object from a selector and loading the html content of this one.
