### PR TITLE
onCollectionShow trigger

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -88,6 +88,7 @@ Marionette.CollectionView = Marionette.View.extend({
       ItemView = that.getItemView(item);
       that.addItemView(item, ItemView, index);
     });
+    this.triggerMethod("collection:show", this);
   },
 
   // Internal method to show an empty view in place of
@@ -139,9 +140,9 @@ Marionette.CollectionView = Marionette.View.extend({
       itemViewOptions = itemViewOptions.call(this, item);
     }
 
-    // build the view 
+    // build the view
     var view = this.buildItemView(item, ItemView, itemViewOptions);
-    
+
     // set up the child view event forwarding
     this.addChildViewEventForwarding(view);
 


### PR DESCRIPTION
Hi guys,

This is probably the smallest pull request in history :) I'm going to explain why I couldn't solve my problem without this event.

I have a Grid with many records (100,000 for example) and I'm using a jQuery plugin called _DataTables_ (http://www.datatables.net/usage/). As you can see in the "Prerequisites" section the plugin requires the table to be already loaded in the DOM in order to work. So here comes the problem. This is my code:

``` javascript
var GridController = {
  //...
  showGrid: function () {
    records = new Records();
    records.fetch(); // N seconds to load...
    gridView  = new GridView({
      collection: records
    });

    //emptyView is showed here until
    //the collection will be loaded
    this.layout.content.show(gridView);
  }
}

var GridView = Marionette.CompositeView.extend({
  //...
  emptyView: LoadingView,
  itemView: GridItemView,

  onCollectionShow: function () {
    // table is fully loaded
    this.$('#my-table').dataTable();
  }

});
```

I think it's a minor change that doesn't affect the code and can be useful to more people. What do you think?

Thanks!
