### PR TITLE
appRoute method on the AppRouter

### DIFF
--- a/spec/javascripts/appRouter.spec.js
+++ b/spec/javascripts/appRouter.spec.js
@@ -273,4 +273,31 @@ describe("app router", function(){
     });
   });
 
+  describe("when an app route is added manually", function() {
+    var controller, router;
+
+    beforeEach(function() {
+      var Router = Backbone.Marionette.AppRouter.extend({});
+
+      controller = {
+        showPost: jasmine.createSpy("showPost")
+      };
+
+      Backbone.history.start();
+
+      router = new Router({ controller: controller });
+      router.appRoute("posts/:id", "showPost");
+      
+      router.navigate("posts/10", true);
+    });
+
+    afterEach(function() {
+      Backbone.history.stop();
+    });
+
+    it("should fire the route", function() {
+      expect(controller.showPost).toHaveBeenCalled();
+    });
+  });
+
 });

--- a/src/marionette.approuter.js
+++ b/src/marionette.approuter.js
@@ -24,26 +24,31 @@ Marionette.AppRouter = Backbone.Router.extend({
     this.options = options;
 
     if (this.appRoutes){
-      var controller = Marionette.getOption(this, "controller");
-      this.processAppRoutes(controller, this.appRoutes);
+      this.processAppRoutes(this.appRoutes);
     }
+  },
+
+  // Similar to route method on a Backbone Router but
+  // method is called on the controller
+  appRoute: function(route, methodName) {
+    var controller = Marionette.getOption(this, "controller");
+    var method = controller[methodName];
+
+    if (!method) {
+      throw new Error("Method '" + methodName + "' was not found on the controller");
+    }
+
+    this.route(route, methodName, _.bind(method, controller));
   },
 
   // Internal method to process the `appRoutes` for the
   // router, and turn them in to routes that trigger the
   // specified method on the specified `controller`.
-  processAppRoutes: function(controller, appRoutes) {
+  processAppRoutes: function(appRoutes) {
     var routeNames = _.keys(appRoutes).reverse(); // Backbone requires reverted order of routes
 
     _.each(routeNames, function(route) {
-      var methodName = appRoutes[route];
-      var method = controller[methodName];
-
-      if (!method) {
-        throw new Error("Method '" + methodName + "' was not found on the controller");
-      }
-
-      this.route(route, methodName, _.bind(method, controller));
+      this.appRoute(route, appRoutes[route]);
     }, this);
   }
 });


### PR DESCRIPTION
Hey, thanks for your work on this project :-)

I wanted to add regular expression routes to my app and it felt a bit messy having to bind context when the logic was mostly already in the AppRouter object and could be moved around. I felt because there's a route method on Backbone.Router and routes collection a corresponding appRoute method for appRoutes collection made more semantic sense.

I've submitted a pull request with it moved and a spec. Only thing this seems to take away from the previous code is that prior to this controller dependency was injected into the processAppRoutes method whereas with this the controller is determined when appRoute is executed.
