### PR TITLE
Add `swap` support to regions.

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -9,6 +9,160 @@ describe("region", function(){
     });
   });
 
+
+  describe("when swapping a view", function(){
+    var MyRegion = Backbone.Marionette.Region.extend({
+      el: "#region",
+
+      onSwap: function(){}
+    });
+
+    var MyView = Backbone.View.extend({
+      render: function(){
+        $(this.el).html("some content");
+      },
+
+      onShow: function(){
+        $(this.el).addClass("onShowClass");
+      }
+    });
+
+    var myRegion, view, swapEvent, swapContext, swapViewPassed;
+
+    beforeEach(function(){
+      setFixtures("<div id='region'></div>");
+
+      view = new MyView();
+      spyOn(view, "render").andCallThrough();
+
+      myRegion = new MyRegion();
+      spyOn(myRegion, "onSwap");
+
+      myRegion.on("swap", function(v){
+        swapViewPassed = v === view;
+        swapEvent = true;
+        swapContext = this;
+      });
+
+      myRegion.swap(view);
+    });
+
+    it("should render the view", function(){
+      expect(view.render).toHaveBeenCalled();
+    });
+
+    it("should append the rendered HTML to the manager's 'el'", function(){
+      expect(myRegion.$el).toHaveHtml(view.el);
+    });
+
+    it("should call 'onShow' for the view, after the rendered HTML has been added to the DOM", function(){
+      expect($(view.el)).toHaveClass("onShowClass");
+    })
+
+    it("should call 'onSwap' for the region, after the rendered HTML has been added to the DOM", function(){
+      expect(myRegion.onSwap).toHaveBeenCalled();
+    })
+
+    it("should trigger a swap event for the view", function(){
+      expect(swapEvent).toBeTruthy();
+    });
+
+    it("should pass the swapped-in view as an argument for the swap event", function(){
+      expect(swapViewPassed).toBeTruthy();
+    });
+
+    it("should set 'this' to the manager, from the swap event", function(){
+      expect(swapContext).toBe(myRegion);
+    });
+  });
+
+  describe("when a view is already swapped-in and swapping another", function(){
+    var MyRegion = Backbone.Marionette.Region.extend({
+      el: "#region"
+    });
+
+    var MyView = Backbone.View.extend({
+      render: function(){
+        $(this.el).html("some content");
+      },
+
+      close: function(){
+      }
+    });
+
+    var myRegion, view1, view2, swapped1, swapped2;
+
+    beforeEach(function(){
+      setFixtures("<div id='region'></div>");
+
+      view1 = new MyView();
+      view2 = new MyView();
+      myRegion = new MyRegion();
+
+      spyOn(view1, "close");
+
+      swapped1 = myRegion.swap(view1);
+      swapped2 = myRegion.swap(view2);
+    });
+
+    it("should never call 'close' on the already open view", function(){
+      expect(view1.close).not.toHaveBeenCalled();
+    });
+
+    it("should return undefined view as a result of the swap operation if no view has been registered", function(){
+      expect(swapped1).toBeUndefined();
+    });
+
+    it("should return the old view as a result of the swap operation", function(){
+      expect(swapped2).toEqual(view1);
+    });
+
+    it("should reference the new view as the current view", function(){
+      expect(myRegion.currentView).toBe(view2);
+    });
+  });
+
+  describe("when a view is already swapped-in and swapping the same one", function(){
+    var MyRegion = Backbone.Marionette.Region.extend({
+      el: "#region"
+    });
+
+    var MyView = Backbone.View.extend({
+      render: function(){
+        $(this.el).html("some content");
+      },
+
+      close: function(){
+      },
+
+      open: function(){
+      }
+    });
+
+    var myRegion, view, swapped;
+
+    beforeEach(function(){
+      setFixtures("<div id='region'></div>");
+
+      view = new MyView();
+      myRegion = new MyRegion();
+      myRegion.swap(view);
+
+      spyOn(view, "close");
+      spyOn(myRegion, "open");
+      spyOn(view, "render");
+      swapped = myRegion.swap(view);
+    });
+
+    it("should not call 'render' on the view", function(){
+      expect(view.render).not.toHaveBeenCalled();
+    });
+
+    it("should return the same view that was passed in as a result of the operation", function(){
+      expect(swapped).toEqual(view);
+    });
+  });
+
   describe("when showing a view", function(){
     var MyRegion = Backbone.Marionette.Region.extend({
       el: "#region",

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -110,6 +110,32 @@ _.extend(Marionette.Region, {
 
 _.extend(Marionette.Region.prototype, Backbone.Events, {
 
+  // Similar to 'show' but enables switching between multiple views
+  // without closing them.
+  // Handles calling the `render` method for you. Reads content
+  // directly from the `el` attribute. Also calls an optional
+  // `onShow` and `close` method on your view, just after showing
+  // or just before closing the view, respectively.
+  // Returns the old view (if defined).
+  swap: function(view) {
+    this.ensureEl();
+
+    if (view === this.currentView) {
+      return view;
+    }
+
+    var oldView = this.currentView;
+
+    view.render();
+    this.open(view);
+    this.currentView = view;
+
+    Marionette.triggerMethod.call(this, "swap", view);
+    Marionette.triggerMethod.call(view, "show");
+
+    return oldView;
+  },
+
   // Displays a backbone view instance inside of the region.
   // Handles calling the `render` method for you. Reads content
   // directly from the `el` attribute. Also calls an optional


### PR DESCRIPTION
As an alternative to https://github.com/marionettejs/backbone.marionette/pull/719 and other similar changes that attempt to re-open a closed view.
