### PR TITLE
Throw an error when itemViewContainer can not be found

### DIFF
--- a/spec/javascripts/compositeView-itemViewContainer.spec.js
+++ b/spec/javascripts/compositeView-itemViewContainer.spec.js
@@ -50,6 +50,39 @@ describe("composite view - itemViewContainer", function(){
     });
   });
 
+  describe("when rendering a collection in a composite view with a missing `itemViewContainer` specified", function(){
+    var CompositeView = Backbone.Marionette.CompositeView.extend({
+      itemView: ItemView,
+      itemViewContainer: '#missing-container',
+      template: "#composite-child-container-template"
+    });
+
+    var compositeView;
+    var order;
+    var deferredResolved;
+
+    beforeEach(function(){
+      order = [];
+      loadFixtures("compositeChildContainerTemplate.html");
+
+      var m1 = new Model({foo: "bar"});
+      var m2 = new Model({foo: "baz"});
+      var collection = new Collection([m1, m2]);
+
+      compositeView = new CompositeView({
+        collection: collection
+      });
+
+      spyOn(compositeView, "resetItemViewContainer").andCallThrough();
+
+    });
+
+    it("should throw an error", function(){
+      expect(function(){compositeView.render()}).toThrow("Missing `itemViewContainer`");
+    });
+  });
+
+
   describe("when rendering a collection in a composite view without an `itemViewContainer` specified", function(){
     var CompositeView = Backbone.Marionette.CompositeView.extend({
       itemView: ItemView,

--- a/src/backbone.marionette.compositeview.js
+++ b/src/backbone.marionette.compositeview.js
@@ -82,6 +82,12 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     } else {
       if (containerView.itemViewContainer){
         container = containerView.$(_.result(containerView, "itemViewContainer"));
+
+        if (container.length <= 0) {
+          var err = new Error("Missing `itemViewContainer`");
+          err.name = "ItemViewContainerMissingError";
+          throw err;
+        }
       } else {
         container = containerView.$el;
       }


### PR DESCRIPTION
I'm still learning Backbone and Marionette, and had wrongfully assumed that the itemViewContainer selector should be scoped manually to the container view. So I had `itemViewContainer: ".discussions table"`. This confusingly did not render any items.

The reason of course is that that selector is automatically scoped to the container element, and thus it returned an empty set of elements. And then `$container.append(iv.el)` does nothing. This pull request throws an error when no elements matched the selector specified by itemViewContainer, so that typos, template changes or misconceptions don't silently fail to render any of the items in the collection.

PS. I feel like it should be possible to write the specs more concisely with less duplication, but I'm just getting my feet wet with Marionette and Jasmine. It might need some improvements there, feel free to let me know.
