### PR TITLE
Do not use toJSON for data serialization in views

### DIFF
--- a/docs/marionette.itemview.md
+++ b/docs/marionette.itemview.md
@@ -180,11 +180,11 @@ Backbone.Marionette.ItemView.extend({
 
 ## ItemView serializeData
 
-Item views will serialize a model or collection, by default, by
-calling `.toJSON` on either the model or collection. If both a model
-and collection are attached to an item view, the model will be used
-as the data source. The results of the data serialization will be passed to the template
-that is rendered. 
+Item views will serialize a model or collection by respectively
+returning the model's attributes or doing so for each model in a collection.
+If both a model and collection are attached to an item view, the model will
+be used as the data source. The results of the data serialization will be passed
+to the template that is rendered.
 
 If the serialization is a model, the results are passed in directly:
 

--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -696,6 +696,27 @@ describe("composite view", function(){
     });
 
   });
+
+  describe("when serializing view data", function(){
+    var modelData = { foo: "bar" };
+    var view;
+
+    beforeEach(function(){
+      view = new Marionette.CompositeView();
+      spyOn(view, "serializeModel").andCallThrough();
+    });
+
+    it("should return an empty object without data", function(){
+      expect(view.serializeData()).toEqual({ });
+    });
+
+    it("should call serializeModel for a model", function(){
+      view.model = new Backbone.Model(modelData);
+      view.serializeData();
+
+      expect(view.serializeModel).toHaveBeenCalled();
+    });
+  });
   
   describe("has a valid inheritance chain back to Marionette.CollectionView", function(){
     

--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -367,6 +367,66 @@ describe("item view", function(){
       expect(renderUpdate).toHaveBeenCalled();
     });
   });
+
+  describe("when serializing view data", function(){
+    var modelData = { foo: "bar" };
+    var collectionData = [ { foo: "bar" }, { foo: "baz" } ];
+    var view;
+
+    beforeEach(function(){
+      view = new ItemView();
+      spyOn(view, "serializeModel").andCallThrough();
+      spyOn(view, "serializeCollection").andCallThrough();
+    });
+
+    it("should return an empty object without data", function(){
+      expect(view.serializeData()).toEqual({ });
+    });
+
+    it("should call serializeModel for a model", function(){
+      view.model = new Backbone.Model(modelData);
+      view.serializeData();
+
+      expect(view.serializeModel).toHaveBeenCalled();
+      expect(view.serializeCollection).not.toHaveBeenCalled();
+    });
+
+    it("should call serializeCollection for a collection", function(){
+      view.collection = new Collection(collectionData);
+      view.serializeData();
+
+      expect(view.serializeCollection).toHaveBeenCalled();
+    });
+
+    it("should call serializeModel when given both a model and a collection", function(){
+      view.model = new Backbone.Model(modelData);
+      view.collection = new Collection(collectionData);
+      view.serializeData();
+
+      expect(view.serializeModel).toHaveBeenCalled();
+      expect(view.serializeCollection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when serializing a collection", function(){
+    var collectionData;
+    var view;
+
+    beforeEach(function(){
+      collectionData = [ { foo: "bar" }, { foo: "baz" } ];
+      view = new ItemView({
+        collection: new Collection(collectionData)
+      });
+    });
+
+    it("should serialize to an items attribute", function(){
+      expect(view.serializeData().items).toBeDefined();
+    });
+
+    it("should serialize all models", function(){
+      expect(view.serializeData().items).toEqual(collectionData);
+    });
+  });
   
   describe("has a valid inheritance chain back to Marionette.View", function(){
     

--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -157,4 +157,19 @@ describe("base view", function(){
     });
   });
 
+  describe("when serializing a model", function(){
+    var modelData = { foo: "bar" };
+    var model;
+    var view;
+
+    beforeEach(function(){
+      model = new Backbone.Model(modelData);
+      view = new Marionette.View();
+    });
+
+    it("should return all attributes", function(){
+      expect(view.serializeModel(model)).toEqual(modelData);
+    });
+  });
+
 });

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -50,10 +50,6 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     return data;
   },
 
-  serializeModel: function(model){
-    return _.clone(model.attributes);
-  },
-
   // Renders the model once, and the collection once. Calling
   // this again will tell the model's view to re-render itself
   // but the collection will not re-render.

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -13,11 +13,12 @@ Marionette.ItemView = Marionette.View.extend({
   },
 
   // Serialize the model or collection for the view. If a model is
-  // found, the attributes are returned. If a collection is found, each
-  // model in the collection is serialized and put into an `items` array
-  // in the resulting data. If both are found, defaults to the model.
-  // You can override the `serializeData` method in your own view
-  // definition, to provide custom serialization for your view's data.
+  // found, the view's `serializeModel` is called. If a collection is found,
+  // each model in the collection is serialized by calling
+  // the view's `serializeCollection` and put into an `items` array in
+  // the resulting data. If both are found, defaults to the model.
+  // You can override the `serializeData` method in your own view definition,
+  // to provide custom serialization for your view's data.
   serializeData: function(){
     var data = {};
 
@@ -31,10 +32,7 @@ Marionette.ItemView = Marionette.View.extend({
     return data;
   },
 
-  serializeModel: function(model){
-    return _.clone(model.attributes);
-  },
-
+  // Serialize a collection by serializing each of its models.
   serializeCollection: function(collection){
     return collection.map(function(model){ return this.serializeModel(model); }, this);
   },

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -26,6 +26,12 @@ Marionette.View = Backbone.View.extend({
     return Marionette.getOption(this, "template");
   },
 
+  // Serialize a model by returning its attributes. Clones
+  // the attributes to allow modification.
+  serializeModel: function(model){
+    return _.clone(model.attributes);
+  },
+
   // Mix in template helper methods. Looks for a
   // `templateHelpers` attribute, which can either be an
   // object literal, or a function that returns an object


### PR DESCRIPTION
This is an updated version of #599 following @samccone's suggestions.

As per the Backbone documentation (see documentcloud/backbone#2134), do not use _model.toJSON_ or _collection.toJSON_ when rendering views. This allows developers to override _toJSON_ without affecting rendering. It was implemented by adding a _serializeModel_ method to View and a _serializeCollection_ method to ItemView mimicking Backbone's implementation of _toJSON_. Appropriate tests where added and the documentation was updated.

This may be a breaking change for those that have overridden _toJSON_ for data serialization.
