### PR TITLE
Remove var that = this in favor of binding

### DIFF
--- a/src/marionette.application.js
+++ b/src/marionette.application.js
@@ -52,11 +52,10 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
   // addRegions({something: "#someRegion"})
   // addRegions{{something: Region.extend({el: "#someRegion"}) });
   addRegions: function(regions){
-    var that = this;
     _.each(regions, function (region, name) {
       var regionManager = Marionette.Region.buildRegion(region, Marionette.Region);
-      that[name] = regionManager;
-    });
+      this[name] = regionManager;
+    }, this);
   },
 
   // Removes a region from your app.

--- a/src/marionette.callbacks.js
+++ b/src/marionette.callbacks.js
@@ -33,13 +33,13 @@ _.extend(Marionette.Callbacks.prototype, {
   // Resets the list of callbacks to be run, allowing the same list
   // to be run multiple times - whenever the `run` method is called.
   reset: function(){
-    var that = this;
     var callbacks = this._callbacks;
     this._deferred = $.Deferred();
     this._callbacks = [];
+    
     _.each(callbacks, function(cb){
-      that.add(cb.cb, cb.ctx);
-    });
+      this.add(cb.cb, cb.ctx);
+    }, this);
   }
 });
 

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -87,12 +87,11 @@ Marionette.CollectionView = Marionette.View.extend({
   // Internal method to loop through each item in the
   // collection view and show it
   showCollection: function(){
-    var that = this;
     var ItemView;
     this.collection.each(function(item, index){
-      ItemView = that.getItemView(item);
-      that.addItemView(item, ItemView, index);
-    });
+      ItemView = this.getItemView(item);
+      this.addItemView(item, ItemView, index);
+    }, this);
   },
 
   // Internal method to show an empty view in place of
@@ -136,8 +135,6 @@ Marionette.CollectionView = Marionette.View.extend({
   // Render the child item's view and add it to the
   // HTML for the collection view.
   addItemView: function(item, ItemView, index){
-    var that = this;
-
     // get the itemViewOptions if any were specified
     var itemViewOptions = Marionette.getOption(this, "itemViewOptions");
     if (_.isFunction(itemViewOptions)){

--- a/src/marionette.layout.js
+++ b/src/marionette.layout.js
@@ -65,18 +65,17 @@ Marionette.Layout = Marionette.ItemView.extend({
       this.regionManagers = {};
     }
 
-    var that = this;
     var regions = this.regions || {};
     _.each(regions, function (region, name) {
+      var regionManager = Marionette.Region.buildRegion(region, this.regionType);
 
-      var regionManager = Marionette.Region.buildRegion(region, that.regionType);
-      regionManager.getEl = function(selector){
-        return that.$(selector);
-      };
+      regionManager.getEl = _.bind(function(selector) {
+        return this.$(selector);
+      }, this);
 
-      that.regionManagers[name] = regionManager;
-      that[name] = regionManager;
-    });
+      this.regionManagers[name] = regionManager;
+      this[name] = regionManager;
+    }, this);
 
   },
 
@@ -96,7 +95,6 @@ Marionette.Layout = Marionette.ItemView.extend({
   // this layout. This method is called when the layout
   // itself is closed.
   closeRegions: function () {
-    var that = this;
     _.each(this.regionManagers, function (manager, name) {
       manager.close();
     });
@@ -105,10 +103,9 @@ Marionette.Layout = Marionette.ItemView.extend({
   // Destroys all of the regions by removing references
   // from the Layout
   destroyRegions: function(){
-    var that = this;
     _.each(this.regionManagers, function (manager, name) {
-      delete that[name];
-    });
+      delete this[name];
+    }, this);
     this.regionManagers = {};
   }
 });

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -122,7 +122,6 @@ _.extend(Marionette.Module, {
 
   // Create a module, hanging off the app parameter as the parent object.
   create: function(app, moduleNames, moduleDefinition){
-    var that = this;
     var module = app;
 
     // get the custom args passed in after the module definition and
@@ -141,9 +140,9 @@ _.extend(Marionette.Module, {
     // Loop through all the parts of the module definition
     _.each(moduleNames, function(moduleName, i){
       var parentModule = module;
-      module = that._getModule(parentModule, moduleName, app);
-      that._addModuleDefinition(parentModule, module, moduleDefinitions[i], customArgs);
-    });
+      module = this._getModule(parentModule, moduleName, app);
+      this._addModuleDefinition(parentModule, module, moduleDefinitions[i], customArgs);
+    }, this);
 
     // Return the last module in the definition chain
     return module;

--- a/src/marionette.templatecache.js
+++ b/src/marionette.templatecache.js
@@ -17,7 +17,6 @@ _.extend(Marionette.TemplateCache, {
   // retrieves the cached version, or loads it
   // from the DOM.
   get: function(templateId){
-    var that = this;
     var cachedTemplate = this.templateCaches[templateId];
 
     if (!cachedTemplate){
@@ -57,8 +56,6 @@ _.extend(Marionette.TemplateCache.prototype, {
 
   // Internal method to load the template
   load: function(){
-    var that = this;
-
     // Guard clause to prevent loading this template more than once
     if (this.compiledTemplate){
       return this.compiledTemplate;

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -45,7 +45,6 @@ Marionette.View = Backbone.View.extend({
   configureTriggers: function(){
     if (!this.triggers) { return; }
 
-    var that = this;
     var triggerEvents = {};
 
     // Allow `triggers` to be configured as a function
@@ -70,10 +69,10 @@ Marionette.View = Backbone.View.extend({
         };
 
         // trigger the event
-        that.triggerMethod(value, args);
+        this.triggerMethod(value, args);
       };
 
-    });
+    }, this);
 
     return triggerEvents;
   },
@@ -139,7 +138,6 @@ Marionette.View = Backbone.View.extend({
   bindUIElements: function(){
     if (!this.ui) { return; }
 
-    var that = this;
 
     if (!this.uiBindings) {
       // We want to store the ui hash in uiBindings, since afterwards the values in the ui hash
@@ -150,8 +148,8 @@ Marionette.View = Backbone.View.extend({
     // refreshing the associated selectors since they should point to the newly rendered elements.
     this.ui = {};
     _.each(_.keys(this.uiBindings), function(key) {
-      var selector = that.uiBindings[key];
-      that.ui[key] = that.$(selector);
-    });
+      var selector = this.uiBindings[key];
+      this.ui[key] = this.$(selector);
+    }, this);
   }
 });


### PR DESCRIPTION
I have gone through the source and remove var that = this. There was a bunch of places it wasn't even being used in closures (#487) and in some spots I simply had to bind the closure (underscore takes an argument for `this` context and many of it's functions).
