### PR TITLE
Make Layout Managers vent property available before calling ItemView constructor

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -356,9 +356,10 @@ Backbone.Marionette = (function(Backbone, _, $){
   // Used for composite view management and sub-application areas.
   Marionette.LayoutManager = Marionette.ItemView.extend({
     constructor: function () {
+      this.vent = new Backbone.Marionette.EventAggregator();
       Backbone.Marionette.ItemView.apply(this, arguments);
       this.regionManagers = {};
-      this.vent = new Backbone.Marionette.EventAggregator();
+      
     },
 
     render: function () {


### PR DESCRIPTION
A tiny change to the ordering of Layout Managers constructor so that it is possible to bind to `this.vent` in the constructor of the LayoutView
