### PR TITLE
fix documentation typo

### DIFF
--- a/docs/marionette.configuration.md
+++ b/docs/marionette.configuration.md
@@ -22,7 +22,7 @@ library, you can directly assign these settings:
 
 ```js
 Backbone.$ = myDOMLib;
-Marioentte.$ = myDOMLib;
+Marionette.$ = myDOMLib;
 ```
 
 Note that you should change both Backbone and Marionette at the same


### PR DESCRIPTION
There was a transposed letter in the code sample on the "configuration" documentation page.
