### PR TITLE
When show is triggered on a Region, ensure that the currentView isClosed property is set back to false so the View close events continue to dispatch on subsequent calls if the View is replaced again later.

### DIFF
--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -134,6 +134,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     }
     
     this.currentView = view;
+    this.currentView.isClosed = false;
 
     Marionette.triggerMethod.call(this, "show", view);
     Marionette.triggerMethod.call(view, "show");


### PR DESCRIPTION
I encountered an issue where if the same View was replaced more than once within a Region the close events were no longer firing on subsequent calls for the View. 

By setting the isClosed property back to false on the View from within the show method for the Region the View now continues to fire its close events when its closed consistently. I am not sure what this property will affect within scope of the Region manager or the View but the issue no longer persists for me.
