### PR TITLE
fixed missing dependencies for async module and moved extensions to Application, Region and View from helpers to their appropriate module files

### DIFF
--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -16,7 +16,9 @@ src_files:
     - public/javascripts/underscore.js
     - public/javascripts/backbone.js
     - src/backbone.marionette.js
+    - src/async/async.js
     - spec/javascripts/support/marionette.support.js
+    - src/backbone.marionette.bindto.js
     - src/backbone.marionette.view.js
     - src/backbone.marionette.itemview.js
     - src/backbone.marionette.collectionview.js
@@ -29,10 +31,8 @@ src_files:
     - src/backbone.marionette.templatecache.js
     - src/backbone.marionette.renderer.js
     - src/backbone.marionette.callbacks.js
-    - src/backbone.marionette.bindto.js
     - src/backbone.marionette.eventaggregator.js
     - src/backbone.marionette.helpers.js
-    - src/async/async.js
     - src/async/backbone.marionette.*.js
 
 # stylesheets

--- a/spec/javascripts/support/marionette.support.js
+++ b/spec/javascripts/support/marionette.support.js
@@ -1,2 +1,2 @@
 Marionette = Backbone.Marionette;
-Marionette.Async = {};
+Async = Marionette.Async;

--- a/src/async/async.init.js
+++ b/src/async/async.init.js
@@ -1,0 +1,4 @@
+/*
+ * Initializes the async-modules.
+ */
+Async.init();

--- a/src/async/async.js
+++ b/src/async/async.js
@@ -8,10 +8,12 @@ Backbone.Marionette.Async = (function(Backbone, Marionette, _, $){
   // Configure Marionette to use the async rendering for all view types
   var Async = {
     init: function(){
-      Marionette.Renderer = Marionette.Async.Renderer;
-      _.extend(Marionette.ItemView.prototype, Marionette.Async.ItemView);
-      _.extend(Marionette.CollectionView.prototype, Marionette.Async.CollectionView);
-      _.extend(Marionette.CompositeView.prototype, Marionette.Async.CompositeView);
+      Marionette.TemplateCache = Async.TemplateCache;
+      Marionette.Renderer = Async.Renderer;
+      _.extend(Marionette.ItemView.prototype, Async.ItemView);
+      _.extend(Marionette.CollectionView.prototype, Async.CollectionView);
+      _.extend(Marionette.CompositeView.prototype, Async.CompositeView);
+      _.extend(Marionette.Region.prototype, Async.Region);
     }
   };
 
@@ -21,6 +23,8 @@ Backbone.Marionette.Async = (function(Backbone, Marionette, _, $){
 // import "backbone.marionette.async.region.js"
 // import "backbone.marionette.async.renderer.js"
 // import "backbone.marionette.async.templatecache.js"
-
+// import "async.init.js"
+// import "../backbone.marionette.helpers.js"
+  
   return Async;
 })(Backbone, Backbone.Marionette, _, window.jQuery || window.Zepto || window.ender);

--- a/src/async/backbone.marionette.async.collectionview.js
+++ b/src/async/backbone.marionette.async.collectionview.js
@@ -2,7 +2,7 @@
 // --------------------
 
 // provides async rendering for collection views
-Marionette.Async.CollectionView = {
+Async.CollectionView = {
   render: function(){
     var that = this;
     var deferredRender = $.Deferred();

--- a/src/async/backbone.marionette.async.compositeview.js
+++ b/src/async/backbone.marionette.async.compositeview.js
@@ -1,7 +1,7 @@
 // Async Composite View
 // --------------------
 
-Marionette.Async.CompositeView = {
+Async.CompositeView = {
   // Renders the model once, and the collection once. Calling
   // this again will tell the model's view to re-render itself
   // but the collection will not re-render.

--- a/src/async/backbone.marionette.async.itemView.js
+++ b/src/async/backbone.marionette.async.itemView.js
@@ -5,7 +5,7 @@
 // assumes template loading, data serialization, `beforRender`, and
 // `onRender` functions are all asynchronous, using `jQuery.Deferred()`
 // and `jQuery.when(...).then(...)` to manage async calls.
-Marionette.Async.ItemView = {
+Async.ItemView = {
   render: function(){
     var that = this;
 

--- a/src/async/backbone.marionette.async.region.js
+++ b/src/async/backbone.marionette.async.region.js
@@ -3,7 +3,7 @@
 
 // Show a view that is rendered asynchronously, waiting for the view
 // to be rendered before swaping it in.
-Marionette.Async.Region = {
+Async.Region = {
   show: function(view){
     var that = this;
 

--- a/src/async/backbone.marionette.async.renderer.js
+++ b/src/async/backbone.marionette.async.renderer.js
@@ -3,7 +3,7 @@
 
 // Render a template with data by passing in the template
 // selector and the data to render. Do it all asynchronously.
-Marionette.Async.Renderer = {
+Async.Renderer = {
 
   // Render a template with data. The `template` parameter is
   // passed to the `TemplateCache` object to retrieve the

--- a/src/async/backbone.marionette.async.templatecache.js
+++ b/src/async/backbone.marionette.async.templatecache.js
@@ -3,14 +3,14 @@
 
 // Manage templates stored in `<script>` blocks,
 // caching them for faster access.
-Marionette.Async.TemplateCache = function(templateId){
+Async.TemplateCache = function(templateId){
   this.templateId = templateId;
 };
 
 // TemplateCache object-level methods. Manage the template
 // caches from these method calls instead of creating 
 // your own TemplateCache instances
-_.extend(Marionette.Async.TemplateCache, {
+_.extend(Async.TemplateCache, {
   templateCaches: {},
 
   // Get the specified template by id. Either
@@ -52,7 +52,7 @@ _.extend(Marionette.Async.TemplateCache, {
 // TemplateCache instance methods, allowing each
 // template cache object to manage it's own state
 // and know whether or not it has been loaded
-_.extend(Marionette.Async.TemplateCache.prototype, {
+_.extend(Async.TemplateCache.prototype, {
 
   // Internal method to load the template asynchronously.
   load: function(){

--- a/src/backbone.marionette.application.js
+++ b/src/backbone.marionette.application.js
@@ -60,3 +60,8 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
   }
 });
 
+// Copy the `extend` function used by Backbone's classes
+Marionette.Application.extend = Backbone.View.extend;
+
+// Copy the features of `BindTo`
+_.extend(Marionette.Application.prototype, Marionette.BindTo);

--- a/src/backbone.marionette.helpers.js
+++ b/src/backbone.marionette.helpers.js
@@ -4,16 +4,6 @@
 // For slicing `arguments` in functions
 var slice = Array.prototype.slice;
 
-// Copy the `extend` function used by Backbone's classes
-var extend = Marionette.View.extend;
-Marionette.Region.extend = extend;
-Marionette.Application.extend = extend;
-
-// Copy the features of `BindTo` on to these objects
-_.extend(Marionette.View.prototype, Marionette.BindTo);
-_.extend(Marionette.Application.prototype, Marionette.BindTo);
-_.extend(Marionette.Region.prototype, Marionette.BindTo);
-
 // A simple wrapper method for deferring a callback until 
 // after another method has been called, passing the
 // results of the first method to the second. Uses jQuery's

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -1,6 +1,7 @@
 Backbone.Marionette = (function(Backbone, _, $){
   var Marionette = {};
 
+// import "backbone.marionette.bindto.js"
 // import "backbone.marionette.view.js"
 // import "backbone.marionette.itemview.js"
 // import "backbone.marionette.collectionview.js"
@@ -13,7 +14,6 @@ Backbone.Marionette = (function(Backbone, _, $){
 // import "backbone.marionette.templatecache.js"
 // import "backbone.marionette.renderer.js"
 // import "backbone.marionette.callbacks.js"
-// import "backbone.marionette.bindto.js"
 // import "backbone.marionette.eventaggregator.js"
 // import "backbone.marionette.helpers.js"
 

--- a/src/backbone.marionette.region.js
+++ b/src/backbone.marionette.region.js
@@ -83,3 +83,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   }
 });
 
+// Copy the `extend` function used by Backbone's classes
+Marionette.Region.extend = Backbone.View.extend;
+
+// Copy the features of `BindTo`
+_.extend(Marionette.Region.prototype, Marionette.BindTo);

--- a/src/backbone.marionette.view.js
+++ b/src/backbone.marionette.view.js
@@ -120,3 +120,5 @@ Marionette.View = Backbone.View.extend({
   }
 });
 
+// Copy the features of `BindTo`
+_.extend(Marionette.View.prototype, Marionette.BindTo);


### PR DESCRIPTION
Hey,

there still were some issues for the build-version of the async module:
a) the helper-functions were missing
b) the referenced 'Marionette.Async' object did not exist
c) init hasn't been called
d) backbone.marionette.helpers.js did contain code related to Region, Application and View (BindTo extensions). Moved this to the related module files. Required the inclusion of bindTo.js to occur earlier.
e) TemplateCache and Region versions of async module weren't applied in Async.init()

I added src/async/async.init.js that is only included for the build-version of marionette and applies the async-versions to their regular counterparts. This initialization must not be done for the tests, so async.init.js is not included there.

Are you fine with these changes? :)
