### PR TITLE
Backbone.Marionette check for DOM library argument

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -18,4 +18,4 @@ Backbone.Marionette = (function(Backbone, _, $){
 //= backbone.marionette.helpers.js
 
   return Marionette;
-})(Backbone, _, window.jQuery || window.Zepto || window.ender);
+})(Backbone, _, $ || window.jQuery || window.Zepto || window.ender);


### PR DESCRIPTION
Situation:

Where jQuery library is instantiated with noConflict in this way:

``` javascript
define(['path/to/jquery.min'], function () {
  return jQuery.noConflict(true);
});
```

as `jquery-amd`, I go into backbone-marionette.js and

`var jquery = require('jquery');`

to

`var jquery = require('jquery-amd');`

and 

`define(['jquery', 'underscore', 'backbone'], factory);`

to:

`define(['jquery', 'underscore', 'backbone'], factory);`

Backbone.Marionette amd is passing jquery, yet not checking for it.

I don't want any DOM library polluting my global/window scope in my case.

@derickbailey: You can close this if this the pr itself is not optimal, but I think the use case is valid.
