### PR TITLE
append itemViews only after the Collection-/CompositeView has been rendered

### DIFF
--- a/spec/javascripts/async/async.compositeView-itemViewContainer.spec.js
+++ b/spec/javascripts/async/async.compositeView-itemViewContainer.spec.js
@@ -104,6 +104,34 @@ describe("async composite view - itemViewContainer", function(){
       expect(compositeView.$el).toContainHtml("<ul></ul>");
     });
   });
+  
+  describe("when adding a model to a collection of a composite view with an `itemViewContainer` specified before its model has been rendered", function(){
+    var CompositeView = Backbone.Marionette.CompositeView.extend({
+      itemView: ItemView,
+      itemViewContainer: "ul",
+      template: "#composite-child-container-template"
+    });
 
+    var compositeView;
+    
+    beforeEach(function(){
+      loadFixtures("compositeChildContainerTemplate.html");
+
+      var m1 = new Model({foo: "bar"});
+      var collection = new Collection();
+
+      compositeView = new CompositeView({
+        collection: collection
+      });
+      
+      spyOn(compositeView.itemView.prototype, "render").andCallThrough();
+      
+      collection.add(m1);
+    });
+
+    it("should not render the item view as the itemViewContainer may not yet be available", function(){
+      expect(compositeView.itemView.prototype.render).not.toHaveBeenCalled();
+    });
+  });
 });
 

--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -641,4 +641,32 @@ describe("collection view", function(){
       expect(viewOnShowContext).toBe(view);
     });
   });
+  
+  describe("when a model is added to the collection of a collection view before the view has been rendered", function(){
+    var m1, col;
+
+    var ItemView = Backbone.Marionette.ItemView.extend({
+      render: function(){}
+    });
+
+    var ColView = Backbone.Marionette.CollectionView.extend({
+      itemView: ItemView
+    });
+
+    beforeEach(function(){
+      spyOn(ItemView.prototype, "render").andCallThrough();
+
+      m1 = new Model();
+      col = new Collection();
+      new ColView({
+        collection: col
+      });
+
+      col.add(m1);
+    });
+
+    it("should not append child views", function(){
+      expect(ItemView.prototype.render).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/spec/javascripts/compositeView-itemViewContainer.spec.js
+++ b/spec/javascripts/compositeView-itemViewContainer.spec.js
@@ -79,5 +79,35 @@ describe("composite view - itemViewContainer", function(){
       expect(compositeView.$el).toContainHtml("<ul></ul>");
     });
   });
+  
+  describe("when adding a model to a collection of a composite view with an `itemViewContainer` specified before it has been rendered", function(){
+    var CompositeView = Backbone.Marionette.CompositeView.extend({
+      itemView: ItemView,
+      itemViewContainer: "ul",
+      template: "#composite-child-container-template"
+    });
+
+    var compositeView;
+    
+    beforeEach(function(){
+      order = [];
+      loadFixtures("compositeChildContainerTemplate.html");
+
+      var m1 = new Model({foo: "bar"});
+      var collection = new Collection();
+
+      compositeView = new CompositeView({
+        collection: collection
+      });
+      
+      spyOn(compositeView.itemView.prototype, "render").andCallThrough();
+      
+      collection.add(m1);
+    });
+
+    it("should not render the item view as the itemViewContainer may not yet be available", function(){
+      expect(compositeView.itemView.prototype.render).not.toHaveBeenCalled();
+    });
+  });
 
 });

--- a/src/async/backbone.marionette.async.collectionview.js
+++ b/src/async/backbone.marionette.async.collectionview.js
@@ -11,6 +11,7 @@ Async.CollectionView = {
     this.triggerBeforeRender();
 
     this.closeChildren();
+    delete this._waitingForRender;
 
     if (this.collection && this.collection.length > 0) {
       promises = this.showCollection();

--- a/src/backbone.marionette.collectionview.js
+++ b/src/backbone.marionette.collectionview.js
@@ -9,6 +9,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this.initChildViewStorage();
     this.initialEvents();
     this.onShowCallbacks = new Marionette.Callbacks();
+    this._waitingForRender = true;
   },
 
   // Configured the initial events that the collection view 
@@ -24,6 +25,9 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Handle a child item added to the collection
   addChildView: function(item, collection, options){
+    if (this._waitingForRender) {
+      return;
+    }
     this.closeEmptyView();
     var ItemView = this.getItemView();
     return this.addItemView(item, ItemView, options.index);
@@ -57,6 +61,7 @@ Marionette.CollectionView = Marionette.View.extend({
   render: function(){
     this.triggerBeforeRender();
     this.closeChildren();
+    delete this._waitingForRender;
 
     if (this.collection && this.collection.length > 0) {
       this.showCollection();


### PR DESCRIPTION
the issue arises when a CompositeView has a itemViewContainer
selector defined and a model is added to a collection before the view is
rendered. The itemViewContainer, which will most likely be only
available after the template has been loaded, will then be empty and
adding the itemViews to it is not possible then (only after render has
been called on the view as it clears the itemViewContainer and
re-renders all children)

If the described issue isn't convincing, mabye I can sell it as an optimization in performance, as it saves rendering ItemViews twice (in the case described above) :)
