### PR TITLE
trigger unbindAll later in close method to be able to self-bindTo 'close' event on a view

### DIFF
--- a/src/backbone.marionette.view.js
+++ b/src/backbone.marionette.view.js
@@ -104,11 +104,11 @@ Marionette.View = Backbone.View.extend({
   close: function(){
     if (this.beforeClose) { this.beforeClose(); }
 
-    this.unbindAll();
     this.remove();
 
     if (this.onClose) { this.onClose(); }
     this.trigger('close');
+    this.unbindAll();
     this.unbind();
   }
 });


### PR DESCRIPTION
Hi Derrick,

is there any reason why unbindAll is triggered so early in the #close method?
I often run into situations, where I want to bind to my own close event and this fails as the trigger is unbound before the close event is triggered... just wondering :)
