### PR TITLE
Correcting property to be passed for updated Backbone fetch() method.

### DIFF
--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -12,7 +12,7 @@ Backbone are not supported at all.
 
 As of Backbone v1.0, calling `fetch()` on a collection will not trigger the **reset** event
 by default. This will cause Marionette's [CollectionView](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.collectionview.md) and [CompositeView](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.compositeview.md) to not function
-as expected. Be sure to pass the `fetch: true` option when calling `fetch()`.
+as expected. Be sure to pass the `reset: true` option when calling `fetch()`.
 
 ### Wreqr v0.2.0
 


### PR DESCRIPTION
See http://backbonejs.org/#upgrading
If you want to smartly update the contents of a Collection, adding new models, removing missing ones, and merging those already present, you now call set (previously named "update"), a similar operation to calling set on a Model. This is now the default when you call fetch on a collection. To get the old behavior, pass {reset: true}
