### PR TITLE
Ignore some files and directories for Bower installs

### DIFF
--- a/component.json
+++ b/component.json
@@ -34,6 +34,18 @@
       "email" : "ruben.vreeken@gmail.com"
     }
   ],
+  "ignore": [
+    "docs",
+    "reports",
+    "spec",
+    ".gitignore",
+    ".travis.yml",
+    "build",
+    "build.cmd",
+    "CONTRIBUTING.md",
+    "changelog.md",
+    "package.json"
+  ],
   "dependencies" : {
     "jquery": "~1.8.0 || ~1.9.0",
     "backbone" : "~1.0.0"


### PR DESCRIPTION
When installing backbone.marionette through Bower, there are a lot of additional files added. This can be ignored.

I used something similar to this: https://github.com/twitter/flight/commit/e5fc35d9d8d6ae0431be4fd6052ce151bb2c0c66
