### PR TITLE
[fix] Move the instantiation of view options above the constructor

### DIFF
--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -144,6 +144,19 @@ describe("base view", function(){
     });
   });
 
+  describe("should expose its options in the constructor", function() {
+    var View = Marionette.View.extend({
+       initialize: function() {
+        this.info = this.options;
+      }
+    });
+
+    it("should be able to access instance options", function() {
+      var myView = new View({name: "LeChuck"});
+      expect(myView.info.name).toBe("LeChuck");
+    });
+  });
+
   describe("when closing a view that is already closed", function(){
     var close, view;
 

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -8,8 +8,13 @@ Marionette.View = Backbone.View.extend({
     _.bindAll(this, "render");
 
     var args = Array.prototype.slice.apply(arguments);
-    Backbone.View.prototype.constructor.apply(this, args);
+
+    // this exposes view options to the view initializer
+    // this is a backfill since backbone removed the assignment
+    // of this.options
+    // at some point however this may be removed
     this.options = options || {};
+    Backbone.View.prototype.constructor.apply(this, args);
 
     Marionette.MonitorDOMRefresh(this);
     this.listenTo(this, "show", this.onShowCalled, this);


### PR DESCRIPTION
This allows for view options to be accessed from within the initialize method for a given view
This is needed since backbone views no longer set the view options in the constructor

Reported here 
https://github.com/marionettejs/backbone.marionette/issues/766

The line that is causing problems in backbone
https://github.com/jashkenas/backbone/commit/a22cbc7f36f0f7bd2b1d6f62e353e95deb4eda3a#diff-0d56d0d310de7ff18b3cef9c2f8f75dcL1092
