### PR TITLE
RE: Issue #33 Support raw HTML strings with TemplateManager.

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -86,7 +86,7 @@ Backbone.Marionette = (function(Backbone, _, $){
         throw err;
       }
 
-      return _.template(template.html(), data);
+      return _.template(template, data);
     },
 
     // Retrieve the template from the call's context. The
@@ -670,7 +670,7 @@ Backbone.Marionette = (function(Backbone, _, $){
     // this method to provide your own template retrieval,
     // such as asynchronous loading from a server.
     loadTemplate: function(templateId, callback){
-      var template = $(templateId);
+      var template = $(templateId).html();
       callback.call(this, template);
     },
 


### PR DESCRIPTION
Remove assumption from `ItemView.renderTemplate(template,data)` that `template` is a jQuery object.

This allows for the default way of working with templates to work as it does now, and if you wanted to load raw HTML Strings, you override `TemplateCache.loadTemplate` with

```
Backbone.Marionette.TemplateCache.loadTemplate = function(templateId, callback) {
    callback.call(this,templateId);
};
```
