### PR TITLE
Add support for Browserify / CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
     "url": "https://github.com/marionettejs/backbone.marionette.git"
   },
   "github": "https://github.com/marionettejs/backbone.marionette",
+  "dependencies": {
+    "jquery": "~1.8.3",
+    "Backbone.BabySitter": "git://github.com/marionettejs/backbone.babysitter",
+    "Backbone.Wreqr": "git://github.com/marionettejs/backbone.wreqr",
+    "backbone": "~0.9.10"
+  },
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-jasmine": "~0.3.1",


### PR DESCRIPTION
Backbone recently added [support for CommonJS](https://github.com/documentcloud/backbone/blob/master/backbone.js#L13-41). Is there any chance this could get added to Marionette and Wreqr?
