### PR TITLE
Add ability to store View metadata

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -223,15 +223,15 @@ as a panel bar could trigger the same event from many different views
 and be handled with a single function.
 
 
-## View.data
+## View.viewData
 
 Plugins and View extensions can use ```data``` to retrieve a domain-scoped
 hash to keep state within a View and avoid polluting the View with root-level attributes.
-The data has will be created if it does not currently exist.
+The data hash will be created if it does not currently exist.
 
 ```js
   // within a View
-  var data = this.data('MyPlugin');
+  var data = this.viewData('MyPlugin');
 ``` 
 
 

--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -182,23 +182,23 @@ describe("when retrieving view metadata", function(){
    });
 
    it("should initialize the data hash", function(){
-     var data = view1.data('foo');
+     var data = view1.viewData('foo');
      expect(!!data).toBe(true);
    });
 
    it("should only create instance-scoped data", function(){
-     var data1 = view1.data('foo');
+     var data1 = view1.viewData('foo');
      data1['test1'] = '1';
-     var data2 = view2.data('foo');
+     var data2 = view2.viewData('foo');
      data2['test2'] = '2';
      expect(data1.test2).toBe(undefined);
      expect(data2.test1).toBe(undefined);
    });
 
    it("should return the same hash with multiple requests", function(){
-     var data1 = view1.data('foo');
+     var data1 = view1.viewData('foo');
      data1['test1'] = '1';
-     data1 = view1.data('foo');
+     data1 = view1.viewData('foo');
      expect(data1.test1).toBe('1');
    });
  });

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -17,7 +17,7 @@ Marionette.View = Backbone.View.extend({
 
   // return a unique data hash for the provided domain
   // this is used to store metadata without polluting the view root attributes
-  data: function(domain){
+  viewData: function(domain){
     var data = this._data || (this._data = {}),
         _data = data[domain];
     if (!_data) {


### PR DESCRIPTION
It would be meaningful to store state within a view and avoid polluting the View root-level attributes with stuff.

I would like to submit more PRs around Views which would benefit from this functionality.
