### PR TITLE
Layout Regions Hash Update

### DIFF
--- a/src/marionette.layout.js
+++ b/src/marionette.layout.js
@@ -70,6 +70,7 @@ Marionette.Layout = Marionette.ItemView.extend({
 
   // Remove a single region from the Layout, by name
   removeRegion: function(name){
+    delete this.regions[name];
     return this.regionManager.removeRegion(name);
   },
 
@@ -120,7 +121,6 @@ Marionette.Layout = Marionette.ItemView.extend({
 
     this.listenTo(this.regionManager, "region:remove", function(name, region){
       delete this[name];
-      delete this.regions[name];
       this.trigger("region:remove", name, region);
     });
   }


### PR DESCRIPTION
I rely of the layout regions hash for filtering out region views when a developer calls .$('some selector'). addRegion currently updates the regions definition hash, but removeRegion does not. I added a line of code to delete the region definition from the regions hash when removeRegion is called, so that they behave consistently.
