### PR TITLE
Support asynchronous serializeData

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -101,21 +101,23 @@ Backbone.Marionette = (function(Backbone, _, $){
     // You can override this in your view definition.
     render: function(){
       var that = this;
+
+      var deferredRender = $.Deferred();
       var template = this.getTemplateSelector();
-      var data = this.serializeData();
+      var deferredData = this.serializeData();
 
       this.beforeRender && this.beforeRender();
       this.trigger("item:before:render", that);
 
-      var deferredRender = $.Deferred();
-
-      var asyncRender = Marionette.Renderer.render(template, data);
-      $.when(asyncRender).then(function(html){
-        that.$el.html(html);
-        that.onRender && that.onRender();
-        that.trigger("item:rendered", that);
-        that.trigger("render", that);
-        deferredRender.resolve();
+      $.when(deferredData).then(function(data) {
+        var asyncRender = Marionette.Renderer.render(template, data);
+        $.when(asyncRender).then(function(html){
+          that.$el.html(html);
+          that.onRender && that.onRender();
+          that.trigger("item:rendered", that);
+          that.trigger("render", that);
+          deferredRender.resolve();
+        });
       });
 
       return deferredRender.promise();

--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -99,6 +99,41 @@ describe("item view", function(){
     });
   });
 
+  describe("when an item view has asynchronous data and is rendered", function(){
+    var view;
+
+    beforeEach(function(){
+      loadFixtures("itemTemplate.html");
+
+      view = new ItemView({
+        template: "#itemTemplate",
+        serializeData: function() {
+          var that = this;
+          var deferred = $.Deferred();
+          setTimeout(function() {
+            deferred.resolve(that.model.toJSON());
+          }, 100);
+          return deferred.promise();
+        },
+        model: new Model({
+          foo: "bar"
+        })
+      });
+
+      spyOn(view, "serializeData").andCallThrough();
+
+      view.render();
+    });
+
+    it("should serialize the model", function(){
+      expect(view.serializeData).toHaveBeenCalled();
+    });
+
+    it("should render the template with the serialized model", function(){
+      expect($(view.el)).toHaveText(/bar/);
+    });
+  });
+
   describe("when an item view has a collection and is rendered", function(){
     var view;
 


### PR DESCRIPTION
ItemView's Render() now assumes either a deferred or returning data directly.
