### PR TITLE
Append an itemView to a the correct index in a collectionView

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -287,6 +287,33 @@ describe("collection view", function(){
 
   });
 
+  describe("when an itemView is appended to the collection's EL", function(){
+    var collectionView;
+    var collection;
+    var model;
+
+    beforeEach(function(){
+      collection = new Backbone.Collection([{foo : "Luke"}, {foo : "Anakin"}]);
+      collectionView = new CollectionView({
+        itemView: ItemView,
+        collection: collection
+      }).render();
+
+      model = new Backbone.Model({foo: "Yoda"});
+    });
+
+    it("should append the model in the correct index in the collection's DOM", function(){
+      collection.add(model, {at : 1});
+      expect(collectionView.$el.children().index(collectionView.children[model.cid].$el)).toBe(1);
+    });
+
+    it("should append the first model as the first child of the collection's EL (index 0)", function(){
+      collection.reset().add(model);
+      expect(collectionView.$el.children().index(collectionView.children[model.cid].$el)).toBe(0);
+    });
+
+  });
+
   describe("when providing a custom render that adds children, without a collection object to use, and removing a child", function(){
     var collectionView;
     var childView;

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -212,7 +212,11 @@ Marionette.CollectionView = Marionette.View.extend({
   // Override this method to do something other
   // then `.append`.
   appendHtml: function(collectionView, itemView, index){
-    collectionView.$el.append(itemView.el);
+    if (index === 0) {
+      collectionView.$el.prepend(itemView.el);
+    } else {
+      collectionView.$el.find("> " + itemView.tagName + ":nth-child(" + index + ")").after(itemView.el);
+    }
   },
 
   // Store references to all of the child `itemView`

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -96,9 +96,13 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // `itemViewContainer` (a jQuery selector). Override this method to
   // provide custom logic of how the child item view instances have their
   // HTML appended to the composite view instance.
-  appendHtml: function(cv, iv){
+  appendHtml: function(cv, iv, index){
     var $container = this.getItemViewContainer(cv);
-    $container.append(iv.el);
+    if (index === 0) {
+      $container.prepend(iv.el);
+    } else {
+      $container.find("> " + iv.tagName + ":nth-child(" + index + ")").after(iv.el);
+    }
   },
 
   // Internal method to ensure an `$itemViewContainer` exists, for the


### PR DESCRIPTION
When working with a collection view or composite view that are bound to a Backbone collection, adding new models to the collection will always append them to the end of the view regardless of whether `{at : index}` was passed.  So if I have a collection of 2 models and I add a new model in between them, the view will render the model last instead of 2nd:

```
collection.toJSON()  // => [{name : "Luke"}, {name : "Anakin"}]
collectionView.el.innerHTML
// =>
<li>Luke</li>
<li>Anakin</li>

collection.add({name : "Yoda"}, {at : 1});
collectionView.el.innerHTML
// =>
<li>Luke</li>
<li>Anakin</li>
<li>Yoda</li>
```

The solution proposed is to modify the `appendHtml` methods so that they do following:
1. If the index is 0, add itemView's element with `$.prepend`.  This ensures that when rendering the collection for the first time, or when doing `collection.add(model, {at : 0})`, the element is added as the collection view's first child.
2. Otherwise, select the nth-child of the collection view's children and append the itemView's element with `$.after`.  This will guarantee that new collections are rendered correctly and that any new models inserted to an existing collection with an arbitrary index other than 0 are rendered in the correct position within the collection view's `el`.
