### PR TITLE
Corrected variable name within the jQuery get call (line 145)

### DIFF
--- a/docs/marionette.async.md
+++ b/docs/marionette.async.md
@@ -142,7 +142,7 @@ Backbone.Marionette.TemplateCache.loadTemplate = function(templateId, callback){
   var url = templateId + ".html";
 
   $.get(url, function(templateHtml){
-    var template = $(tmplateHtml).find(templateId);
+    var template = $(templateHtml).find(templateId);
     callback(template);
   });
 }


### PR DESCRIPTION
I've been reviewing all that I would need to do to update to 0.91 and I came across this typo in the marionette.async.md.
