### PR TITLE
added resolve method to application object, for easier fetching of submo...

### DIFF
--- a/lib/backbone.marionette.js
+++ b/lib/backbone.marionette.js
@@ -1157,7 +1157,7 @@ Marionette.View = Backbone.View.extend({
     if (!this.uiBindings) {
       // We want to store the ui hash in uiBindings, since afterwards the values in the ui hash
       // will be overridden with jQuery selectors.
-      this.uiBindings = _.result(this, "ui");
+      this.uiBindings = this.ui;
     }
 
     // refreshing the associated selectors since they should point to the newly rendered elements.


### PR DESCRIPTION
So disclaimer here is that I am new to this so I'm not what the proper way is to submit experimental code like this. I'm just want to share this so you can take a look a it, in case you like it or want to work something similar into the module system when it gets a revamp in 2.0. If there is a better way to submit stuff like this in the future please let me know.

Exploring further submodule stuff, I was ending up with things that looked like:

``` javascript
App.module( "Dialogs.EditCustomFieldDialog", function( ..., baseDialogView )
    this.view = baseDialog.extend( {
        ...
    } );
}, App.submodules.Dialogs.submodules.BaseDialog.view );
```

The ugly part being the last line. This pull request adds a "resolve" method to the application object that can resolve module paths, so you can do:

``` javascript
App.module( "Dialogs.EditCustomFieldDialog", function( ..., baseDialogView )
    this.view = baseDialog.extend( {
        ...
    } );
}, App.resolve( "Dialogs.BaseDialog" ).view );
```

Not sure this is valuable enough for everybody in include in marionette proper, and the implementation could definitely be polished, but just wanted to put this out there.

Enough for today =)!
