### PR TITLE
Added 'lazy module' syntactic sugar to Application

### DIFF
--- a/src/backbone.marionette.application.js
+++ b/src/backbone.marionette.application.js
@@ -73,6 +73,11 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
 
     // see the Marionette.Module object for more information
     return Marionette.Module.create.apply(Marionette.Module, args);
+  },
+
+  // Create a module, attached to the application, which doesn't start with it by default
+  lazyModule: function(moduleNames, moduleDefinition) {
+    return this.module(moduleNames, {startWithParent: false, define: moduleDefinition})
   }
 });
 


### PR DESCRIPTION
When dealing with a module split into lots of files, adding the 'startWithParent: false' option to every definition is a bit messy. 

I added a a new way to define a module with this option set to false by default - 'lazyModule'. The name might not fit well (couldn't think of anything better).

It's a simple-stupid addition, but it really cleans up the code.
