### PR TITLE
fixed unclear usage of itemViewContainer parameter in #getItemViewContainer of CompositeView

### DIFF
--- a/src/backbone.marionette.compositeview.js
+++ b/src/backbone.marionette.compositeview.js
@@ -80,7 +80,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
       container = containerView.$itemViewContainer;
     } else {
       if (containerView.itemViewContainer){
-        container = containerView.$(containerView.itemViewContainer);
+        container = containerView.$(_.result(containerView, "itemViewContainer"));
       } else {
         container = containerView.$el;
       }


### PR DESCRIPTION
the itemViewContainer was passed in, but then it was checked for existance of containerView.itemViewContainer instead of the itemViewContainer parameter, but the parameter value was used nevertheless....
I think it would be best to remove the parameter and use containerViews attribute only.

Another addition could be to get the result of containerView.itemViewContainer via _.result to allow usage of functions here (see second commit for that)
