### PR TITLE
[fix] default view options should be {} and not undefined

### DIFF
--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -130,6 +130,20 @@ describe("base view", function(){
     });
   });
 
+  describe("constructing a view with default options", function(){
+    var view = Marionette.ItemView.extend();
+
+    it("should take and store view options", function() {
+      var viewInstance = new view({"Guybrush": "Island"});
+      expect(viewInstance.options.Guybrush).toBe("Island");
+    });
+
+    it("should have an empty hash of options by default", function() {
+      var viewInstance = new view;
+      expect(typeof(viewInstance.options.Guybrush)).toBe("undefined");
+    });
+  });
+
   describe("when closing a view that is already closed", function(){
     var close, view;
 

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -9,7 +9,7 @@ Marionette.View = Backbone.View.extend({
 
     var args = Array.prototype.slice.apply(arguments);
     Backbone.View.prototype.constructor.apply(this, args);
-    this.options = options;
+    this.options = options || {};
 
     Marionette.MonitorDOMRefresh(this);
     this.listenTo(this, "show", this.onShowCalled, this);


### PR DESCRIPTION
Reported here https://github.com/marionettejs/backbone.marionette/pull/752
Introduced here https://github.com/marionettejs/backbone.marionette/commit/f3c632dd
