### PR TITLE
Enhance 'triggers'-based autowiring to include emitting view as an argument to triggered events.

### DIFF
--- a/src/backbone.marionette.view.js
+++ b/src/backbone.marionette.view.js
@@ -84,7 +84,7 @@ Marionette.View = Backbone.View.extend({
       triggerEvents[key] = function(e){
         if (e && e.preventDefault){ e.preventDefault(); }
         if (e && e.stopPropagation){ e.stopPropagation(); }
-        that.trigger(value);
+        that.trigger(value, that);
       };
 
     });


### PR DESCRIPTION
Event auto-wiring based on the 'triggers' hash on Backbone.Marionette.View is a useful way to map DOM events to application-level View events, but current implementation simply emits an event with the specified name and no other context.  In particular, the event does not include context such as the view that triggered the event, the model/collection that the view is fronting, the DOM event that was the origin of the event, etc.  
Since the main consumer of these view-level events are probably application components that should not need to have a dependency on the DOM it is understandable that the DOM event itself is not passed, however the view itself would be a very useful argument since you can extract the associated model/collection itself.
This pull request includes a commit to have the view passed as an argument to each emitted event.
The benefit is that it makes triggers-based autowiring more functional and thus eliminates situations where boilerplate on the view is required.
