### PR TITLE
Change view.configureTriggers to call view.triggerMethod (instead of plan view.trigger)

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -123,7 +123,7 @@ widget suites), see [this blog post on KendoUI + Backbone](http://www.kendoui.co
 ## View.triggers
 
 Views can define a set of `triggers` as a hash, which will 
-convert a DOM event in to a `view.trigger` event.
+convert a DOM event into a `view.triggerMethod` call.
 
 The left side of the hash is a standard Backbone.View DOM
 event configuration, while the right side of the hash is the

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -71,7 +71,7 @@ Marionette.View = Backbone.View.extend({
         };
 
         // trigger the event
-        that.trigger(value, args);
+        that.triggerMethod(value, args);
       };
 
     });


### PR DESCRIPTION
This merely changes view.configureTriggers to call view.triggerMethod instead of simply calling view.trigger.  This simply allows for slightly more concise view implementation code.

Please pardon me if there is a reason that triggerMethod was not used other than simply not being updated to utilize the new triggerMethod function.

While this could break compatibility, since the introduction of
the triggerMethod call, it would be unwise to use methods which match
the standardized method calls for any other purpose, anyway.
