### PR TITLE
Fixed Error when a layout was reloaded after it had been closed

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -440,7 +440,7 @@ Backbone.Marionette = (function(Backbone, _, $){
         manager.close();
         delete that[name];
       });
-      delete this.regionManagers;
+      this.regionManagers = {};
     }
   });
 


### PR DESCRIPTION
Closing a layout made it delete its regionManager property, which is suposed to be an empty array by default.
This behaviour has been fixed.
