### PR TITLE
Change renderer context to invoking view

### DIFF
--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -84,7 +84,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     data = this.mixinTemplateHelpers(data);
 
     var template = this.getTemplate();
-    return Marionette.Renderer.render(template, data);
+    return Marionette.Renderer.render(template, data, this);
   },
 
   // Appends the `el` of itemView instances to the specified

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -40,7 +40,7 @@ Marionette.ItemView =  Marionette.View.extend({
     data = this.mixinTemplateHelpers(data);
 
     var template = this.getTemplate();
-    var html = Marionette.Renderer.render(template, data);
+    var html = Marionette.Renderer.render(template, data, this);
 
     this.$el.html(html);
     this.bindUIElements();

--- a/src/marionette.renderer.js
+++ b/src/marionette.renderer.js
@@ -9,7 +9,7 @@ Marionette.Renderer = {
   // passed to the `TemplateCache` object to retrieve the
   // template function. Override this method to provide your own
   // custom rendering and template handling for all of Marionette.
-  render: function(template, data){
+  render: function(template, data, context){
 
     if (!template) {
       var error = new Error("Cannot render the template since it's false, null or undefined.");
@@ -24,7 +24,7 @@ Marionette.Renderer = {
       templateFunc = Marionette.TemplateCache.get(template);
     }
 
-    return templateFunc(data);
+    return templateFunc.call(context, data);
   }
 };
 


### PR DESCRIPTION
In some cases I have written custom template selection based on model/view state.  The method that invokes the template (`View.template`) isn't run in context of the view, but the window, so I needed to manually bind it to the views, which isn't desirable for things like mixins.

This would correct that.

An example is:

``` CoffeeScript
  class UserDefinedFieldView extends Marionette.ItemView
    template: (data) ->
      fieldType = @model.get("fieldType")
      JST["templates/#{fieldType}"].call(@, data)
```

Where the template chosen varies based on a field type (for example a date template vs a text template).
