### PR TITLE
fix #429, #175, #182 (multiple EmptyView zombie)

### DIFF
--- a/spec/javascripts/collectionView.emptyView.spec.js
+++ b/spec/javascripts/collectionView.emptyView.spec.js
@@ -119,5 +119,35 @@ describe("collectionview - emptyView", function(){
     });
   });
 
+
+  describe("when the collection is reset multiple times", function () {
+    var collectionView, collection, population = [{foo:1},{foo:2},{foo:3}];
+
+    beforeEach(function () {
+      collection = new Backbone.Collection();
+      collectionView = new EmptyCollectionView({
+        collection: collection
+      });
+    });
+
+    it("should remove all EmptyView", function () {
+      collectionView.render();        // 1st showEmptyView
+      collection.reset(population);   // 1st closeEmptyView
+      collection.reset();             // 2nd showEmptyView
+      collection.reset(population);   // 2nd closeEmptyView
+      expect(collectionView.$el).not.toContain('span.isempty')
+    });
+
+    it("should have only one emptyView open", function () {
+      collectionView.render();        // 1st showEmptyView
+      collection.reset(population);   // 1st closeEmptyView
+      collection.reset();             // 2nd closeEmptyView, showEmptyView
+      collection.reset();             // 3nd closeEmptyView, showEmptyView
+      expect(collectionView.$('span.isempty').length).toEqual(1);
+    });
+
+  });
+
+
 });
 

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -257,8 +257,9 @@ Marionette.CollectionView = Marionette.View.extend({
       this.removeChildView(child);
     }, this);
 
+    // commented to fix issue #429
     // re-initialize to clean up after ourselves
-    this._initChildViewStorage();
+    // this._initChildViewStorage();
   }
 });
 


### PR DESCRIPTION
I don't know what `_initChildViewStorage` supposed to do, but it created EmptyView zombies (not closing container, just replacing it). This fixes #429, #175, #182.
I have just commented out that line & all the test pass, so I don't think that line should even be there.

I have also added two test for #429 (sorry for the poor naming).
