### PR TITLE
DOCS - Region config 'type' should be 'regionType'

### DIFF
--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -82,7 +82,7 @@ var regions = rm.addRegions({
   foo: "#bar",
   baz: {
     selector: "#quux",
-    type: MyRegionType
+    regionType: MyRegionType
   }
 });
 
@@ -106,7 +106,7 @@ pairs that will be applied to every region added.
 var rm = new Marionette.RegionManager();
 
 var defaults = {
-  type: MyRegionType
+  regionType: MyRegionType
 };
 
 var regions = {


### PR DESCRIPTION
There's an error in the docs where the region type parameter is documented as type when it should be regionType (according to the code).
