### PR TITLE
Update region manager length when regions are removed

### DIFF
--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -99,6 +99,7 @@ Marionette.RegionManager = (function(Marionette){
     _remove: function(name, region){
       region.close();
       delete this._regions[name];
+      this.length = _.size(this._regions);
       this.triggerMethod("region:remove", name, region);
     }
 


### PR DESCRIPTION
Currently only updates the length attribute when regions are added.
