### PR TITLE
Marionette.triggerMethod checks for trigger before calling

### DIFF
--- a/spec/javascripts/triggerMethod.spec.js
+++ b/spec/javascripts/triggerMethod.spec.js
@@ -1,10 +1,14 @@
 describe("trigger event and method name", function(){
   "use strict";
 
-  var view, eventHandler, methodHandler;
+  var view, eventHandler, methodHandler, CustomClass, customObject;
 
   beforeEach(function(){
     view = new Marionette.View();
+
+    CustomClass = function() {
+      this.triggerMethod = Marionette.triggerMethod;
+    };
 
     eventHandler = jasmine.createSpy("event handler");
     methodHandler = jasmine.createSpy("method handler");
@@ -31,7 +35,22 @@ describe("trigger event and method name", function(){
 
     it("returns the value returned by the on{Event} method", function(){
       expect(returnVal).toBe("return val");
-    })
+    });
+
+    describe("when trigger does not exist", function() {
+
+      beforeEach(function() {
+        customObject = new CustomClass();
+      });
+
+      it("should do nothing", function() {
+        var triggerNonExistantEvent = function() {
+          customObject.triggerMethod("does:not:exist");
+        };
+
+        expect( triggerNonExistantEvent ).not.toThrow();
+      });
+    });
   });
 
   describe("when triggering an event with arguments", function(){

--- a/src/marionette.triggermethod.js
+++ b/src/marionette.triggermethod.js
@@ -1,18 +1,18 @@
-// Trigger an event and a corresponding method name. Examples:
+// Trigger an event and/or a corresponding method name. Examples:
 //
 // `this.triggerMethod("foo")` will trigger the "foo" event and
-// call the "onFoo" method. 
+// call the "onFoo" method.
 //
 // `this.triggerMethod("foo:bar") will trigger the "foo:bar" event and
 // call the "onFooBar" method.
 Marionette.triggerMethod = (function(){
-  
+
   // split the event name on the :
   var splitter = /(^|:)(\w)/gi;
 
   // take the event section ("section1:section2:section3")
   // and turn it in to uppercase name
-  function getEventName(match, prefix, eventName) { 
+  function getEventName(match, prefix, eventName) {
     return eventName.toUpperCase();
   }
 
@@ -22,8 +22,10 @@ Marionette.triggerMethod = (function(){
     var methodName = 'on' + event.replace(splitter, getEventName);
     var method = this[methodName];
 
-    // trigger the event
-    this.trigger.apply(this, arguments);
+    // trigger the event, if a trigger method exists
+    if( this.trigger ) {
+      this.trigger.apply(this, arguments);
+    }
 
     // call the onMethodName if it exists
     if (_.isFunction(method)) {


### PR DESCRIPTION
I ran into this today, I have an object where I want to use `triggerMethod` to invoke methods in extending classes but don't need/want any events to be triggered.
