### PR TITLE
Fixing jam config

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "jam":{
     "dependencies": {
       "jquery": ">=1.8.0",
-      "underscore": "1.3.3-jam.1",
+      "underscore": ">=1.4.0",
       "backbone": ">=0.9.2"
     },
     "main": "lib/amd/backbone.marionette.js",


### PR DESCRIPTION
Loads a newer version of underscore to be compatible with Backbone.
Didn't test this yet, will do it soon and report back.
