### PR TITLE
fixed volo path

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "grunt-contrib-connect": "~0.1.2"
   },
   "volo": {
-    "url": "https://raw.github.com/marionettejs/backbone.marionette/v{version}/lib/amd/backbone.marionette.js",
+    "url": "https://raw.github.com/marionettejs/backbone.marionette/v{version}/lib/core/amd/backbone.marionette.js",
     "dependencies": {
       "backbone": "backbone"
     }


### PR DESCRIPTION
Volo path is out of date since the addition of the 'core' directory between /lib and /lib/amd...
