### PR TITLE
Allow Marionette to be installed using volo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "amd": { },
+  "volo": {
+    "url": "https://raw.github.com/derickbailey/backbone.marionette/{version}/lib/amd/backbone.marionette.js",
+    "dependencies": {
+      "backbone": "backbone"
+    }
+  }
+}


### PR DESCRIPTION
[volo](https://github.com/volojs/volo) is a JavaScript package/dependency manager. Adding a `package.json` file with some metadata allows users to add Marionette to their project using `volo add derickbailey/backbone.marionette`.
