### PR TITLE
Moves backbone.babysitter and backbone.wreqr to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -60,6 +60,6 @@
   },
   "devDependencies": {
     "backbone.babysitter": "~0.0.6",
-    "backbone.wreqr": "~0.2.0",
+    "backbone.wreqr": "~0.2.0"
   }
 }


### PR DESCRIPTION
Since `lib/backbone.marionette.js` includes both babysitter and wreqr there's no need to have them in the dependencies.
ATM they get installed as separate components side-by-side with backbone.marionette. If a developer's not attentive she'll include those in their html too.
And if a developer chooses to use the `core` versions instead, she'll know she needs to bower install those, or link the ones in `public`.
