### PR TITLE
Make processRoutes optional to avoid cases of double initialization.

### DIFF
--- a/src/marionette.approuter.js
+++ b/src/marionette.approuter.js
@@ -23,7 +23,7 @@ Marionette.AppRouter = Backbone.Router.extend({
 
     this.options = options;
 
-    if (this.appRoutes){
+    if (this.appRoutes && (typeof options.processRoutes === 'undefined' || options.processRoutes)) {
       var controller = Marionette.getOption(this, "controller");
       this.processAppRoutes(controller, this.appRoutes);
     }


### PR DESCRIPTION
Some organizational structures enforce convention in URLs, and they need to call processRoutes manually after manipulating appRoutes. It'd be nice if this didn't get called twice in those cases.
