### PR TITLE
Refer to local Marionette instead of Backbone.Marionette

### DIFF
--- a/src/marionette.layout.js
+++ b/src/marionette.layout.js
@@ -17,7 +17,7 @@ Marionette.Layout = Marionette.ItemView.extend({
     this.initializeRegions();
 
     var args = Array.prototype.slice.apply(arguments);
-    Backbone.Marionette.ItemView.apply(this, args);
+    Marionette.ItemView.apply(this, args);
   },
 
   // Layout's render will use the existing region objects the
@@ -51,7 +51,7 @@ Marionette.Layout = Marionette.ItemView.extend({
     this.destroyRegions();
 
     var args = Array.prototype.slice.apply(arguments);
-    Backbone.Marionette.ItemView.prototype.close.apply(this, args);
+    Marionette.ItemView.prototype.close.apply(this, args);
   },
 
   // Initialize the regions that have been defined in a


### PR DESCRIPTION
- Problem: Referring to the `Backbone` global variable after initialization makes it difficult to use Marionette as a separate module (ie `define(['marionette'], function(Marionette) { ... })`
- Solution: Refer to the `Marionette` object directly instead of referring to `Backbone.Marionette`
