### PR TITLE
Added underscore as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "github": "https://github.com/marionettejs/backbone.marionette",
   "dependencies": {
+    "underscore": ">=1.4.4",
     "backbone.babysitter": "~0.0.6",
     "backbone.wreqr": "~0.2.0",
     "backbone": "~1.0.0"


### PR DESCRIPTION
This fixes the issue raised in #535 and allows Marionette to be used as a CommonJS module without any errors occuring e.g.

``` js
var Marionette = require('backbone.marionette');
```
