### PR TITLE
delete region definition from layout regions hash when removing region

### DIFF
--- a/src/marionette.layout.js
+++ b/src/marionette.layout.js
@@ -120,6 +120,7 @@ Marionette.Layout = Marionette.ItemView.extend({
 
     this.listenTo(this.regionManager, "region:remove", function(name, region){
       delete this[name];
+      delete this.regions[name];
       this.trigger("region:remove", name, region);
     });
   }


### PR DESCRIPTION
I rely of the layout regions hash for filtering out region views when a developer calls <layout instance>.$('some selector'). addRegion currently updates the regions definition hash, but removeRegion does not. I added a line of code to delete the region definition from the regions hash when removeRegion is called, so that they behave consistently.
