### PR TITLE
triggerMethod should have a return value

### DIFF
--- a/src/marionette.triggermethod.js
+++ b/src/marionette.triggermethod.js
@@ -21,6 +21,6 @@ Marionette.triggerMethod = function(){
 
   if (_.isFunction(this[methodName])){
     args.shift();
-    this[methodName].apply(this, args);
+    return this[methodName].apply(this, args);
   }
 };


### PR DESCRIPTION
A simple change, but I'd like triggerMethod to return the value of the method it triggered.  This was mainly for my implementation of Async, so that when `onBeforeRender` is called by `triggerMethod` it could return a promise, but it would also be useful for other reasons. In my app, I use onBeforeRender as a hook to sometimes reject the deferred.
