### PR TITLE
CompositeView attempts to appendHtml of itemViews before itemViewContainer exists (before template is rendered)

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -183,7 +183,9 @@ Marionette.CollectionView = Marionette.View.extend({
   // render the item view
   renderItemView: function(view, index) {
     view.render();
-    this.appendHtml(this, view, index);
+    if (this.isRendered) {
+        this.appendHtml(this, view, index);
+    }
   },
 
   // Build an `itemView` for every model in the collection.


### PR DESCRIPTION
I have a `CompositeView` which takes a model (already downloaded from server) and a collection which is then fetched. As soon as the `sync` is finished, I want to render my CompositeView. However, the CompositeView appears to try appending the itemViews for the collection before it renders its own template, and so it can't find its own `itemViewContainer`, generating error `Uncaught ItemViewContainerMissingError: The specified`itemViewContainer`was not found: .modal__body`.

[Here is a gist.](https://gist.github.com/OliverJAsh/43898688447d89b08d2f#file-feed-controller-js-L18-L22)

I should note that I have exactly the same setup elsewhere and it works with no problems, so it could well be something on my end, but I've spent long enough debugging this one and I can't seem to find the problem!
