### PR TITLE
do not render a view if it has already been closed

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -118,6 +118,11 @@ Backbone.Marionette = (function(Backbone, _, $){
       if (this.onClose) { this.onClose(); }
       this.trigger('close');
       this.unbind();
+      this.closed = true;
+    },
+    
+    isClosed: function(){
+    	return this.closed;
     }
   });
 
@@ -167,7 +172,11 @@ Backbone.Marionette = (function(Backbone, _, $){
       }
 
       var templateRendered = function(html){
-        that.$el.html(html);
+        if (that.isClosed && that.isClosed()) {
+          deferredRender.resolve();
+          return;
+        }
+    	that.$el.html(html);
         callDeferredMethod(that.onRender, onRenderDone, that);
       }
 
@@ -300,6 +309,9 @@ Backbone.Marionette = (function(Backbone, _, $){
 
       var viewRendered = view.render();
       $.when(viewRendered).then(function(){
+        if (view.isClosed && view.isClosed()) {
+          return;
+        }
         that.appendHtml(that, view);
       });
       


### PR DESCRIPTION
when a view has been closed while rendering was still waiting for a
deferred to resolve (e.g. waiting for data- or template retrieval) its
markup should not be appended.

The only thing I'm not really sure about is, if the deferredRender in the ItemView should be resolved or rejected (probably rejecting the deferredRender is more appropriate?)

In my case I had many changes (add, reset, remove) on a collection that was rendered via CollectionView. While the ItemViews were still waiting for the template-retrieval to resolve, they had already been closed (due to a collection:remove) but after template-retrieval resolved, their markup got rendered nevertheless.
