### PR TITLE
Closed event

### DIFF
--- a/backbone.marionette.js
+++ b/backbone.marionette.js
@@ -47,11 +47,11 @@ Backbone.Marionette = (function(Backbone, _, $){
       this.beforeClose && this.beforeClose();
 
       this.unbindAll();
-      this.unbind();
       this.remove();
 
       this.onClose && this.onClose();
       this.trigger('close');
+      this.unbind();
     }
   });
 


### PR DESCRIPTION
By calling this.unbind() all event listeners are cancelled so the "closed" event is never triggered.

By moving the call to after the trigger listeners will be notified.
