### PR TITLE
Use view as context for template function when rendering ItemView

### DIFF
--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -44,7 +44,7 @@ Marionette.ItemView =  Marionette.View.extend({
     data = this.mixinTemplateHelpers(data);
 
     var template = this.getTemplate();
-    var html = Marionette.Renderer.render(template, data);
+    var html = Marionette.Renderer.render.call(this, template, data);
     this.$el.html(html);
     this.bindUIElements();
 

--- a/src/marionette.renderer.js
+++ b/src/marionette.renderer.js
@@ -11,7 +11,7 @@ Marionette.Renderer = {
   // custom rendering and template handling for all of Marionette.
   render: function(template, data){
     var templateFunc = typeof template === 'function' ? template : Marionette.TemplateCache.get(template);
-    var html = templateFunc(data);
+    var html = templateFunc.call(this, data);
     return html;
   }
 };


### PR DESCRIPTION
Why:
I want to change the classes of rendered elements based on the options argument given to my view by the router. These options stem from the URL and therefore aren't contained in the model and shouldn't be saved server side either. 

Using a template function with custom arguments as documented in marionette.itemview.md#itemview-render seems to be the best way to send these options to my template. However, as the context of the template function is the window object I do not have access to these options and cannot pass them on to my template.

What: Use view as context for template function when rendering ItemView
How: By having access to the view, I can send view.myVariable to the template for rendering

Any suggestions / objections to adding this to Marionette?
The current commit only implements this for ItemView, so if this seems like an elegant solution, I will make more work of it.
