### PR TITLE
Remove 'that' from unbindAll

### DIFF
--- a/src/backbone.marionette.eventbinder.js
+++ b/src/backbone.marionette.eventbinder.js
@@ -40,14 +40,12 @@ _.extend(Marionette.EventBinder.prototype, {
 
   // Unbind all of the events that we have stored.
   unbindAll: function () {
-    var that = this;
-
     // The `unbindFrom` call removes elements from the array
     // while it is being iterated, so clone it first.
     var bindings = _.map(this._eventBindings, _.identity);
-    _.each(bindings, function (binding, index) {
-      that.unbindFrom(binding);
-    });
+    var unbind = _.bind(this.unbindFrom, this);
+
+    _.each(bindings, unbind);
   }
 });
 


### PR DESCRIPTION
I guess I just think it reads better when we get rid of the `var that = this` stuff.
