### PR TITLE
Pass along event object through trigger to make available for finally called function

### DIFF
--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -17,7 +17,7 @@ Marionette.View = Backbone.View.extend({
   },
 
   // import the "triggerMethod" to trigger events with corresponding
-  // methods if the method exists 
+  // methods if the method exists
   triggerMethod: Marionette.triggerMethod,
 
   // Get the template for this view
@@ -70,7 +70,7 @@ Marionette.View = Backbone.View.extend({
       triggerEvents[key] = function(e){
         if (e && e.preventDefault){ e.preventDefault(); }
         if (e && e.stopPropagation){ e.stopPropagation(); }
-        that.trigger(value);
+        that.trigger(value, e);
       };
 
     });


### PR DESCRIPTION
Why: 
I need access to the triggering DOM event from within the finally called (by the trigger) function (that is triggered by said DOM event).

https://gist.github.com/3982834

What:
Pass along the event object instead of just swallowing it

How:
It makes the event object available to the finally called function
