### PR TITLE
Update marionette.view.md

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -50,7 +50,9 @@ The context (`this`) will automatically be set to the view. You can
 optionally set the context by using `_.bind`.
 
 ```js
-// While the view is active, inject a reconciliation callback into the collection.
+// Force the context of the "reconcileCollection" callback method to be the collection
+// itself, for this event handler only (does not affect any other use of the
+// "reconcileCollection" method)
 this.listenTo(this.collection, "add", _.bind(this.reconcileCollection, this.collection));
 ```
 


### PR DESCRIPTION
Backbone.Events.listenTo no longer accepts a 4th 'context' parameter. Updated documentation to reflect this, including an example of the workaround for those cases where it is desired.
