### PR TITLE
[Callbacks] Fixed resetting callbacks

### DIFF
--- a/spec/javascripts/callbacks.spec.js
+++ b/spec/javascripts/callbacks.spec.js
@@ -84,7 +84,7 @@ describe("callbacks", function(){
   });
 
   describe("when resetting callbacks and re-running them", function(){
-    var cb, context, runContext;
+    var cb, numCallbacks;
 
     beforeEach(function(){
       var callbacks = new Backbone.Marionette.Callbacks();
@@ -96,10 +96,16 @@ describe("callbacks", function(){
       callbacks.reset();
 
       callbacks.run();
+
+      numCallbacks = callbacks._callbacks.length;
     });
 
     it("should run the callbacks again", function(){
       expect(cb.callCount).toBe(2);
+    });
+
+    it("should not duplicate the callbacks", function() {
+      expect(numCallbacks).toBe(1);
     });
   });
 

--- a/src/backbone.marionette.callbacks.js
+++ b/src/backbone.marionette.callbacks.js
@@ -34,8 +34,10 @@ _.extend(Marionette.Callbacks.prototype, {
   // to be run multiple times - whenever the `run` method is called.
   reset: function(){
     var that = this;
+    var callbacks = this._callbacks;
     this._deferred = $.Deferred();
-    _.each(this._callbacks, function(cb){
+    this._callbacks = [];
+    _.each(callbacks, function(cb){
       that.add(cb.cb, cb.ctx);
     });
   }


### PR DESCRIPTION
I ran into a problem that a callback of a module initialization calls several times for each the startup module, after the module has been stopped more than once.

When you reset the Marionette.Callbacks for each registered earlier callback will be added it's copy. Happens duplication callbacks in an arithmetic progression every time you resetting the callbacks.
