### PR TITLE
Call buildUIElements in Async.ItemView.render.

### DIFF
--- a/src/async/backbone.marionette.async.itemView.js
+++ b/src/async/backbone.marionette.async.itemView.js
@@ -27,6 +27,7 @@ Async.ItemView = {
 
     var templateRendered = function(html){
       that.$el.html(html);
+      that.bindUIElements();
       callDeferredMethod(that.onRender, onRenderDone, that);
     }
 


### PR DESCRIPTION
`Async.ItemView` overrides the `ItemView.render` function but doesn't call `buildUIElements` after the html is inserted. Adding the call to `buildUIElements`.
