### PR TITLE
Documentation fixes to View, typo fix in TemplateCache

### DIFF
--- a/docs/marionette.templatecache.md
+++ b/docs/marionette.templatecache.md
@@ -63,7 +63,7 @@ Backbone.Marionette.TemplateCache.clear("#my-template", "#this-template")
 
 If you want to use an alternate template engine while
 still taking advantage of the template caching functionality, or want to customize
-how templates are stored and retreived, you will need to customize the
+how templates are stored and retrieved, you will need to customize the
 `TemplateCache object`. The default operation of `TemplateCache`, is to
 retrieve templates from the DOM based on the containing element's id
 attribute, and compile the html in that element with the underscore.js

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -27,7 +27,7 @@ behaviors that are shared across all views.
 
 ## Binding To View Events
 
-Marionette.View extends `Marionette.BindTo`. It is recommended that you use
+Marionette.View extends `Backbone.View`. It is recommended that you use
 the `listenTo` method to bind model, collection, or other events from Backbone
 and Marionette objects.
 
@@ -62,12 +62,12 @@ View implements a `close` method, which is called by the region
 managers automatically. As part of the implementation, the following
 are performed:
 
-* unbind all `listenTo` events
+* call an `onBeforeClose` event on the view, if one is provided
+* call an `onClose` event on the view, if one is provided
 * unbind all custom view events
 * unbind all DOM events
 * remove `this.el` from the DOM
-* call an `onBeforeClose` event on the view, if one is provided
-* call an `onClose` event on the view, if one is provided
+* unbind all `listenTo` events
 
 By providing an `onClose` event in your view definition, you can
 run custom code for your view that is fired after your view has been
@@ -223,7 +223,7 @@ Backbone.Marionette.CompositeView.extend({
   },
 
   collectionEvents: {
-    "add": "itemAdded" // equivalent to view.listenTo(view.collection, "add", collection.itemAdded, view)
+    "add": "itemAdded" // equivalent to view.listenTo(view.collection, "add", view.itemAdded, view)
   },
 
   // ... event handler methods


### PR DESCRIPTION
- Fixed typo in TemplateCache
- Fixed docs to match reality of which class Marionette.View extends
- View.close: fixed the order of the list of things it does
- View.collectionEvents -- fixed the "equivalent to" comment (method is on view, not collection)
