### PR TITLE
added 'render' and 'before:render' events to CollectionView

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -98,11 +98,19 @@ describe("collection view", function(){
     });
 
     it("should trigger a 'before:render' event", function(){
+      expect(collectionView.trigger).toHaveBeenCalledWith("before:render", collectionView);
+    });
+    
+    it("should trigger a 'collection:before:render' event", function(){
       expect(collectionView.trigger).toHaveBeenCalledWith("collection:before:render", collectionView);
     });
 
-    it("should trigger a 'rendered' event", function(){
+    it("should trigger a 'collection:rendered' event", function(){
       expect(collectionView.trigger).toHaveBeenCalledWith("collection:rendered", collectionView);
+    });
+    
+    it("should trigger a 'render' event", function(){
+      expect(collectionView.trigger).toHaveBeenCalledWith("render", collectionView);
     });
 
     it("should call `onItemAdded` for each itemView instance", function(){

--- a/src/backbone.marionette.collectionview.js
+++ b/src/backbone.marionette.collectionview.js
@@ -39,6 +39,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // and events
   triggerBeforeRender: function(){
     if (this.beforeRender) { this.beforeRender(); }
+    this.trigger("before:render", this);
     this.trigger("collection:before:render", this);
   },
 
@@ -46,6 +47,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // events
   triggerRendered: function(){
     if (this.onRender) { this.onRender(); }
+    this.trigger("render", this);
     this.trigger("collection:rendered", this);
   },
 


### PR DESCRIPTION
ItemView and CompositeView (as it extends ItemView) both trigger a 'render' and 'before:render'
event, CollectionView did only trigger a 'collection:rendered' and
'before:collection:rendered' event.
Would be nice to have a unified event for 'finished rendering'.
