### PR TITLE
CompositeRegion initialize model

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -350,7 +350,7 @@ Backbone.Marionette = (function(Backbone, _, $){
   // Used for composite view management and sub-application areas.
   Marionette.CompositeRegion = Marionette.ItemView.extend({
     constructor: function () {
-      Backbone.Marionette.ItemView.call(this, arguments);
+      Backbone.Marionette.ItemView.apply(this, arguments);
       this.regionManagers = {};
       this.vent = new Backbone.Marionette.EventAggregator();
     },


### PR DESCRIPTION
When using CompositeRegion it does not pass arguments through to Backbone.View correctly such as "model" because using call rather than apply
