### PR TITLE
Allow children to have remove called before parent

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -221,9 +221,10 @@ Backbone.Marionette = (function(Backbone, _, $){
     close: function(){
       this.unbind();
       this.unbindAll();
-      this.remove();
 
       this.closeChildren();
+
+      this.remove();
 
       if (this.onClose){
         this.onClose();


### PR DESCRIPTION
I have an item view that has an outside dependancy that creates elements in the dom, that is looked up via jquery data on the el of an ItemView

To have them removed correctly I overrode remove which is called from close in ItemView as onClose happens after el is removed from the dom and thus data removed.

However when a CollectionView closes it removes itself from the dom before allowing the children to be removed, I have changed the order so that children can be cleaned up correctly.
