### PR TITLE
Fix errors in "Region Events And Callbacks" docs

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -179,12 +179,12 @@ These events can be used to run code when your region manager
 opens and closes views.
 
 ```js
-MyApp.mainRegion.on("show", function(view){
+MyApp.mainRegion.on("view:show", function(view){
   // manipulate the `view` or do something extra
   // with the region manager via `this`
 });
 
-MyApp.mainRegion.on("closed", function(view){
+MyApp.mainRegion.on("view:closed", function(view){
   // manipulate the `view` or do something extra
   // with the region manager via `this`
 });


### PR DESCRIPTION
Fixed misnamed event bindings:

Changed `on("show"` to `on("view:show"` and `on("closed"` to on("view:closed"`.
