### PR TITLE
Call CompositeView#itemViewContainer function with current scope

### DIFF
--- a/spec/javascripts/compositeView-itemViewContainer.spec.js
+++ b/spec/javascripts/compositeView-itemViewContainer.spec.js
@@ -166,4 +166,23 @@ describe("composite view - itemViewContainer", function(){
     });
   });
 
+  describe("using a function as the itemViewContainer", function() {
+    
+    var CompositeView = Backbone.Marionette.CompositeView.extend({
+      itemView: ItemView,
+      itemViewContainer: function  () {
+        return "#item-view-container-" + this.model.id;
+      },
+      template: _.template('<div id="item-view-container-<%= id %>"></div>')
+    });
+
+    it("should be called with the context of the view", function() {
+      var model = new Model({id: 1});
+      var collection = new Collection([new Model({foo: 1})]);      
+
+      new CompositeView({model: model, collection: collection}).render();
+    });
+
+  });
+
 });

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -113,7 +113,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     var itemViewContainer = Marionette.getOption(containerView, "itemViewContainer");
     if (itemViewContainer){
 
-      var selector = _.isFunction(itemViewContainer) ? itemViewContainer() : itemViewContainer;
+      var selector = _.isFunction(itemViewContainer) ? itemViewContainer.call(this) : itemViewContainer;
       container = containerView.$(selector);
       if (container.length <= 0) {
         throwError("The specified `itemViewContainer` was not found: " + containerView.itemViewContainer, "ItemViewContainerMissingError");


### PR DESCRIPTION
When using a function for CompositeView#itemViewContainer, call that function with the current scope. Allows using model attributes to determine the itemViewContainer.
