### PR TITLE
Bind CollectionView to child view events prior to rendering child view

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -618,6 +618,45 @@ describe("collection view", function(){
     });
   });
 
+  describe("when a child view triggers default events", function(){
+    var model = new Backbone.Model({foo: "bar"});
+    var collection = new Backbone.Collection([model]);
+    var collectionView;
+    var eventNames = [];
+
+    beforeEach(function(){
+      collectionView = new CollectionView({
+        itemView: Backbone.Marionette.ItemView.extend({
+            template: function() { return '<%= foo %>'; }
+        }),
+        collection: collection
+      });
+
+      collectionView.on("all", function(){
+        var eventName = arguments[0];
+
+        eventNames.push(eventName);
+      });
+
+      collectionView.render();
+    });
+
+    it("should bubble up through the parent collection view", function(){
+      expect(eventNames).toBeDefined();
+      expect(eventNames).toEqual([
+          'before:render',
+          'collection:before:render',
+          'item:added',
+          'itemview:before:render',
+          'itemview:item:before:render',
+          'itemview:render',
+          'itemview:item:rendered',
+          'render',
+          'collection:rendered'
+      ]);
+    });
+  });
+
   describe("when a child view is removed from a collection view", function(){
     var model;
     var collection;

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -137,14 +137,6 @@ Marionette.CollectionView = Marionette.View.extend({
     this.storeChild(view);
     this.triggerMethod("item:added", view);
 
-    // Render it and show it
-    var renderResult = this.renderItemView(view, index);
-
-    // call onShow for child item views
-    if (view.onShow){
-      this.onShowCallbacks.add(view.onShow, view);
-    }
-
     // Forward all child item view events through the parent,
     // prepending "itemview:" to the event name
     var childBinding = this.bindTo(view, "all", function(){
@@ -159,6 +151,14 @@ Marionette.CollectionView = Marionette.View.extend({
     // them when removing / closing the child view
     this.childBindings = this.childBindings || {};
     this.childBindings[view.cid] = childBinding;
+
+    // Render it and show it
+    var renderResult = this.renderItemView(view, index);
+
+    // call onShow for child item views
+    if (view.onShow){
+      this.onShowCallbacks.add(view.onShow, view);
+    }
 
     return renderResult;
   },


### PR DESCRIPTION
This is a potential fix to an issue where a CollectionView is not receiving events from it's child view. 

The approach taken in this solution was to move the childBinding code in CollectionView.addItemView to occur prior to rendering the child view.

There also is a unit test that was written to verify this solution.  Prior to the change, none of the "itemview:*" events where being seen by the handler added to the CollectionView.
