### PR TITLE
Add "main" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Make your Backbone.js apps dance!",
   "version": "1.0.0-rc6",
   "homepage": "https://github.com/marionettejs/backbone.marionette",
+  "main": "lib/amd/backbone.marionette.js",
   "keywords": [
     "backbone",
     "plugin",


### PR DESCRIPTION
I see there's a `jam.main`, but there is not `main`. I'm using `backbone.marionette` as an NPM module and requiring it using Browserify, therefore the module needs a `main` property.

I wondered why this hasn't been included?
