### PR TITLE
This moved the registration of onShowCallbacks to before initialize in case `render` is called, that way all the callbacks would still fire properly

### DIFF
--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -82,6 +82,55 @@ describe("composite view", function(){
     });
   });
 
+  describe("when a composite view triggers render in initialize", function(){
+    var compositeView;
+
+    var on_show;
+
+    var EmptyView = Backbone.Marionette.ItemView.extend({
+      template: "#emptyTemplate",
+      tagName: "hr",
+      onShow: function() {
+          on_show.push("EMPTY");
+      }
+    });
+
+    var ItemView = Backbone.Marionette.ItemView.extend({
+      template: "#collectionItemTemplate",
+      tagName: "span"
+    });
+
+    var CompositeView = Backbone.Marionette.CompositeView.extend({
+      itemView: ItemView,
+      emptyView: EmptyView,
+      template: "#collection-template",
+      initialize: function() {
+        this.render();
+      },
+      onRender: function(){}
+    });
+
+    beforeEach(function(){
+      loadFixtures("collectionTemplate.html", "collectionItemTemplate.html",
+          "emptyTemplate.html");
+
+      var m1 = new Model({foo: "bar"});
+
+      compositeView = new CompositeView({
+          model: m1,
+          collection: new Collection()
+      });
+
+      on_show = [];
+
+      compositeView.trigger("show");
+    });
+
+    it("should call 'onShowCallbacks.add'", function(){
+        expect(on_show.length == 1).toBeTruthy();
+    });
+  });
+
   describe("when rendering a composite view", function(){
     var compositeView, order, deferredResolved;
 

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -11,12 +11,12 @@ Marionette.CollectionView = Marionette.View.extend({
   // constructor
   constructor: function(options){
     this.initChildViewStorage();
+    this.onShowCallbacks = new Marionette.Callbacks();
 
     var args = Array.prototype.slice.apply(arguments);
     Marionette.View.prototype.constructor.apply(this, args);
 
     this.initialEvents();
-    this.onShowCallbacks = new Marionette.Callbacks();
   },
 
   // Configured the initial events that the collection view


### PR DESCRIPTION
Sorry the PR doesn't include compiled libraries, grunt doesn't generate the lib/ stuff for me on linux.
