### PR TITLE
Support asynchronous ItemView.onRender

### DIFF
--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -13,6 +13,19 @@ describe("item view", function(){
     onRender: function(){}
   });
 
+  var AsyncOnRenderView = Backbone.Marionette.ItemView.extend({
+    template: "#emptyTemplate",
+    asyncCallback: function(){},
+    onRender: function() {
+      var that = this;
+      var deferred = $.Deferred();
+      setTimeout(function() {
+        deferred.resolve(that.asyncCallback());
+      }, 200);
+      return deferred.promise();
+    }
+  });
+
   var CustomRenderView = Backbone.Marionette.ItemView.extend({
     renderTemplate: function(template, data){
       return "<foo>custom</foo>";
@@ -131,6 +144,22 @@ describe("item view", function(){
 
     it("should render the template with the serialized model", function(){
       expect($(view.el)).toHaveText(/bar/);
+    });
+  });
+
+  describe("when an item view has an asynchronous onRender and is rendered", function(){
+    var view;
+
+    beforeEach(function(){
+      loadFixtures("emptyTemplate.html");
+      view = new AsyncOnRenderView();
+      spyOn(view, "asyncCallback").andCallThrough();
+    });
+
+    it("should delay until onRender resolves", function(){
+      $.when(view.render()).then(function(){
+        expect(view.asyncCallback).toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -107,10 +107,13 @@ Backbone.Marionette = (function(Backbone, _, $){
 
         $.when(asyncRender).then(function(html){
           that.$el.html(html);
-          if (that.onRender) { that.onRender(); }
-          that.trigger("item:rendered", that);
-          that.trigger("render", that);
-          deferredRender.resolve();
+          var onRenderPromise = {};
+          if (that.onRender) { onRenderPromise = that.onRender(); }
+          $.when(onRenderPromise).then(function() {
+            that.trigger("item:rendered", that);
+            that.trigger("render", that);
+            deferredRender.resolve();
+          });
         });
 
       });


### PR DESCRIPTION
Hi Derick, I ran across this issue with ItemViews rendering prematurely recently.

Currently if you define an onRender() method for an ItemView, the events 'render' and 'item:rendered' can be sent before the onRender() method completes, if onRender() calls one or more asynchronous functions.

This is particularly important since the move to make ItemView.render() methods themselves asynchronous.

For example, I have a situation where an ItemView creates and renders several sub views (they are rendered in the onRender() method because they depend on the parent having created DOM elements for them to bind to).  This commit allows onRender() to return a promise which will prevent the render() method from firing its render completed events and resolving its own promise until the SubViews have completed their rendering.

The included test fails before and passes after the addition.

FYI, I believe a similar situation exists for CollectionViews.
