### PR TITLE
Provide default options in View if none is given.

### DIFF
--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -9,7 +9,7 @@ Marionette.View = Backbone.View.extend({
 
     var args = Array.prototype.slice.apply(arguments);
     Backbone.View.prototype.constructor.apply(this, args);
-    this.options = options;
+    this.options = options || {};
 
     Marionette.MonitorDOMRefresh(this);
     this.listenTo(this, "show", this.onShowCalled, this);


### PR DESCRIPTION
In f3c632dd, where the action "Re-added this.options to the View base class"
was taken, it isn't exactly what Backbone used to do in 1.0.0.  No
default value is set if no option argument is provided, whereas Backbone
used {} as the default.  Change to be fully compatible.
