### PR TITLE
Allow overriding HTML rendering on per view basis

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -103,14 +103,13 @@ Backbone.Marionette = (function(Backbone, _, $){
       var that = this;
 
       var deferredRender = $.Deferred();
-      var template = this.getTemplateSelector();
       var deferredData = this.serializeData();
 
       this.beforeRender && this.beforeRender();
       this.trigger("item:before:render", that);
 
       $.when(deferredData).then(function(data) {
-        var asyncRender = Marionette.Renderer.render(template, data);
+        var asyncRender = that.renderHtml(data);
         $.when(asyncRender).then(function(html){
           that.$el.html(html);
           that.onRender && that.onRender();
@@ -121,6 +120,11 @@ Backbone.Marionette = (function(Backbone, _, $){
       });
 
       return deferredRender.promise();
+    },
+
+    renderHtml: function(data) {
+      var template = this.getTemplateSelector();
+      return Marionette.Renderer.render(template, data);
     },
 
     // Override the default close event to add a few


### PR DESCRIPTION
Extracts a method responsible only for creating the ItemView's HTML, so it can be overridden per view without having to override the entire render method.
