### PR TITLE
Three small features for the ui + events hashes

### DIFF
--- a/lib/backbone.marionette.js
+++ b/lib/backbone.marionette.js
@@ -471,6 +471,7 @@ Backbone.Marionette = Marionette = (function(Backbone, _, $){
 
 // For slicing `arguments` in functions
 var slice = Array.prototype.slice;
+var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
 // Marionette.extend
 // -----------------
@@ -1121,7 +1122,38 @@ Marionette.View = Backbone.View.extend({
     var triggers = this.configureTriggers();
     _.extend(combinedEvents, events, triggers);
 
+    events = this.expandUIBindingsInEventHash(events);
+
     Backbone.View.prototype.delegateEvents.call(this, combinedEvents);
+  },
+
+  // Interal method, handles the exansion of "alias" for jquery selectors
+  // given by the UI hash. These aliases, when found in the keys of
+  // the events hash, will be expanded to their corresponding selectors
+  // in the events hash.
+  expandUIBindingsInEventHash : function(events) {
+    var newEvents = {};
+
+    var uiBindings = this.uiBindings || _.result(this, "ui");
+    if (!uiBindings) { return events; }
+
+    _.each(events, function( value, key ){
+      var match = key.match(delegateEventSplitter);
+      var eventName = match[1], uiElName = match[2];
+
+      if(uiElName !== "" && ! _.isUndefined(uiBindings[uiElName])) {
+        var selector = uiBindings[uiElName];
+        if(selector[selector.length - 1] === "!")
+          selector = selector.slice(0, selector.length - 1);
+
+        key = eventName + " " + selector;
+      }
+      
+      newEvents[key] = value;
+    });
+
+
+    return newEvents;
   },
 
   // Internal method, handles the `show` event.
@@ -1157,14 +1189,23 @@ Marionette.View = Backbone.View.extend({
     if (!this.uiBindings) {
       // We want to store the ui hash in uiBindings, since afterwards the values in the ui hash
       // will be overridden with jQuery selectors.
-      this.uiBindings = this.ui;
+      this.uiBindings = _.result(this, "ui");
     }
 
     // refreshing the associated selectors since they should point to the newly rendered elements.
     this.ui = {};
     _.each(_.keys(this.uiBindings), function(key) {
       var selector = that.uiBindings[key];
+     
+      // if the selector ends with "!", we assert that there is exactly one DOM element that matches
+      // the selector. That is, we through an error if the number of matches elements != 1.
+      var assertOneAndOnlyOne = selector[selector.length - 1] === "!";
+      if( assertOneAndOnlyOne ) selector = selector.slice(0, selector.length - 1);
       that.ui[key] = that.$(selector);
+      if( assertOneAndOnlyOne ) {
+        if( that.ui[key].length !== 1 ) throw new Error( "Expected selector \"" + selector + "\" to match 1 element, but " + that.ui[key].length + " found." );
+        that.uiBindings[key] = selector;
+      }
     });
   }
 });
@@ -1937,31 +1978,6 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
 
     // see the Marionette.Module object for more information
     return Marionette.Module.create.apply(Marionette.Module, args);
-  },
-
-  resolve: function(modulePath){
-    var that = this;
-    var currentPositionInChain = that;
-    var modulePathArray = modulePath.split(".");
-
-    // Loop through all the parts of the module definition
-    var length = modulePathArray.length;
-    _.each(modulePathArray, function(thisPathComponent, i){
-      var isLastComponentInPath = (i === length-1);
-      // first check special case of trailing "." in modulePath, which
-      // indicates that we should return the "submodules" object of the
-      // last module in the chain
-      // (e.g. "Libraries.UI." -> return app.submodules.Libraries.submodules.UI.submodules)
-      if( isLastComponentInPath && thisPathComponent === "" )
-        currentPositionInChain = currentPositionInChain.submodules;
-      else {
-        if(_.isUndefined(currentPositionInChain.submodules) || _.isUndefined(currentPositionInChain.submodules[thisPathComponent]))
-            throw new Error("Could not resolve module path \"" + modulePath + "\"");
-        else currentPositionInChain = currentPositionInChain.submodules[thisPathComponent];
-      }
-    });
-
-    return currentPositionInChain;
   }
 });
 


### PR DESCRIPTION
I was going to try to submit this as three different pull requests because there are really three different changes here, but I am still learning git and I think I am too far down a wrong path, so I will just submit these three changes as one pull request. Here are the three changes:
1. Support for the ui element being a function. This allows a class to extend the ui element of its parent. For example:
   
   ``` javascript
   ui : function() { return _.extend( {}, baseFieldView.prototype.ui, {
       "valueFld" : "[name='value']"
   } ); },
   ```
2. Support for using the "aliases" setup by the ui element in the "events" hash. For example:
   
   ``` javascript
   ui : {
       "valueFld" : "[name='value']"
   },
   
   events : {
       "focus valueFld" : "_saveOldValue"
   }
   ```
3. Support for automatically asserting that selectors in the ui hash select one and only one DOM element. Often times I find that my selectors either do not select what I anticipate from the get-go, or more illusively, something changes and the selector no longer maps correctly to the DOM. Sometimes it is difficult to track down errors caused by these cases, but this difficultly can be avoided by asserting that your selectors are actually selecting something (and not too many things). This implementation uses an explanation mark at the end of the selector to indicate that it should select one and only one DOM element. So, for example,
   
   ``` javascript
   ui : {
       "valueFld" : "[name='value']!"
   },
   ```
   
   In this case, if `this.$( "[name='value']" ).length` is anything but 1, an error is thrown from `view#bindUIElements`:
   
   ```
   Expected "[name='value']" to match 1 element, but 0 found.
   ```
