### PR TITLE
Return a deferred promise from Region.show

### DIFF
--- a/src/async/backbone.marionette.async.region.js
+++ b/src/async/backbone.marionette.async.region.js
@@ -6,6 +6,7 @@
 Async.Region = {
   show: function(view){
     var that = this;
+    var asyncShow = $.Deferred();
 
     this.ensureEl();
     this.close();
@@ -19,8 +20,11 @@ Async.Region = {
 
       if (that.onShow) { that.onShow(view); }
       that.trigger("view:show", view);
+      
+      asyncShow.resolve();
     });
 
     this.currentView = view;
+    return asyncShow.promise();
   }
 };


### PR DESCRIPTION
This pull requests addresses the comments in #118 regarding delayed showing of layout subviews in the layout regions until the layout and the subviews have finished rendering.

Most of the infrastructure to support this is already in Marionette.Async. Once the `show` function returns a promise, then one could do the following in a layout:

``` javascript
var MyLayout= Backbone.Marionette.Layout.extend({

  regions: {
    regionOne: '#region1',
    regionTwo: '#region2'
  },

  onRender: function(){
    var asyncOnRender = $.Deferred();

    var view1 = new MyFirstView;
    var regionOnePromise = this.regionOne.show(view1);

    var view2 = new MySecondView;
    var regionTwoPromise = this.regionTwo.show(view2);

    $.when(regionOnePromise, regionTwoPromise).then(function(){
      asyncOnRender.resolved();
    });

    return asyncOnRender.promise();
  }
});
```

To verify that this actually works, in one of the subviews, do the following:

``` javascript
var MyFirstView = Backbone.Marionette.ItemView.extend({
  // ... templates and other other stuff.

  onRender: function(){
    var asyncOnRender = $.Deferred();
    setTimeout(asyncOnRender.resolve, 10000);
    return asyncOnRender.promise();
  }
});
```

Without patching Region.show, the layout's template will appear on the screen long before the subview. With the patch, nothing will appear for 10 seconds and the both the layout the subview will appear at the same time.
