### PR TITLE
region.show() should respect view.onBeforeClose() return value

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -286,6 +286,48 @@ describe("region", function(){
     });
   });
 
+  describe("when a view is already show, show another view, and the current view prevents the close", function() {
+    var MyRegion = Backbone.Marionette.Region.extend({
+      el: "<div></div>"
+    });
+
+    var MyView = Backbone.Marionette.View.extend({
+      onBeforeClose: function() {
+        return false;
+      }
+    });
+
+    var region, view1, view2;
+
+    beforeEach(function() {
+      region = new MyRegion();
+      view1 = new MyView();
+      view2 = new MyView();
+
+      spyOn(view1, "onBeforeClose").andCallThrough();
+      spyOn(view2, "render").andCallThrough();
+
+      region.show(view1);
+      region.show(view2);
+    });
+
+    it("should not close the current view", function() {
+      expect(view1.isClosed).toBe(false);
+    });
+
+    it("should call not call 'render' on the second view", function() {
+      expect(view2.render).not.toHaveBeenCalled();
+    });
+
+    it("should call 'onBeforeClose' on the current view", function() {
+      expect(view1.onBeforeClose).toHaveBeenCalled();
+    });
+
+    it("should reference the first view as the current view", function(){
+      expect(region.currentView).toBe(view1);
+    });
+  });
+
   describe("when closing the current view and it does not have a 'close' method", function(){
     var MyRegion = Backbone.Marionette.Region.extend({
       el: "<div></div>"

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -125,6 +125,14 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     if (isDifferentView) {
       this.close();
+
+      if (
+        this.currentView &&
+        !_.isUndefined(this.currentView.isClosed) &&
+        !this.currentView.isClosed
+      ) {
+        return;
+      }
     }
 
     view.render();
@@ -164,8 +172,17 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     if (!view || view.isClosed){ return; }
 
     // call 'close' or 'remove', depending on which is found
-    if (view.close) { view.close(); }
-    else if (view.remove) { view.remove(); }
+    if (view.close) {
+      view.close();
+
+      // if close is prevented
+      if (
+        !_.isUndefined(view.isClosed) &&
+        !view.isClosed
+      ) {
+        return;
+      }
+    } else if (view.remove) { view.remove(); }
 
     Marionette.triggerMethod.call(this, "close");
 

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -121,6 +121,7 @@ Marionette.View = Backbone.View.extend({
     // from the `onBeforeClose` method
     var shouldClose = this.triggerMethod("before:close");
     if (shouldClose === false){
+      this.isClosed = false;
       return;
     }
 


### PR DESCRIPTION
`Marionette.Region.show()` should respect the return value of `Marionette.View.onBeforeClose()`.  In particular, it should not close the region's current view, if that view's `onBeforeClose()` returns false, as [per spec](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.view.md#view-onbeforeclose).

related issue: https://github.com/marionettejs/backbone.marionette/issues/703
