### PR TITLE
Region does not re-delegateEvent on previously closed view

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -33,6 +33,7 @@ describe("region", function(){
 
       view = new MyView();
       spyOn(view, "render").andCallThrough();
+      spyOn(view, "delegateEvents").andCallThrough();
 
       myRegion = new MyRegion();
       spyOn(myRegion, "onShow");
@@ -50,15 +51,19 @@ describe("region", function(){
       expect(view.render).toHaveBeenCalled();
     });
 
+    it("should not call 'delegateEvents' for a view that has not been closed", function(){
+      expect(view.delegateEvents).not.toHaveBeenCalled();
+    });
+
     it("should append the rendered HTML to the manager's 'el'", function(){
       expect(myRegion.$el).toHaveHtml(view.el);
     });
 
-    it("shoudl call 'onShow' for the view, after the rendered HTML has been added to the DOM", function(){
+    it("should call 'onShow' for the view, after the rendered HTML has been added to the DOM", function(){
       expect($(view.el)).toHaveClass("onShowClass");
     })
 
-    it("shoudl call 'onShow' for the region, after the rendered HTML has been added to the DOM", function(){
+    it("should call 'onShow' for the region, after the rendered HTML has been added to the DOM", function(){
       expect(myRegion.onShow).toHaveBeenCalled();
     })
 
@@ -142,6 +147,7 @@ describe("region", function(){
       spyOn(view, "close");
       spyOn(myRegion, "open");
       spyOn(view, "render");
+      spyOn(view, "delegateEvents");
       myRegion.show(view);
     });
 
@@ -156,6 +162,10 @@ describe("region", function(){
     it("should call 'render' on the view", function(){
       expect(view.render).toHaveBeenCalled();
     });
+
+    it("should not call 'delegateEvents' on the view", function(){
+      expect(view.delegateEvents).not.toHaveBeenCalled();
+    });
   });
 
    describe("when a view is already shown, close, and showing the same one", function(){
@@ -166,7 +176,7 @@ describe("region", function(){
     var MyView = Backbone.Marionette.ItemView.extend({
       render: function(){
         $(this.el).html("some content");
-      }, 
+      },
       open : function() {}
     });
 
@@ -182,7 +192,8 @@ describe("region", function(){
 
       spyOn(view, "close");
       spyOn(myRegion, "open");
-      spyOn(view, "render")
+      spyOn(view, "render");
+      spyOn(view, "delegateEvents");
       myRegion.show(view);
     });
 
@@ -196,6 +207,10 @@ describe("region", function(){
 
     it("should call 'render' on the view", function(){
       expect(view.render).toHaveBeenCalled();
+    });
+
+    it("should call 'delegateEvents' on the view", function(){
+      expect(view.delegateEvents).toHaveBeenCalled();
     });
   });
 
@@ -412,7 +427,7 @@ describe("region", function(){
 
       MyApp = new Backbone.Marionette.Application();
       MyApp.addRegions({
-        MyRegion: "#region", 
+        MyRegion: "#region",
         anotherRegion: "#region2"
       });
 

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -1,4 +1,4 @@
-// Region 
+// Region
 // ------
 //
 // Manage the visual regions of your composite application. See
@@ -53,19 +53,19 @@ _.extend(Marionette.Region, {
     }
 
     var selector, RegionType;
-   
+
     // get the selector for the region
-    
+
     if (regionIsString) {
       selector = regionConfig;
-    } 
+    }
 
     if (regionConfig.selector) {
       selector = regionConfig.selector;
     }
 
     // get the type for the region
-    
+
     if (regionIsType){
       RegionType = regionConfig;
     }
@@ -77,7 +77,7 @@ _.extend(Marionette.Region, {
     if (regionConfig.regionType) {
       RegionType = regionConfig.regionType;
     }
-    
+
     // build the region instance
     var region = new RegionType({
       el: selector
@@ -132,7 +132,12 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     if (isDifferentView || isViewClosed) {
       this.open(view);
     }
-    
+
+    if (isViewClosed) {
+      // this is a view that was closed, events need to be re-delegated
+      view.delegateEvents();
+    }
+
     this.currentView = view;
 
     Marionette.triggerMethod.call(this, "show", view);
@@ -172,8 +177,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     delete this.currentView;
   },
 
-  // Attach an existing view to the region. This 
-  // will not call `render` or `onShow` for the new view, 
+  // Attach an existing view to the region. This
+  // will not call `render` or `onShow` for the new view,
   // and will not replace the current HTML for the `el`
   // of the region.
   attachView: function(view){


### PR DESCRIPTION
This is a fix for https://github.com/marionettejs/backbone.marionette/issues/651

Region.show will call delegateEvents on the view if the view is one that was previously closed.

Test included.
