### PR TITLE
Don't close views we are going to show

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -113,6 +113,51 @@ describe("region", function(){
     });
   });
 
+  describe("when a view is already shown and showing the same one", function(){
+    var MyRegion = Backbone.Marionette.Region.extend({
+      el: "#region"
+    });
+
+    var MyView = Backbone.View.extend({
+      render: function(){
+        $(this.el).html("some content");
+      },
+
+      close: function(){
+      },
+
+      open: function(){
+      }
+    });
+
+    var myRegion, view;
+
+    beforeEach(function(){
+      setFixtures("<div id='region'></div>");
+
+      view = new MyView();
+      myRegion = new MyRegion();
+      myRegion.show(view);
+
+      spyOn(view, "close");
+      spyOn(view, "open");
+      spyOn(view, "render");
+      myRegion.show(view);
+    });
+
+    it("should not call 'close' on the view", function(){
+      expect(view.close).not.toHaveBeenCalled();
+    });
+
+    it("should not call 'open' on the view", function(){
+      expect(view.open).not.toHaveBeenCalled();
+    });
+
+    it("should call 'render' on the view", function(){
+      expect(view.render).toHaveBeenCalled();
+    });
+  });
+
   describe("when a view is already closed and showing another", function(){
     var MyRegion = Backbone.Marionette.Region.extend({
       el: "#region"

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -103,10 +103,14 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   show: function(view){
 
     this.ensureEl();
-    this.close();
 
-    view.render();
-    this.open(view);
+    if (view !== this.currentView) {
+      this.close();
+      view.render();
+      this.open(view);
+    } else {
+      view.render();
+    }
 
     Marionette.triggerMethod.call(view, "show");
     Marionette.triggerMethod.call(this, "show", view);


### PR DESCRIPTION
At present, if you have a view that is visible in a region, and you call .show and pass the same view again, .close will be called. .close will call .remove will call .stopListening which will unexpectedly unbind events from a view which is still in use.

This patch changes the behaviour of Region.show to only call close & open if the view being show differs from the current view. If the view is the same as the current view, it simply re-renders it.
