### PR TITLE
Add unbinding specific handlers from events

### DIFF
--- a/spec/javascripts/bindTo.spec.js
+++ b/spec/javascripts/bindTo.spec.js
@@ -70,7 +70,39 @@ describe("bind to", function(){
     });
   });
 
-  describe("when unbinding", function(){
+  describe("when unbinding an event", function(){
+    var handler = {
+      doIt: function(){},
+      dontDoIt: function(){}
+    }
+    var binder = _.extend({}, Backbone.Marionette.BindTo);
+    var model;
+
+    beforeEach(function(){
+      spyOn(handler, "doIt");
+      spyOn(handler, "dontDoIt");
+      model = new Model();
+      binder.bindTo(model, "change:foo", handler.doIt);
+      binder.bindTo(model, "change:foo", handler.dontDoIt);
+
+      binder.unbindFrom(model, "change:foo", handler.dontDoIt);
+      model.set({foo: "bar"});
+    });
+
+    it("should unbind the registered events for the given callback", function(){
+      expect(handler.doIt).toHaveBeenCalled();
+      expect(handler.dontDoIt).not.toHaveBeenCalled();
+    });
+
+    it("should remove the binding from the list of registered events", function(){
+      var bindings = _.filter(binder.bindings, function(binding) {
+        return binding.obj === model && binding.eventName === "change:foo" && binding.callback === handler.dontDoIt;
+      });
+      expect(bindings.length).toBe(0);
+    });
+  });
+
+  describe("when unbinding all events", function(){
     var handler = {
       doIt: function(){}
     }

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -624,6 +624,25 @@ Backbone.Marionette = (function(Backbone, _, $){
       });
     },
 
+    // Unbind the callback from obj for an event and context.
+    unbindFrom: function (obj, eventName, callback, context) {
+      context = context || this;
+      var bindings = {};
+      for (var i = 0; i < this.bindings.length; i++) {
+        var binding = this.bindings[i];
+        if (binding.obj === obj && binding.eventName === eventName && binding.callback === callback && binding.context === context) {
+          bindings[i] = binding;
+        }
+      }
+      for (var index in bindings) {
+        if (bindings.hasOwnProperty(index)) {
+          var binding = bindings[index];
+          binding.obj.off(binding.eventName, binding.callback, binding.context);
+          this.bindings.splice(index, 1);
+        }
+      }
+    },
+
     // Unbind all of the events that we have stored.
     unbindAll: function () {
       _.each(this.bindings, function (binding) {
@@ -678,6 +697,10 @@ Backbone.Marionette = (function(Backbone, _, $){
     // object being bound to.
     bindTo: function(eventName, callback, context){
       Marionette.BindTo.bindTo.call(this, this, eventName, callback, context);
+    },
+
+    unbindFrom: function(eventName, callback, context){
+      Marionette.BindTo.unbindFrom.call(this, this, eventName, callback, context);
     }
   });
 


### PR DESCRIPTION
The longer my app stays in memory, creating and removing views, and binding to events, the larger my app-wide EventAggregator's bindings array gets.

This will allow unbinding specific event handlers for events on a given object.

There may be a simpler method than what I have here, but regardless, I think this is a very useful addition.
