### PR TITLE
Using Marionette.Region.show() multiple times causes events to stop firing

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -174,6 +174,7 @@ Backbone.Marionette = (function(Backbone, _, $){
       var onRenderDone = function(){
         that.trigger("render", that);
         that.trigger("item:rendered", that);
+        that.delegateEvents()
 
         deferredRender.resolve();
       }
@@ -181,6 +182,10 @@ Backbone.Marionette = (function(Backbone, _, $){
       callDeferredMethod(this.beforeRender, beforeRenderDone, this);
 
       return deferredRender.promise();
+    },
+
+    onClose: function() {
+      this.undelegateEvents();
     },
 
     // Render the data for this item view in to some HTML.


### PR DESCRIPTION
Switching views in and out of the DOM can cause
event handlers to stop firing. Explicitly delegating
and undelegating the event handlers on render and
close resolves this issue and appears to be a
standard practice for Backbone applications.
