### PR TITLE
Take advantage of jQuery deferred

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -48,11 +48,13 @@ Backbone.Marionette = (function(Backbone, _, $){
     },
 
     _openView: function(view){
-      view.render();
-      this.$el.html(view.el);
-      if (view.onShow){
-        view.onShow();
-      }
+      var that = this;
+      $.when(view.render()).then(function () {
+        that.$el.html(view.el);
+        if (view.onShow) {
+          view.onShow();
+        }
+      });
     }
   });
 


### PR DESCRIPTION
to take into account overridden render methods who want to take advantage of async template rendering. When a render method passed into the .when is not a deferred it will be treated as a resolved Deferred and any doneCallbacks attached will be executed immediately so it is not a breaking change, it does however put a dependency on jQuery 1.5+.

I need this since I have had to customize our itemview rendering because when using external templates and rendering a collection the app was requesting the template x times since as there was no deferred to wait for the first non cached template response - so I had to implement this functionality but not sure if it fits with what you want?
