### PR TITLE
fix for leaking CollectionView (does not unbind events from closed childviews)

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -237,6 +237,7 @@ describe("collection view", function(){
         template: "#itemTemplate",
         collection: collection
       });
+      collectionView.someItemViewCallback = function(){};
       collectionView.render();
 
 
@@ -244,6 +245,7 @@ describe("collection view", function(){
       childView = collectionView.children[childModel.cid];
 
       collectionView.bindTo(collection, "foo", collectionView.someCallback);
+      collectionView.bindTo(collectionView, "item:foo", collectionView.someItemViewCallback);
 
       spyOn(childView, "close").andCallThrough();
       spyOn(collectionView, "removeItemView").andCallThrough();
@@ -251,12 +253,15 @@ describe("collection view", function(){
       spyOn(collectionView, "unbindAll").andCallThrough();
       spyOn(collectionView, "remove").andCallThrough();
       spyOn(collectionView, "someCallback").andCallThrough();
+      spyOn(collectionView, "someItemViewCallback").andCallThrough();
       spyOn(collectionView, "close").andCallThrough();
       spyOn(collectionView, "onClose").andCallThrough();
       spyOn(collectionView, "beforeClose").andCallThrough();
       spyOn(collectionView, "trigger").andCallThrough();
 
       collectionView.close();
+
+      childView.trigger("foo");
 
       collection.trigger("foo");
       collection.remove(childModel);
@@ -272,7 +277,18 @@ describe("collection view", function(){
 
     it("should unbind all collection events for the view", function(){
       expect(collectionView.someCallback).not.toHaveBeenCalled();
-      expect(collectionView.removeItemView).not.toHaveBeenCalled();
+    });
+
+    it("should unbind all item-view events for the view", function(){
+      expect(collectionView.someItemViewCallback).not.toHaveBeenCalled();
+    });
+
+    it("should not retain any references to its children", function(){
+      expect(_.size(collectionView.children)).toBe(0);
+    });
+
+    it("should not retain any bindings to its children", function(){
+      expect(_.size(collectionView.bindings)).toBe(0);
     });
 
     it("should unbind any listener to custom view events", function(){
@@ -351,6 +367,70 @@ describe("collection view", function(){
     it("should forward all other arguments in order", function(){
       expect(eventArgs[1]).toBe("test");
       expect(eventArgs[2]).toBe(model);
+    });
+  });
+
+  describe("when a child view is removed from a collection view", function(){
+    var model;
+    var collection;
+    var collectionView;
+    var childView;
+
+    beforeEach(function(){
+      model = new Model({foo: "bar"});
+      collection = new Collection([model]);
+
+      collectionView = new EventedView({
+        template: "#itemTemplate",
+        collection: collection
+      });
+
+      collectionView.render();
+
+      childView = collectionView.children[model.cid];
+      collection.remove(model)
+    });
+
+    it("should not retain any bindings to this view", function(){
+      expect(_.any(collectionView.bindings, function(binding) {
+        return binding.obj === childView;
+      })).toBe(false);
+    });
+
+    it("should not retain any references to this view", function(){
+      expect(_.size(collectionView.children)).toBe(0);
+    });
+  });
+
+  describe("when the collection of a collection view is resetted", function(){
+    var model;
+    var collection;
+    var collectionView;
+    var childView;
+
+    beforeEach(function(){
+      model = new Model({foo: "bar"});
+      collection = new Collection([model]);
+
+      collectionView = new EventedView({
+        template: "#itemTemplate",
+        collection: collection
+      });
+
+      collectionView.render();
+
+      childView = collectionView.children[model.cid];
+      collection.reset();
+    });
+
+    it("should not retain any references to the previous views", function(){
+      expect(_.size(collectionView.children)).toBe(0);
+    });
+
+    it("should not retain any bindings to the previous views", function(){
+      expect(_.any(collectionView.bindings, function(binding) {
+        return binding.obj === childView;
+      })).toBe(false);
     });
   });
 });

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -283,7 +283,7 @@ Backbone.Marionette = (function(Backbone, _, $){
       var that = this;
 
       var view = this.buildItemView(item, ItemView);
-      this.bindTo(view, "all", function(){
+      var childBinding = this.bindTo(view, "all", function(){
 
         // get the args, prepend the event name
         // with "itemview:" and insert the child view
@@ -294,6 +294,8 @@ Backbone.Marionette = (function(Backbone, _, $){
 
         that.trigger.apply(that, args);
       });
+      this.childBindings = this.childBindings || {};
+      this.childBindings[view.cid] = childBinding;
 
       this.storeChild(view);
       this.trigger("item:added", view);
@@ -318,6 +320,11 @@ Backbone.Marionette = (function(Backbone, _, $){
     removeItemView: function(item){
       var view = this.children[item.cid];
       if (view){
+    	var childBinding = this.childBindings[view.cid];
+    	if (childBinding) {
+    	  this.unbindFrom(childBinding);
+    	  delete this.childBindings[view.cid];
+    	}
         view.close();
         delete this.children[item.cid];
       }
@@ -350,9 +357,10 @@ Backbone.Marionette = (function(Backbone, _, $){
     },
 
     closeChildren: function(){
+      var that = this;
       if (this.children){
-        _.each(this.children, function(childView){
-          childView.close();
+        _.each(_.clone(this.children), function(childView){
+          that.removeItemView(childView.model);
         });
       }
     }


### PR DESCRIPTION
When child-views are closed, not all references to the children are cleaned up, which can lead to increasing memory consumption over time.

I had to remove an expectation that removeItemView does not get called when closing a CollectionView but in my opinion it has to be called to cleanup the references to child-views and bindings.

This time with tests included :) Maybe I can write some for the closed-views soon
