### PR TITLE
Add a default render method to `Marionette.View`

### DIFF
--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -27,6 +27,33 @@ describe("base view", function(){
     });
   });
 
+  describe("when rendering a view", function(){
+    var render;
+    var beforeRender;
+    var isClosed;
+    beforeEach(function(){
+      render = jasmine.createSpy("render");
+      beforeRender = jasmine.createSpy("before:render");
+      var view = new Marionette.View();
+      view.listenTo(view, "render", render);
+      view.listenTo(view, "before:render", beforeRender);
+      view.render();
+      isClosed = view.isClosed;
+    });
+
+    it("should trigger render event", function(){
+      expect(render).toHaveBeenCalled();
+    });
+
+    it("should trigger before:render event", function(){
+      expect(beforeRender).toHaveBeenCalled();
+    });
+
+    it("should have isClosed property set to `false`", function(){
+      expect(isClosed).not.toBe(true);
+    });
+  });
+
   describe("when using listenTo for the 'close' event on itself, and closing the view", function(){
     var close;
 

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -173,5 +173,13 @@ Marionette.View = Backbone.View.extend({
     // reset the ui element to the original bindings configuration
     this.ui = this._uiBindings;
     delete this._uiBindings;
+  },
+
+  render: function(){
+    this.isClosed = false;
+    this.triggerMethod("before:render", this);
+    this.triggerMethod("render", this);
+    return this;
   }
+
 });


### PR DESCRIPTION
For a consistent API throughtout the `Marionette.View` type and its
subtypes, add a `render` method to `Marionette.View` that sets
`this.isClosed` to false and triggers the appropriate render events
("before:render", "render")
