### PR TITLE
Refactor Marionette#triggerMethod

### DIFF
--- a/src/marionette.triggermethod.js
+++ b/src/marionette.triggermethod.js
@@ -5,22 +5,13 @@
 //
 // `this.triggerMethod("foo:bar") will trigger the "foo:bar" event and
 // call the "onFooBar" method.
-Marionette.triggerMethod = function(){
-  var args = Array.prototype.slice.apply(arguments);
-  var eventName = args[0];
-  var segments = eventName.split(":");
-  var segment, capLetter, methodName = "on";
+Marionette.triggerMethod = function(event) {
+  var methodName = 'on' + event.replace(/(^|:)(\w)/gi, function() { return arguments[2].toUpperCase(); });
+  var method = this[methodName];
 
-  for (var i = 0; i < segments.length; i++){
-    segment = segments[i];
-    capLetter = segment.charAt(0).toUpperCase();
-    methodName += capLetter + segment.slice(1);
-  }
+  this.trigger.apply(this, arguments);
 
-  this.trigger.apply(this, args);
-
-  if (_.isFunction(this[methodName])){
-    args.shift();
-    return this[methodName].apply(this, args);
+  if (_.isFunction(method)) {
+    return method.apply(this, _.tail(arguments));
   }
 };


### PR DESCRIPTION
Using RegExp to convert namespaced event into method name seems to be cleaner. Utilize `_.tail` for arguments manipulating
