### PR TITLE
Filter Out Regions from Layout.$

### DIFF
--- a/src/marionette.layout.js
+++ b/src/marionette.layout.js
@@ -74,6 +74,22 @@ Marionette.Layout = Marionette.ItemView.extend({
     return this.regionManager.removeRegion(name);
   },
 
+  filterRegions: false,
+
+  $: function (selector) {  
+    var not = [];
+
+    if (!Marionette.getOption(this, 'filterRegions') || !_.size(this.regions)) {
+      return this.constructor.__super__.$.call(this, selector);
+    } 
+
+    _.each(this.regions, function(region) {
+      not.push(region + ' ' + selector);
+    });       
+
+    return this.$el.find(selector).not(not.join(','));
+  },  
+
   // internal method to build regions
   _buildRegions: function(regions){
     var that = this;


### PR DESCRIPTION
In some cases a developer may not have any knowledge of a how an application was assembled or have full control over the modules on the page. This is happens frequently in large composite applications. This pull is a prototype for optionally filtering out region views in a layout view when <layout instance>.$('some selector') is called. This helps prevent a developer of one module's view from unintentionally impacting another developer's module view.
