### PR TITLE
Supports defining the controller in the router's definition.

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -377,7 +377,11 @@ Backbone.Marionette = (function(Backbone, _, $){
       Backbone.Router.prototype.constructor.call(this, options);
 
       if (this.appRoutes){
-        this.processAppRoutes(options.controller, this.appRoutes);
+        var controller = this.controller;
+        if (options && options.controller) {
+          controller = options.controller;
+        }
+        this.processAppRoutes(controller, this.appRoutes);
       }
     },
 

--- a/spec/javascripts/appRouter.spec.js
+++ b/spec/javascripts/appRouter.spec.js
@@ -25,7 +25,33 @@ describe("app router", function(){
       router.navigate("m1", true);
     });
 
-    it("should call the configured method on the specified controller", function(){
+    it("should call the configured method on the controller passed in the constructor", function(){
+      expect(controller.method1).toHaveBeenCalled();
+    });
+  });
+
+  describe("when a route fires", function(){
+    var controller = {
+      method1: function(){},
+    }
+
+    var Router = Backbone.Marionette.AppRouter.extend({
+      controller: controller
+    , appRoutes: {
+        "m1": "method1"
+      }
+    });
+
+    beforeEach(function(){
+      spyOn(controller, "method1");
+
+      var router = new Router();
+      startRouters();
+
+      router.navigate("m1", true);
+    });
+
+    it("should call the configured method on the controller defined in the prototype", function(){
       expect(controller.method1).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Originally, the controller for AppRouter needed to be passed in the constructor.
Now supports providing the router in the definition.

Example:

``` javascript
var controller = {
  foo: function() {
    // ...
  }
}

var Router = Backbone.Marionette.AppRouter.extend({
  controller: controller
, appRoutes: {
    "foo": "foo"
  }
});

// No need to pass the controller in here. This is because the initialization may
// happen in a different file where the controller is not available.
var router = new Router();
```

I'm using require.js and each Router and Controller pair are defined in their own files (ex: BookRouter.js would defined a BookController and BookRouter). The uninitialized Router is returned (BookRouter in the example) and another file would call new BookRouter().
