### PR TITLE
Ensure templates are only retrieved once

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -643,6 +643,7 @@ Backbone.Marionette = (function(Backbone, _, $){
   // caching them for faster access.
   Marionette.TemplateCache = {
     templates: {},
+    loaders: {},
 
     // Get the specified template by id. Either
     // retrieves the cached version, or loads it
@@ -655,11 +656,18 @@ Backbone.Marionette = (function(Backbone, _, $){
       if (cachedTemplate){
         templateRetrieval.resolve(cachedTemplate);
       } else {
+        var loader = this.loaders[templateId];
+        if(loader) {
+          templateRetrieval = loader;
+        } else {
+          this.loaders[templateId] = templateRetrieval;
 
-        this.loadTemplate(templateId, function(template){
-          that.templates[templateId] = template;
-          templateRetrieval.resolve(template);
-        });
+          this.loadTemplate(templateId, function(template){
+            delete that.loaders[templateId];
+            that.templates[templateId] = template;
+            templateRetrieval.resolve(template);
+          });
+        }
 
       }
 


### PR DESCRIPTION
With the introduction of caching in replacement for the template manager there is a case where when rendering collections it will call get on the same template multiple times because the deferred object was being shared between multiple requests.
