### PR TITLE
Add defaults support in Application.addRegions()

### DIFF
--- a/spec/javascripts/application.appRegions.spec.js
+++ b/spec/javascripts/application.appRegions.spec.js
@@ -78,6 +78,27 @@ describe("application regions", function(){
       expect(MyApp.MyRegion.el).toBe("#region");
     });
   });
+  
+  describe("when adding custom region types using a defaults set", function(){
+    var MyApp = new Backbone.Marionette.Application();
+    var MyRegion = Backbone.Marionette.Region.extend({});
+
+    beforeEach(function(){
+      var defaults = {
+        regionType: MyRegion
+      };
+
+      MyApp.addRegions({
+        foo: '#bar',
+        baz: '#quux'
+      }, defaults);
+    });
+
+    it("should add all regions with the specified type", function(){
+      expect(MyApp.foo).toBeInstanceOf(MyRegion);
+      expect(MyApp.baz).toBeInstanceOf(MyRegion);
+    });
+  });
 
   describe("when an app has a region", function(){
     var app, reg1;

--- a/src/marionette.application.js
+++ b/src/marionette.application.js
@@ -52,8 +52,8 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
   // Accepts a hash of named strings or Region objects
   // addRegions({something: "#someRegion"})
   // addRegions({something: Region.extend({el: "#someRegion"}) });
-  addRegions: function(regions){
-    return this._regionManager.addRegions(regions);
+  addRegions: function(regions, defaults){
+    return this._regionManager.addRegions(regions, defaults);
   },
 
   // Close all regions in the app, without removing them


### PR DESCRIPTION
Hi,

Small change - I noticed that the `defaults` parameter accepted by `RegionManager.addRegions(regions, defaults)` wasn't accepted by `Application.addRegions(regions)`.  I'm guessing this is because defaults were added to regions fairly recently and the application proxy method was forgotten about at the time of the change.

Without this fix, when setting up an app's regions, either the region definitions have to be written out in full, or you have to hackishly bypass the incomplete method:

``` js
var MyApp = new Backbone.Marionette.Application();
MyApp._regionManager.addRegions({ ... });
```
