### PR TITLE
Bugfix for issue #655

### DIFF
--- a/spec/javascripts/view.uiBindings.spec.js
+++ b/spec/javascripts/view.uiBindings.spec.js
@@ -127,6 +127,29 @@ describe("view ui elements", function() {
 
   });
 
+  describe("when closing a view that has not been rendered", function(){
+    var View = Marionette.ItemView.extend({
+      template: function(){return "<div id='foo'></div>";},
+
+      ui: {
+        foo: "#foo"
+      }
+    });
+
+    var view1, view2;
+
+    beforeEach(function(){
+      view1 = new View();
+      view1.close();
+      view2 = new View();
+    });
+
+    it("should not affect future ui bindings", function(){
+      expect(view2.ui.foo).toBe("#foo");
+    });
+
+  });
+
   describe("when closing a view", function(){
     var View = Marionette.ItemView.extend({
       template: function(){return "<div id='foo'></div>";},

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -163,7 +163,7 @@ Marionette.View = Backbone.View.extend({
 
   // This method unbinds the elements specified in the "ui" hash
   unbindUIElements: function(){
-    if (!this.ui){ return; }
+    if (!this.ui || !this._uiBindings){ return; }
 
     // delete all of the existing ui bindings
     _.each(this.ui, function($el, name){


### PR DESCRIPTION
Calling close without having calling render causes the ui object to
disappear, if defined.
