### PR TITLE
adds 'renderData' function to ItemView (both regular and async)

### DIFF
--- a/src/async/backbone.marionette.async.itemView.js
+++ b/src/async/backbone.marionette.async.itemView.js
@@ -6,6 +6,9 @@
 // `onRender` functions are all asynchronous, using `jQuery.Deferred()`
 // and `jQuery.when(...).then(...)` to manage async calls.
 Async.ItemView = {
+  // Consider overriding 'renderData' if you want to keep the
+  // render-events being triggered but change the way your data
+  // is being rendered.
   render: function(){
     var that = this;
 
@@ -20,13 +23,11 @@ Async.ItemView = {
     } 
 
     var dataSerialized = function(data){
-      var template = that.getTemplate();
-      var asyncRender = Marionette.Renderer.render(template, data);
+      var asyncRender = that.renderData(data);
       $.when(asyncRender).then(templateRendered);
     }
 
     var templateRendered = function(html){
-      that.$el.html(html);
       callDeferredMethod(that.onRender, onRenderDone, that);
     }
 
@@ -40,5 +41,21 @@ Async.ItemView = {
     callDeferredMethod(this.beforeRender, beforeRenderDone, this);
 
     return deferredRender.promise();
+  },
+  
+  // Render the provided data using Marionette.Renderer.
+  // Override this to render the given data using a mechanism
+  // that suits your needs. 
+  // In general you should override the `Marionette.Renderer` 
+  // object to change how Marionette renders views.
+  // Return a deferred object when performing custom async rendering.
+  renderData: function(data) {
+    var template = this.getTemplate();
+    var asyncRender = Marionette.Renderer.render(template, data);
+    var that = this;
+    $.when(asyncRender).then(function(html) {
+      that.$el.html(html);
+    });
+    return asyncRender;
   }
 };

--- a/src/backbone.marionette.itemview.js
+++ b/src/backbone.marionette.itemview.js
@@ -21,22 +21,33 @@ Marionette.ItemView =  Marionette.View.extend({
 
   // Render the view, defaulting to underscore.js templates.
   // You can override this in your view definition to provide
-  // a very specific rendering for your view. In general, though,
-  // you should override the `Marionette.Renderer` object to
-  // change how Marionette renders views.
+  // a very specific rendering for your view.
+  // Consider overriding 'renderData' if you want to keep the
+  // render-events being triggered but change the way your data
+  // is being rendered.
   render: function(){
     if (this.beforeRender){ this.beforeRender(); }
     this.trigger("before:render", this);
     this.trigger("item:before:render", this);
 
     var data = this.serializeData();
-    var template = this.getTemplate();
-    var html = Marionette.Renderer.render(template, data);
-    this.$el.html(html);
 
+    this.renderData(data);
+    
     if (this.onRender){ this.onRender(); }
     this.trigger("render", this);
     this.trigger("item:rendered", this);
+  },
+  
+  // Render the provided data using Marionette.Renderer.
+  // Override this to render the given data using a mechanism
+  // that suits your needs. 
+  // In general you should override the `Marionette.Renderer` 
+  // object to change how Marionette renders views.
+  renderData: function(data) {
+    var template = this.getTemplate();
+    var html = Marionette.Renderer.render(template, data);
+    this.$el.html(html);
   },
 
   // Override the default close event to add a few


### PR DESCRIPTION
This pull request adds another function 'renderData' to ItemView that, per default, calls getTemplate() and renders this template and the data passed in as parameter using Marionette.Renderer.

The intention behind this additional indirection is, that it may be overridden by framework users to take advantage of the events being triggered in 'render' but still provide custom-logic to
render the data provided (e.g. not using templates at all and creating small chunks of DOM-elements on-the-fly).

I think this is quite similar to the previously existing 'renderHtml' function which was removed.
In my opinion it would be nice to provide this hook in ItemView.
