### PR TITLE
Create collection if none passed to CollectionView

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -192,7 +192,15 @@ Backbone.Marionette = (function(Backbone, _, $){
   Marionette.CollectionView = Backbone.View.extend({
     modelView: Marionette.ItemView,
 
-    constructor: function(){
+    constructor: function(options){
+      // Create a default collection if none specified.
+      if (!options) {
+        options = {};
+        [].push.apply(arguments, [options]);
+      }
+      if (!options.collection) {
+        options.collection = new Backbone.Collection();
+      }
       Backbone.View.prototype.constructor.apply(this, arguments);
 
       _.bindAll(this, "addChildView", "render");

--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -58,7 +58,20 @@ describe("collection view", function(){
       expect(collectionView.render).toThrow("An `itemView` must be specified");
     });
   });
-  
+
+  describe("when rendering a collection view with no collection specified", function(){
+    var collectionView;
+
+    beforeEach(function(){
+      collectionView = new CollectionView();
+    });
+
+    it("should create an empty collection", function(){
+      expect(collectionView.collection).toBeTruthy();
+      expect(collectionView.collection.length).toEqual(0);
+    });
+  });
+
   describe("when rendering a collection view", function(){
     var collection = new Collection([{foo: "bar"}, {foo: "baz"}]);
     var collectionView;


### PR DESCRIPTION
Lots of logic depends on a collection existing in CollectionView and will crash if none specified. While I agree the best practice is to pass in a collection, it may be more convenient not to create one ahead of creating the view.

As this is a bit more controversial, I understand if you want to discuss it more or decline the request.
