### PR TITLE
trigger events from trigger hash that are already contained in events hash

### DIFF
--- a/lib/backbone.marionette.js
+++ b/lib/backbone.marionette.js
@@ -1069,9 +1069,9 @@ Marionette.View = Backbone.View.extend({
         if (!existingMethod) throw new Error('Method "' + existingEvents[key] + '" does not exist');
 
         triggerEvents[key] = function() {
-          // pass on arguments supplied by DOM library to existingMethod
+          // pass on arguments (event obj) supplied by DOM library
           existingMethod.apply(that, arguments);
-          triggerFunction();
+          triggerFunction.apply(that, arguments);
         }
       }
     });


### PR DESCRIPTION
This PR is a patch that prevents the events in the trigger hash from overriding events in the event hash. For example, right now if you do:

``` javascript
events : {
    "click div.name" : "_onMyNameClicked"
}

triggers : {
    "click div.name" : "click:name"
}
```

The `_onMyNameClicked` function will never get called because the trigger function will override the original event handler.

The patch solves this inconsistency, so that `_onMyNameClicked` is called and then the "click:name" event is triggered.
