### PR TITLE
Fixed tiny code sample bug

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -138,7 +138,7 @@ A sub-module can override this behavior by setting it's `startWithParent`
 to false. This prevents it from being started by the parent's `start` call.
 
 ```js
-MyApp.module("Foo", define: function(){...});
+MyApp.module("Foo", function(){...});
 
 MyApp.module("Foo.Bar", {
   startWithParent: true,


### PR DESCRIPTION
you had 

``` javascript
define: function(){}
```

as an argument when it should have either been inside an object literal or just been a function without the property name.
