### PR TITLE
Added loadingView support

### DIFF
--- a/spec/javascripts/collectionView.loadingView.spec.js
+++ b/spec/javascripts/collectionView.loadingView.spec.js
@@ -1,0 +1,141 @@
+describe("collectionview - loadingView", function(){
+  "use strict";
+
+  var ItemView = Backbone.Marionette.ItemView.extend({
+    tagName: "span",
+    render: function(){
+      this.$el.html(this.model.get("foo"));
+    },
+    onRender: function(){}
+  });
+
+  var EmptyView = Backbone.Marionette.ItemView.extend({
+    tagName: "span",
+    className: "isempty",
+    render: function(){}
+  });
+    
+  var LoadingView = Backbone.Marionette.ItemView.extend({
+    tagName: "span",
+    className: "isloading",
+    render: function(){}
+  })
+
+  var EmptyCollectionView = Backbone.Marionette.CollectionView.extend({
+    itemView: ItemView,
+    emptyView: EmptyView,
+    loadingView: LoadingView
+  });
+
+  describe("when rendering a collection view with an empty collection", function(){
+    var collectionView;
+
+    beforeEach(function(){
+      var collection = new Backbone.Collection();
+      collectionView = new EmptyCollectionView({
+        collection: collection
+      });
+
+      collectionView.render();
+    });
+
+    it("should append the html for the loadingView", function(){
+      expect($(collectionView.$el)).toHaveHtml("<span class=\"isloading\"></span>");
+    });
+
+    it("should reference each of the rendered view items", function(){
+      expect(_.size(collectionView.children)).toBe(1);
+    });
+  });
+
+  describe("when rendering a collection view with an empty collection", function(){
+    var collectionView;
+
+    beforeEach(function(){
+      var collection = new Backbone.Collection();
+      collectionView = new EmptyCollectionView({
+        collection: collection
+      });
+
+      collectionView.render();
+      collection.trigger("sync")
+    });
+
+    it("should append the html for the emptyView after a `fetch` has finished with no items", function(){
+      expect($(collectionView.$el)).toHaveHtml("<span class=\"isempty\"></span>");
+    });
+
+    it("should reference each of the rendered view items", function(){
+      expect(_.size(collectionView.children)).toBe(1);
+    });
+  });
+
+  describe("when rendering a collection view with an item", function(){
+    var collectionView;
+
+    beforeEach(function(){
+      var collection = new Backbone.Collection();
+      collectionView = new EmptyCollectionView({
+        collection: collection
+      });
+
+      collectionView.render();
+    
+      collection.add(new Backbone.Model({"foo":"bar"}));
+    });
+
+    it("should append the html for the model after an item has been added", function(){
+      expect($(collectionView.$el)).toHaveHtml("<span>bar</span>");
+    });
+
+    it("should reference each of the rendered view items", function(){
+      expect(_.size(collectionView.children)).toBe(1);
+    });
+  });
+
+  describe("when rendering a collection view with an empty collection, adding, then removing, should show the empty collection again", function(){
+    var collectionView;
+    var collection;
+      
+    var models = [
+      new Backbone.Model({"foo":"bar"}),
+      new Backbone.Model({"foo":"bar2"})
+    ];
+
+    beforeEach(function(){
+      collection = new Backbone.Collection();
+      collectionView = new EmptyCollectionView({
+        collection: collection
+      });
+
+      collectionView.render();
+      
+      collection.add(models[0]);
+      collection.add(models[1]);
+    });
+
+    it("should append the html for the itemViews", function(){
+      expect($(collectionView.$el)).toHaveHtml("<span>bar</span><span>bar2</span>");
+    });
+
+    it("should reference each of the rendered view items", function(){
+      expect(_.size(collectionView.children)).toBe(2);
+    });
+    
+    describe("when models are removed", function() {
+      beforeEach( function() {
+        collection.remove(models[0]);
+        collection.remove(models[1]);
+      });
+      
+      it("should revert to empty when the models are removed", function(){
+        expect($(collectionView.$el)).toHaveHtml("<span class=\"isempty\"></span>");
+      });
+    
+      it("should reference only the emptyView", function(){
+        expect(_.size(collectionView.children)).toBe(1);
+      });
+    });
+  });
+    
+});

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -25,6 +25,8 @@ Marionette.CollectionView = Marionette.View.extend({
       this.listenTo(this.collection, "add", this.addChildView, this);
       this.listenTo(this.collection, "remove", this.removeItemView, this);
       this.listenTo(this.collection, "reset", this.render, this);
+      this.listenToOnce(this.collection, "add", this.firstElement, this);
+      this.listenTo(this.collection, "sync", this.onSync, this);
     }
   },
 
@@ -57,6 +59,20 @@ Marionette.CollectionView = Marionette.View.extend({
     this.triggerMethod("render", this);
     this.triggerMethod("collection:rendered", this);
   },
+    
+  // marks the collection as synchronised
+  onSync: function() {
+    this.collectionFetched = true;
+    this.checkEmpty();
+  },
+
+  // Called once on the addition of the first element to the
+  // collection, closing the loading view and setting the 
+  // collection as fetched
+  firstElement: function() {
+    this.collectionFetched = true;
+    this.closeLoadingView();
+  },
 
   // Render the collection of items. Override this method to
   // provide your own implementation of a render function for
@@ -74,12 +90,13 @@ Marionette.CollectionView = Marionette.View.extend({
   // process
   _renderChildren: function(){
     this.closeEmptyView();
+    this.closeLoadingView();
     this.closeChildren();
 
     if (this.collection && this.collection.length > 0) {
       this.showCollection();
     } else {
-      this.showEmptyView();
+        this.checkEmpty();
     }
   },
 
@@ -102,7 +119,22 @@ Marionette.CollectionView = Marionette.View.extend({
     if (EmptyView && !this._showingEmptyView){
       this._showingEmptyView = true;
       var model = new Backbone.Model();
-      this.addItemView(model, EmptyView, 0);
+      this._emptyView = this.addItemView(model, EmptyView, 0);
+    }
+  },
+
+  // Internal method to show an empty view in place of
+  // a collection of item views, when the collection is
+  // empty
+  showLoadingView: function(){
+    var LoadingView = Marionette.getOption(this, "loadingView");
+
+    if (LoadingView && !this._showingLoadingView){
+      this._showingLoadingView = true;
+      var model = new Backbone.Model();
+      this._loadingView = this.addItemView(model, LoadingView, 0);
+    } else {
+      this.showEmptyView();
     }
   },
 
@@ -111,8 +143,20 @@ Marionette.CollectionView = Marionette.View.extend({
   // rendered empty, and then an item is added to the collection.
   closeEmptyView: function(){
     if (this._showingEmptyView){
-      this.closeChildren();
+      this.removeChildView(this._emptyView);
       delete this._showingEmptyView;
+      delete this._emptyView;
+    }
+  },
+
+  // Internal method to close an existing loadingView instance
+  // if one exists. Called when the collection married to the 
+  // collection view has a new item added to it
+  closeLoadingView: function(){
+    if (this._showingLoadingView){
+      this.removeChildView(this._loadingView);
+      delete this._showingLoadingView;
+      delete this._loadingView;
     }
   },
 
@@ -162,6 +206,8 @@ Marionette.CollectionView = Marionette.View.extend({
 
     // this view was added
     this.triggerMethod("after:item:added", view);
+    
+    return view;
   },
 
   // Set up the child view event forwarding. Uses an "itemview:"
@@ -221,8 +267,14 @@ Marionette.CollectionView = Marionette.View.extend({
   checkEmpty: function() {
     // check if we're empty now, and if we are, show the
     // empty view
+    
     if (!this.collection || this.collection.length === 0){
-      this.showEmptyView();
+      if ( this.collectionFetched && this.collectionFetched === true ) {
+        this.closeLoadingView();
+        this.showEmptyView();
+      } else {
+        this.showLoadingView();
+      }
     }
   },
 
@@ -257,7 +309,5 @@ Marionette.CollectionView = Marionette.View.extend({
     this.children.each(function(child){
       this.removeChildView(child);
     }, this);
-    this.checkEmpty();
   }
 });
-


### PR DESCRIPTION
This PR adds support in `CollectionView` for an optional `loadingView` parameter, in the same vein as `emptyView`, which appears when the `CollectionView` is first loaded, before any data has arrived, and which then removes itself when the first item in the collection is added, or when the collection's `sync` event is fired.
