### PR TITLE
Switch 2 comments to their right methods

### DIFF
--- a/src/marionette.domRefresh.js
+++ b/src/marionette.domRefresh.js
@@ -6,14 +6,14 @@
 // re-rendered.
 
 Marionette.MonitorDOMRefresh = (function(){
-  // track when the view has been rendered
+  // track when the view has been shown in the DOM,
+  // using a Marionette.Region (or by other means of triggering "show")
   function handleShow(view){
     view._isShown = true;
     triggerDOMRefresh(view);
   }
 
-  // track when the view has been shown in the DOM,
-  // using a Marionette.Region (or by other means of triggering "show")
+  // track when the view has been rendered
   function handleRender(view){
     view._isRendered = true;
     triggerDOMRefresh(view);


### PR DESCRIPTION
Reading the annotated source is confusing otherwise. handleShow()
is for when the view is shown and handleRender is for when it's
rendered, not the other way around.
