### PR TITLE
Minor documentation fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,7 +225,7 @@ LosTechies.com blog.
 ## Release Notes
 
 For change logs and release notes, see the
-[changelog](https://github.com/marionettejs/backbone.babysitter/blob/master/CHANGELOG.md) file.
+[changelog](https://github.com/marionettejs/backbone.marionette/blob/master/changelog.md) file.
 
 ## Legal Mumbo Jumbo (MIT License)
 


### PR DESCRIPTION
Hi Derick -- I keep track of where Marionette is by looking at the change log.  With the last push, the changelog link in the Marionette readme.md was set to point to the Babysitter change log!  I've fixed the link in this patch.

Thanks for doing Marionette!  It's fantastic.
