### PR TITLE
Harmful Bug - use correct variable to get the actual view method

### DIFF
--- a/src/marionette.bindEntityEvents.js
+++ b/src/marionette.bindEntityEvents.js
@@ -44,7 +44,7 @@
     var methodNames = methods.split(/\s+/);
 
     _.each(methodNames,function(methodName) {
-      var method = target[method];
+      var method = target[methodName];
       target.stopListening(entity, evt, method, target);
     });
   }


### PR DESCRIPTION
The `.stopListening()`method won't unsubscribe the method from the event because is not finding the correct method method, in fact it is `undefined`. Use the correct variable passed in the iteration to get the correct method.
