### PR TITLE
added view and event object to parameters for trigger function

### DIFF
--- a/lib/backbone.marionette.js
+++ b/lib/backbone.marionette.js
@@ -1051,7 +1051,7 @@ Marionette.View = Backbone.View.extend({
       triggerEvents[key] = function(e){
         if (e && e.preventDefault){ e.preventDefault(); }
         if (e && e.stopPropagation){ e.stopPropagation(); }
-        that.trigger(value,that,e);
+        that.trigger(value, that);
       };
 
     });


### PR DESCRIPTION
Wow. It has been a very long road to isolate this change but also a very good learning process.

This PR contains a simple change that adds two additional parameters to the function called as a result of the configuration of the `triggers` hash. Namely:
1. The view object that triggered the event. Sometimes you are "listening" to a triggered event from another view, and need to know which view triggered the event. For example, a parent views wants to listen to triggered events form multiple subviews. The trigger hash for each subview as the form:
   
   ``` javascript
   triggers : {
       "click div.name" : "click:name"
   }
   ```
   
   The parent view then listens for the event from two distinct subviews with a function like:
   
   ``` javascript
   this.subviews.A.bind( "click:name", this._subview_onNameClicked, this );
   this.subviews.B.bind( "click:name", this._subview_onNameClicked, this );
   ```
   
   The same function can be used to listen to both subviews. But if the subview is not passed as a parameter to `this._subview_onNameClicked`, there is no way to determine which subview triggered the event.
2. The second parameter that was added in this PR is the jQuery event object. Don't have a specific use case for this one yet but seems like it is bound to come up, since the nature of the event itself will also at times be of interest to the view listening to the triggered event. 
