### PR TITLE
bindTo of EventAggregator now returns binding

### DIFF
--- a/spec/javascripts/eventAggregator.spec.js
+++ b/spec/javascripts/eventAggregator.spec.js
@@ -40,4 +40,24 @@ describe("event aggregator", function(){
     });
   });
 
+  describe("when unbinding from a binding object", function(){
+    var vent, handlerCalled;
+
+    beforeEach(function(){
+      var vent = new Backbone.Marionette.EventAggregator();
+
+      binding = vent.bindTo("foo", function(){
+        handlerCalled = true;
+      });
+
+      vent.unbindFrom(binding);
+
+      vent.trigger("foo");
+    });
+
+    it("should not fire any handlers", function(){
+      expect(handlerCalled).toBeUndefined();
+    });
+  });
+
 });

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -693,7 +693,7 @@ Backbone.Marionette = (function(Backbone, _, $){
     // Assumes the event aggregator itself is the 
     // object being bound to.
     bindTo: function(eventName, callback, context){
-      Marionette.BindTo.bindTo.call(this, this, eventName, callback, context);
+      return Marionette.BindTo.bindTo.call(this, this, eventName, callback, context);
     }
   });
 


### PR DESCRIPTION
The implementation of `bindTo` in `EventAggregator` didn't return a binding object, so it was not possible to use the new `unbindFrom` method with e.g. `Application.vent`.
