### PR TITLE
volo.url in package.json has the wrong URL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "amd": { },
   "volo": {
-    "url": "https://raw.github.com/derickbailey/backbone.marionette/{version}/lib/amd/backbone.marionette.js",
+    "url": "https://raw.github.com/derickbailey/backbone.marionette/v{version}/lib/amd/backbone.marionette.js",
     "dependencies": {
       "backbone": "backbone"
     }


### PR DESCRIPTION
_facepalm_ I erroneously thought that {version} was replaced with the name of the latest semver-compatible tag name (including the `v`), but it's actually just the version number. Added the `v` so volo can actually fetch the
script when you run `volo add backbone.marionette`.
