### PR TITLE
Make CompositeView.appendHtml method signature match docs and CollectionViews implementation

### DIFF
--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -96,7 +96,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // `itemViewContainer` (a jQuery selector). Override this method to
   // provide custom logic of how the child item view instances have their
   // HTML appended to the composite view instance.
-  appendHtml: function(cv, iv){
+  appendHtml: function(cv, iv, index){
     var $container = this.getItemViewContainer(cv);
     $container.append(iv.el);
   },


### PR DESCRIPTION
1. The CompositeView's implementation of appendHtml does not specify that a third property that is the index of the item view being added is available.
2. Adding the index property that is available in CompositeViews appendHtml definition. 
3. This being here could clarify the fact that there is a third parameter available without having to dig into the implementation of a collection view. This change is to match the documentation as someone could be confused due to the discrepency between the docs and the source.

OS: Mac OS X 10.8.3
Backbone: 1.0.0
Marionette: 1.0.2
