### PR TITLE
Failing spec showing onDomRefresh is still called if the view.el doesn't exist in the DOM

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -615,7 +615,7 @@ describe("collection view", function(){
   });
 
   describe("when a child view is added to a collection view, after the collection view has been shown", function(){
-    var m1, m2, col, view;
+    var m1, m2, col, view, colView;
 
     var ItemView = Backbone.Marionette.ItemView.extend({
       onShow: function(){},
@@ -638,7 +638,7 @@ describe("collection view", function(){
       m1 = new Backbone.Model();
       m2 = new Backbone.Model();
       col = new Backbone.Collection([m1]);
-      var colView = new ColView({
+      colView = new ColView({
         collection: col
       });
 
@@ -659,8 +659,16 @@ describe("collection view", function(){
       expect(context).toBe(view);
     });
 
-    it("should call the child's 'onDomRefresh' method with itself as the context", function(){
+    it("should call the child's 'onDomRefresh' method if does exist in the DOM", function() {
+      $('body').append(colView.el);
+      expect(jQuery.contains(document.documentElement, view.el)).toBe(true);
       expect(ItemView.prototype.onDomRefresh).toHaveBeenCalled();
+      colView.remove();
+    });
+
+    it("should not call the child's 'onDomRefresh' method if doesn't exist in the DOM", function() {
+      expect(jQuery.contains(document.documentElement, view.el)).toBe(false);
+      expect(ItemView.prototype.onDomRefresh).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This bug was brought up in #497. A Region will still trigger (by extension) the onDomRefresh method of an freshly attached child view even if the `Region.el` _isn't_ in the DOM (and therefore the child view isn't in the DOM either).

This is a bit tricky because if the `Region.el` is out of the DOM, the Region has no way of knowing when it _is_ added to the DOM and can safely trigger this event.
