### PR TITLE
Change view.configureTriggers to call view.triggerMethod (instead of plan view.trigger)

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -123,7 +123,7 @@ widget suites), see [this blog post on KendoUI + Backbone](http://www.kendoui.co
 ## View.triggers
 
 Views can define a set of `triggers` as a hash, which will 
-convert a DOM event in to a `view.trigger` event.
+convert a DOM event into a `view.triggerMethod` call.
 
 The left side of the hash is a standard Backbone.View DOM
 event configuration, while the right side of the hash is the

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -71,7 +71,7 @@ Marionette.View = Backbone.View.extend({
         };
 
         // trigger the event
-        that.trigger(value, args);
+        that.triggerMethod(value, args);
       };
 
     });


### PR DESCRIPTION
Modified view.configureTriggers to call view.triggerMethod in place of
view.trigger.  Updated view doc to reflect this, as well.

view.configureTriggers orignally simple called 'trigger' for the
calculated event.  The excellent Marionette.triggerMethod function calls
both the trigger _and_ local methods of a standardized name.  Making
triggers call triggerMethod allows for more concise and reusable view
code than merely using trigger alone.

While this could break compatibility, since the introduction of
the triggerMethod call, it would be unwise to use methods which match
the standardized method calls for any other purpose, anyway.
