### PR TITLE
Fixed test running issue related to grunt jasmine dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.0",
-    "grunt-contrib-jasmine": "~0.3.1",
+    "grunt-contrib-jasmine": "~0.4.2",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-plato": "~0.1.4",
     "grunt-preprocess": "git://github.com/onehealth/grunt-preprocess.git#grunt-0.4.0",


### PR DESCRIPTION
This dependency update [fixed my ability to run jasmine tests](https://github.com/gruntjs/grunt-contrib-jasmine/issues/45) in PhantomJS from the command line.
