### PR TITLE
Do not use toJSON for data serialization in views

### DIFF
--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -43,10 +43,14 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     var data = {};
 
     if (this.model){
-      data = this.model.toJSON();
+      data = this.serializeModel(this.model);
     }
 
     return data;
+  },
+
+  serializeModel: function(model){
+    return _.clone(model.attributes);
   },
 
   // Renders the model once, and the collection once. Calling

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -10,22 +10,30 @@ Marionette.ItemView =  Marionette.View.extend({
   },
 
   // Serialize the model or collection for the view. If a model is
-  // found, `.toJSON()` is called. If a collection is found, `.toJSON()`
-  // is also called, but is used to populate an `items` array in the
-  // resulting data. If both are found, defaults to the model.
+  // found, the attributes are returned. If a collection is found, each
+  // model in the collection is serialized and put into an `items` array
+  // in the resulting data. If both are found, defaults to the model.
   // You can override the `serializeData` method in your own view
   // definition, to provide custom serialization for your view's data.
   serializeData: function(){
     var data = {};
 
     if (this.model) {
-      data = this.model.toJSON();
+      data = this.serializeModel(this.model);
     }
     else if (this.collection) {
-      data = { items: this.collection.toJSON() };
+      data = { items: this.serializeCollection(this.collection) };
     }
 
     return data;
+  },
+
+  serializeModel: function(model){
+    return _.clone(model.attributes);
+  },
+
+  serializeCollection: function(collection){
+    return collection.map(function(model){ return this.serializeModel(model); }, this);
   },
 
   // Render the view, defaulting to underscore.js templates.


### PR DESCRIPTION
As per the Backbone documentation (see documentcloud/backbone#2134), do not use model.toJSON or collection.toJSON when rendering views. This allows developers to override toJSON without affecting rendering.

This patch replaces the calls to toJSON with Backbone's original implementation.
