### PR TITLE
Documentation fix in MarionetteApplication

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -110,7 +110,7 @@ MyApp.vent.on("foo", function(){
 MyApp.vent.trigger("foo"); // => alert box "bar"
 ```
 
-See the `Marionette.EventAggregator` documentation below, for more details.
+See the [`Marionette.EventAggregator`](./marionette.eventaggregator.md) documentation for more details.
 
 ## Regions And The Application Object
 


### PR DESCRIPTION
Was no EventAggregator information below to see, but lets link to EventAggregator docs[.](www.youtube.com/watch?v=bA7jKHhMSJk#t=34s)
