### PR TITLE
Fix Layout display region if already rendered

### DIFF
--- a/src/marionette.layout.js
+++ b/src/marionette.layout.js
@@ -36,6 +36,14 @@ Marionette.Layout = Marionette.ItemView.extend({
     }
 
     var result = Marionette.ItemView.prototype.render.apply(this, arguments);
+
+    // inject regions into template
+    var that = this;
+    _.each(this.regionManagers, function(region){
+      if (region.currentView) {
+        that.$el.find(region.el).html(region.currentView.$el);
+      }
+    });
     return result;
   },
 


### PR DESCRIPTION
This is a fix for regions initialize in the Layout.initialize(). 
See [this jsfiddle](http://jsfiddle.net/m8BA7/3/)

Does not break the regions define outside as in [the initial jsfiddle](http://jsfiddle.net/TDqkj/6/)
