### PR TITLE
#657 Added info: define an item view before referencing in a collection view

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -57,6 +57,10 @@ Backbone.Marionette.CollectionView.extend({
 });
 ```
 
+Item views must be defined before they are referenced by the 
+`itemView` attribute in a collection view definition. Use `getItemView` 
+to lookup the definition as child views are instantiated.
+
 Alternatively, you can specify an `itemView` in the options for
 the constructor:
 


### PR DESCRIPTION
#657 Added info: define an item view before referencing in a collection view definition.
