### PR TITLE
Support defining itemViewContainer in CompositeView instance creation

### DIFF
--- a/spec/javascripts/compositeView-itemViewContainer.spec.js
+++ b/spec/javascripts/compositeView-itemViewContainer.spec.js
@@ -21,35 +21,58 @@ describe("composite view - itemViewContainer", function(){
       template: "#composite-child-container-template"
     });
 
+    var CompositeViewWithoutItemViewContainer = Backbone.Marionette.CompositeView.extend({
+      itemView: ItemView,
+      template: "#composite-child-container-template"
+    });
+
     var compositeView;
     var order;
     var deferredResolved;
+    var collection;
 
-    beforeEach(function(){
+    beforeEach(function() {
       order = [];
       loadFixtures("compositeChildContainerTemplate.html");
 
       var m1 = new Model({foo: "bar"});
       var m2 = new Model({foo: "baz"});
-      var collection = new Collection([m1, m2]);
+      collection = new Collection([m1, m2]);
+    });
 
-      compositeView = new CompositeView({
+    specCase('in the view definition', function() {
+      return new CompositeView({
         collection: collection
       });
-
-      spyOn(compositeView, "resetItemViewContainer").andCallThrough();
-
-      compositeView.render();
     });
 
-    it("should reset any existing itemViewContainer", function(){
-      expect(compositeView.resetItemViewContainer).toHaveBeenCalled();
+    specCase('in the view creation', function() {
+      return new CompositeViewWithoutItemViewContainer({
+        itemViewContainer: "ul",
+        collection: collection
+      });
     });
 
-    it("should render the items in to the specified container", function(){
-      expect(compositeView.$("ul")).toHaveText(/bar/);
-      expect(compositeView.$("ul")).toHaveText(/baz/);
-    });
+    function specCase(desc, viewCreation) {
+      describe(desc, function() {
+        beforeEach(function(){
+          compositeView = viewCreation();
+
+          spyOn(compositeView, "resetItemViewContainer").andCallThrough();
+
+          compositeView.render();
+        });
+
+        it("should reset any existing itemViewContainer", function(){
+          expect(compositeView.resetItemViewContainer).toHaveBeenCalled();
+        });
+
+        it("should render the items in to the specified container", function(){
+          expect(compositeView.$("ul")).toHaveText(/bar/);
+          expect(compositeView.$("ul")).toHaveText(/baz/);
+        });
+      });
+    }
   });
 
   describe("when rendering a collection in a composite view with a missing `itemViewContainer` specified", function(){

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -5,8 +5,8 @@
 // Extends directly from CollectionView and also renders an
 // an item view as `modelView`, for the top leaf
 Marionette.CompositeView = Marionette.CollectionView.extend({
-  
-  // Setting up the inheritance chain which allows changes to 
+
+  // Setting up the inheritance chain which allows changes to
   // Marionette.CollectionView.prototype.constructor which allows overriding
   constructor: function(){
     Marionette.CollectionView.prototype.constructor.apply(this, slice(arguments));
@@ -37,7 +37,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     return itemView;
   },
 
-  // Serialize the collection for the view. 
+  // Serialize the collection for the view.
   // You can override the `serializeData` method in your own view
   // definition, to provide custom serialization for your view's data.
   serializeData: function(){
@@ -61,7 +61,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     this.triggerBeforeRender();
     var html = this.renderModel();
     this.$el.html(html);
-    // the ui bindings is done here and not at the end of render since they 
+    // the ui bindings is done here and not at the end of render since they
     // will not be available until after the model is rendered, but should be
     // available before the collection is rendered.
     this.bindUIElements();
@@ -110,9 +110,10 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     }
 
     var container;
-    if (containerView.itemViewContainer){
+    var itemViewContainer = Marionette.getOption(containerView, "itemViewContainer");
+    if (itemViewContainer){
 
-      var selector = _.result(containerView, "itemViewContainer");
+      var selector = _.isFunction(itemViewContainer) ? itemViewContainer() : itemViewContainer;
       container = containerView.$(selector);
       if (container.length <= 0) {
         throwError("The specified `itemViewContainer` was not found: " + containerView.itemViewContainer, "ItemViewContainerMissingError");


### PR DESCRIPTION
This allows to set the `itemViewContainer` in the CompositeView creation, not just in the View definition. This goes in sync with how the other parameters behave in these two scenarios.

So, you can either define the itemViewContainer like this:

``` js
MyCompositeView = Backbone.Marionette.CompositeView.extend({
  itemViewContainer: selectorOrFunction,
  ...
});
```

or like this:

``` js
var view = new Backbone.Marionette.CompositeView({ //or a custom view that inherits from CompositeView
  collection: someCollection,
  model: someModel,
  itemViewContainer: selectorOrFunction
});
```
