### PR TITLE
Fixes multiple rendering of EmptyView on multiple collection resets

### DIFF
--- a/src/backbone.marionette.collectionview.js
+++ b/src/backbone.marionette.collectionview.js
@@ -56,8 +56,9 @@ Marionette.CollectionView = Marionette.View.extend({
   // the collection view.
   render: function(){
     this.triggerBeforeRender();
+    this.closeEmptyView();
     this.closeChildren();
-
+    
     if (this.collection && this.collection.length > 0) {
       this.showCollection();
     } else {
@@ -94,7 +95,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // if one exists. Called when a collection view has been
   // rendered empty, and then an item is added to the collection.
   closeEmptyView: function(){
-    if (this.showingEmptyView){
+    if (EmptyView && !this.showingEmptyView){
       this.closeChildren();
       delete this.showingEmptyView;
     }


### PR DESCRIPTION
(and also (untested) render error on init with empty collection, reset (by fetch), add, which will only render the added item, and not the items added before the reset)

I'm not sure whether this is the ideal solution, but this will also allow overriding showEmptyView and closeEmptyView with other functionality, which feels clean to me at least. Not too happy about the double call to closeChildren(), but I don't see another solution without keeping an extra reference to emptyView, and keeping it out of the chlidviews, which again feels like a lot of unnecessary duplication to me.
