### PR TITLE
allow template functions with async renderer

### DIFF
--- a/spec/javascripts/async/async.renderer.spec.js
+++ b/spec/javascripts/async/async.renderer.spec.js
@@ -11,6 +11,27 @@ describe("async renderer", function(){
     Backbone.Marionette.Renderer = this.renderer;
   });
 
+  describe("when given a template function to render", function(){
+    var templateFunction = function(){return "<div>Hello World</div>";};
+    var result;
+
+    beforeEach(function(){
+      spyOn(Backbone.Marionette.TemplateCache, "get").andCallThrough();
+      var promise = Backbone.Marionette.Renderer.render(templateFunction);
+      promise.done(function(html){
+        result = $(html);
+      });
+    });
+
+    it("should retrieve the template from the cache", function(){
+      expect(Backbone.Marionette.TemplateCache.get).toHaveBeenCalledWith(templateFunction);
+    });
+
+    it("should render the template", function(){
+      expect(result).toHaveText(/Hello World/);
+    });
+  });
+
   describe("when given a template id to render", function(){
     var templateSelector = "#renderer-template";
     var result;

--- a/src/backbone.marionette.templatecache.js
+++ b/src/backbone.marionette.templatecache.js
@@ -17,6 +17,9 @@ _.extend(Marionette.TemplateCache, {
   // retrieves the cached version, or loads it
   // from the DOM.
   get: function(templateId){
+    if (typeof templateId == "function"){
+      return $.Deferred().resolve(templateId);
+    }
     var that = this;
     var cachedTemplate = this.templateCaches[templateId];
 


### PR DESCRIPTION
When using the async addon, template functions don't work currently. This is because the async renderer assumes that only template ids are passed into TemplateCache.get().

I've just added a check to see if it is a function, it is wrapped in a deferred and passed back immediately.
