### PR TITLE
Added removeRegion method to Application

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -287,4 +287,31 @@ describe("region", function(){
       expect(Manager.prototype.initialize).toHaveBeenCalledWith(expectedOptions);
     });
   });
+
+  describe("when removing a region", function(){
+    var MyApp = new Backbone.Marionette.Application();
+
+    var myRegion = Backbone.Marionette.Region.extend({
+      el: "#region"
+    });
+
+    var myRegion2 = Backbone.Marionette.Region.extend({
+      el: "#region2"
+    });
+
+    beforeEach(function(){
+      setFixtures("<div id='region'></div>");
+      setFixtures("<div id='region2'></div>");
+
+      MyApp.addRegions({MyRegion: myRegion, anotherRegion: myRegion2});
+      MyApp.removeRegion('MyRegion')
+    });
+
+    it("should be removed from the app", function(){
+      expect(MyApp.MyRegion).not.toBeDefined()
+    })
+    it("should call 'close' of the region", function(){
+      expect(MyApp.MyRegion.close).toHaveBeenCalled()
+    })
+  })
 });

--- a/src/backbone.marionette.application.js
+++ b/src/backbone.marionette.application.js
@@ -53,6 +53,14 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
     }
   },
 
+  // Removes a region from your app.
+  // Accepts the regions name
+  // removeRegion('myRegion')
+  removeRegion: function(region) {
+    this[region].close();
+    delete this[region]
+  },
+
   // Create a module, attached to the application
   module: function(){
     // see the Marionette.Module object for more information


### PR DESCRIPTION
I've added a removeRegion method to the Application.

The method first calls region.close(), then deleted the region property from the App.

I've tried to add tests too, but could not run them as my os fails with building ruby 1.9
Probably the second test would fail as it would check for calling a method on an already deleted property of the object, and I don't have any ideas how to test for this.
