### PR TITLE
Allow AppRouter to be instantiated through the constructor

### DIFF
--- a/src/marionette.approuter.js
+++ b/src/marionette.approuter.js
@@ -21,6 +21,8 @@ Marionette.AppRouter = Backbone.Router.extend({
   constructor: function(options){
     Backbone.Router.prototype.constructor.apply(this, slice(arguments));
 
+	if (options.appRoutes) this.appRoutes = options.appRoutes;
+	
     this.options = options;
 
     if (this.appRoutes){


### PR DESCRIPTION
Allow AppRouter to be instantiated through the constructor instead of only .extend().
Currently, if "new AppRouter({ appRoutes: { ... } })" is used, the appRoutes property is not processed.

This code adds the same behavior that Backbone.Router has.
