### PR TITLE
Moving `initialEvents` to `View`

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -15,8 +15,6 @@ Marionette.CollectionView = Marionette.View.extend({
 
     var args = Array.prototype.slice.apply(arguments);
     Marionette.View.prototype.constructor.apply(this, args);
-
-    this.initialEvents();
   },
 
   // Configured the initial events that the collection view

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -8,10 +8,6 @@ Marionette.ItemView =  Marionette.View.extend({
   constructor: function(){
     var args = Array.prototype.slice.apply(arguments);
     Marionette.View.prototype.constructor.apply(this, args);
-
-    if (this.initialEvents){
-      this.initialEvents();
-    }
   },
 
   // Serialize the model or collection for the view. If a model is

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -16,6 +16,8 @@ Marionette.View = Backbone.View.extend({
 
     Marionette.MonitorDOMRefresh(this);
     this.bindTo(this, "show", this.onShowCalled, this);
+
+    this.initialEvents();
   },
 
   // import the "triggerMethod" to trigger events with corresponding


### PR DESCRIPTION
By default `View` should have `initialEvents`, so you can always write your own `initialEvents` function with `super()` (in Coffeescript) to _add_ events instead of replacing them.

**Use case**
Imagine having an `ItemView`, to which you want to add some events to initialise with. The right place to do this is in initialEvents. So we write:

```
class SomeClass extends Backbone.Marionette.ItemView
  initialEvents: ->
    @bindTo @model, 'change', @render, @
```

Later on, we refactor it to a `CompositeView`. Now the initialEvents method _overrides_ the original one, which we did not intend to do! So we could have written this in the first place:

```
class SomeClass extends Backbone.Marionette.ItemView
  initialEvents: ->
    super()
    @bindTo @model, 'change', @render, @
```

This makes it easier to refactor to another view later. The other way around also holds: we can refactor from a `CollectionView` or `CompositeView` to another view while still using `super()`.

Only, this is not possible, because `ItemView` does not have an `initialEvents` method! With this pull request we add `initialEvents` to `View`, which makes it easier to refactor code when `super()` is used.
