### PR TITLE
Manually configure triggers events

### DIFF
--- a/spec/javascripts/view.triggers.spec.js
+++ b/spec/javascripts/view.triggers.spec.js
@@ -137,4 +137,53 @@ describe("view triggers", function(){
     });
   });
 
+  describe("when triggers items are manually configured", function(){
+    var View = Backbone.Marionette.ItemView.extend({
+      triggers: {
+        "click .foo": {
+          event: "do:foo",
+          preventDefault: true,
+          stopPropagation: false
+        },
+        "click .bar": {
+          event: "do:bar",
+          stopPropagation: true
+        }
+      },
+
+      render: function(){
+        this.$el.html("<button class='foo'></button><a href='#' class='bar'>asdf</a>");
+      }
+    });
+
+    var view, fooEvent, barEvent;
+
+    beforeEach(function(){
+      view = new View();
+      view.render();
+
+      fooEvent = $.Event("click");
+      barEvent = $.Event("click");
+
+      spyOn(fooEvent, 'preventDefault');
+      spyOn(fooEvent, 'stopPropagation');
+
+      spyOn(barEvent, 'preventDefault');
+      spyOn(barEvent, 'stopPropagation');
+
+      view.$(".foo").trigger(fooEvent);
+      view.$(".bar").trigger(barEvent);
+    });
+
+    it("should prevent and don't stop the first view event", function(){
+      expect(fooEvent.preventDefault).toHaveBeenCalled();
+      expect(fooEvent.stopPropagation).not.toHaveBeenCalled();
+    });
+
+    it("should not prevent and stop the second view event", function(){
+      expect(barEvent.preventDefault).not.toHaveBeenCalled();
+      expect(barEvent.stopPropagation).toHaveBeenCalled();
+    });
+  });
+
 });

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -62,8 +62,9 @@ Marionette.View = Backbone.View.extend({
 
         // stop the event in it's tracks
         if (e) {
-          if (e.preventDefault && hasOptions ? value.preventDefault : true) { e.preventDefault(); }
-          if (e.stopPropagation && hasOptions ? value.stopPropagation : true) { e.stopPropagation(); }
+          var prevent, stop;
+          if ((prevent = e.preventDefault) && hasOptions ? value.preventDefault : prevent) { prevent(); }
+          if ((stop = e.stopPropagation) && hasOptions ? value.stopPropagation : stop) { stop(); }
         }
 
         // build the args for the event


### PR DESCRIPTION
Example:

``` javascript
triggers : {
  'click [data-first]' : 'event1',
  'click [data-second]': {
    event : 'event2',
    preventDefault : true,
    stopPropagation: false
  }
}
```
