### PR TITLE
Fix build on case-sensitive file systems.

### DIFF
--- a/src/build/marionette.core.js
+++ b/src/build/marionette.core.js
@@ -6,7 +6,7 @@ var Marionette = (function(Backbone, _, $){
 
 //= ../marionette.helpers.js
 //= ../marionette.createObject.js
-//= ../marionette.triggerMethod.js
+//= ../marionette.triggermethod.js
 //= ../marionette.domRefresh.js
 
 //= ../marionette.eventbinder.js


### PR DESCRIPTION
Marionette build does not work for me, I'm on Linux on ext4. The problem is ext4 is case-sensitive file-system. This commit fixes case mismatch for one file included via rigger.
