### PR TITLE
added setCollection function to CollectionView

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -29,6 +29,18 @@ Marionette.CollectionView = Marionette.View.extend({
     }
   },
 
+  // Handle setting the collection
+  setCollection: function(newCollection){
+    // unbind to current collection
+    if (this.collection){
+      this.stopListening(this.collection);
+    }
+    // set new collection
+    this.collection = newCollection;
+    // bind to new collection
+    this._initialEvents();
+  },
+
   // Handle a child item added to the collection
   addChildView: function(item, collection, options){
     this.closeEmptyView();


### PR DESCRIPTION
Why: When using a CollectionView or CompostiveView, I had a need to change the collection used in the view. Simply setting myView.collection = myOtherCollection caused problems when the original collection had items added. Using this setCollection function I wrote solves this.

What: a new function in CollectionView called setCollection. This function will be inherited to CompositeView.

How: unbind to the collection a view has and bind to the new collection.
