### PR TITLE
Use DocumentFragment when appending multiple nodes

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -245,7 +245,7 @@ describe("collection view", function(){
 
       render: function(){
         var ItemView = this.getItemView();
-        this.addItemView(model, ItemView, 0);
+        this.addItemView(this.getItemViewContainer(), model, ItemView, 0);
       }
     });
 
@@ -432,8 +432,8 @@ describe("collection view", function(){
     var PrependHtmlView = Backbone.Marionette.CollectionView.extend({
       itemView: ItemView,
 
-      appendHtml: function(collectionView, itemView){
-        collectionView.$el.prepend(itemView.el);
+      appendHtml: function($container, itemView){
+        $container.prepend(itemView.el);
       }
     });
 

--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -517,10 +517,7 @@ describe("composite view", function(){
       tagName: "table",
       template: "#grid-template",
       itemView: GridRow,
-
-      appendHtml: function(cv, iv){
-        cv.$("tbody").append(iv.el);
-      }
+      itemViewContainer: "tbody"
     });
 
     beforeEach(function(){
@@ -578,10 +575,7 @@ describe("composite view", function(){
       tagName: "table",
       template: "#grid-template",
       itemView: GridRow,
-
-      appendHtml: function(cv, iv){
-        cv.$("tbody").append(iv.el);
-      }
+      itemViewContainer: "tbody"
     });
 
     var GridViewWithUIBindings = GridView.extend({

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -33,7 +33,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this.closeEmptyView();
     var ItemView = this.getItemView(item);
     var index = this.collection.indexOf(item);
-    this.addItemView(item, ItemView, index);
+    this.addItemView(this.getItemViewContainer(), item, ItemView, index);
   },
 
   // Override from `Marionette.View` to guarantee the `onShow` method
@@ -83,14 +83,20 @@ Marionette.CollectionView = Marionette.View.extend({
     }
   },
 
+  getItemViewContainer: function() {
+    return this.$el;
+  },
+
   // Internal method to loop through each item in the
   // collection view and show it
   showCollection: function(){
     var ItemView;
+    var $fragment = $(document.createDocumentFragment());
     this.collection.each(function(item, index){
       ItemView = this.getItemView(item);
-      this.addItemView(item, ItemView, index);
+      this.addItemView($fragment, item, ItemView, index);
     }, this);
+    this.getItemViewContainer().append($fragment);
   },
 
   // Internal method to show an empty view in place of
@@ -102,7 +108,7 @@ Marionette.CollectionView = Marionette.View.extend({
     if (EmptyView && !this._showingEmptyView){
       this._showingEmptyView = true;
       var model = new Backbone.Model();
-      this.addItemView(model, EmptyView, 0);
+      this.addItemView(this.getItemViewContainer(), model, EmptyView, 0);
     }
   },
 
@@ -131,7 +137,7 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Render the child item's view and add it to the
   // HTML for the collection view.
-  addItemView: function(item, ItemView, index){
+  addItemView: function($container, item, ItemView, index){
     // get the itemViewOptions if any were specified
     var itemViewOptions = Marionette.getOption(this, "itemViewOptions");
     if (_.isFunction(itemViewOptions)){
@@ -152,7 +158,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this.children.add(view);
 
     // Render it and show it
-    this.renderItemView(view, index);
+    this.renderItemView($container, view, index);
 
     // call the "show" method if the collection view
     // has already been shown
@@ -181,9 +187,9 @@ Marionette.CollectionView = Marionette.View.extend({
   },
 
   // render the item view
-  renderItemView: function(view, index) {
+  renderItemView: function($container, view, index) {
     view.render();
-    this.appendHtml(this, view, index);
+    this.appendHtml($container, view, index);
   },
 
   // Build an `itemView` for every model in the collection.
@@ -229,8 +235,8 @@ Marionette.CollectionView = Marionette.View.extend({
   // Append the HTML to the collection's `el`.
   // Override this method to do something other
   // then `.append`.
-  appendHtml: function(collectionView, itemView, index){
-    collectionView.$el.append(itemView.el);
+  appendHtml: function($container, itemView, index){
+    $container.append(itemView.el);
   },
 
   // Internal method to set up the `children` object for

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -97,33 +97,32 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // `itemViewContainer` (a jQuery selector). Override this method to
   // provide custom logic of how the child item view instances have their
   // HTML appended to the composite view instance.
-  appendHtml: function(cv, iv, index){
-    var $container = this.getItemViewContainer(cv);
+  appendHtml: function($container, iv, index){
     $container.append(iv.el);
   },
 
   // Internal method to ensure an `$itemViewContainer` exists, for the
   // `appendHtml` method to use.
-  getItemViewContainer: function(containerView){
-    if ("$itemViewContainer" in containerView){
-      return containerView.$itemViewContainer;
+  getItemViewContainer: function(){
+    if ("$itemViewContainer" in this){
+      return this.$itemViewContainer;
     }
 
     var container;
-    var itemViewContainer = Marionette.getOption(containerView, "itemViewContainer");
+    var itemViewContainer = Marionette.getOption(this, "itemViewContainer");
     if (itemViewContainer){
 
       var selector = _.isFunction(itemViewContainer) ? itemViewContainer() : itemViewContainer;
-      container = containerView.$(selector);
+      container = this.$(selector);
       if (container.length <= 0) {
-        throwError("The specified `itemViewContainer` was not found: " + containerView.itemViewContainer, "ItemViewContainerMissingError");
+        throwError("The specified `itemViewContainer` was not found: " + this.itemViewContainer, "ItemViewContainerMissingError");
       }
 
     } else {
-      container = containerView.$el;
+      container = this.$el;
     }
 
-    containerView.$itemViewContainer = container;
+    this.$itemViewContainer = container;
     return container;
   },
 


### PR DESCRIPTION
Similar to issue #573 but keeps tighter to the current interface for inheritors, this is breaking though, in that it swaps the view parameter for the target DOM node container.  

Appending with DocumentFragment can speed up high model count collections with complicated item templates.

You can see some of the performance implications here: http://jsperf.com/marionette-documentfragment-collectionview
