### PR TITLE
Fixed issue with the lost of events

### DIFF
--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -105,6 +105,12 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     view.render();
     this.open(view);
+    
+    // Reinitialize $el events for view if it's rendered not for the first time.
+    // Otherwise events will be lost
+    if (view._isShown) {
+      view.delegateEvents();
+    }
 
     Marionette.triggerMethod.call(view, "show");
     Marionette.triggerMethod.call(this, "show", view);


### PR DESCRIPTION
Steps to reproduce:

```
view1 = /* ... */;
view2 = Backbone.Marionette.Layout.extend({ /* ... */, events : {
  'evt element' : 'handler'
}});
region.show(view2); // here we can handle `handler`
region.show(view1);
region.show(view2); // but here not
```
