### PR TITLE
addChildViewEventForwarding available from ItemView

### DIFF
--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -382,4 +382,48 @@ describe("item view", function(){
     });
   });
 
+  describe("when a view set as a child with addChildViewEventForwarding triggers an event", function() {
+
+    var ContainerView = Marionette.ItemView.extend({
+      template: function(){return "<div>foo</div>"; },
+      onRender: function() {
+        this.addChildViewEventForwarding(childView, "itemview");
+      }
+    });
+    var containerView;
+    var childView;
+    var childModel = new Backbone.Model({foo: "bar"});
+    var triggeringView;
+    var eventArgs;
+
+    beforeEach(function(){
+      childView = new ItemView({
+        template: function(){return "<div>foo</div>"; },
+        model: childModel
+      });
+      containerView = new ContainerView();
+      containerView.render();
+      containerView.on("itemview:some:event", function(){
+        eventArgs = Array.prototype.slice.call(arguments);
+      });
+
+      spyOn(containerView, "trigger").andCallThrough();
+      childView.trigger("some:event", "test", childModel);
+    });
+
+    it("should bubble up through the container view", function(){
+      expect(containerView.trigger).toHaveBeenCalledWith("itemview:some:event", childView, "test", childModel);
+    });
+
+    it("should provide the child view that triggered the event as the first parameter", function(){
+      expect(eventArgs[0]).toBe(childView);
+    });
+
+    it("should forward all other arguments in order", function(){
+      expect(eventArgs[1]).toBe("test");
+      expect(eventArgs[2]).toBe(childModel);
+    });
+
+  });
+
 });

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -147,7 +147,8 @@ Marionette.CollectionView = Marionette.View.extend({
     var view = this.buildItemView(item, ItemView, itemViewOptions);
 
     // set up the child view event forwarding
-    this.addChildViewEventForwarding(view);
+    var prefix = Marionette.getOption(this, "itemViewEventPrefix");
+    this.addChildViewEventForwarding(view, prefix);
 
     // this view is about to be added
     this.triggerMethod("before:item:added", view);
@@ -167,22 +168,6 @@ Marionette.CollectionView = Marionette.View.extend({
 
     // this view was added
     this.triggerMethod("after:item:added", view);
-  },
-
-  // Set up the child view event forwarding. Uses an "itemview:"
-  // prefix in front of all forwarded events.
-  addChildViewEventForwarding: function(view){
-    var prefix = Marionette.getOption(this, "itemViewEventPrefix");
-
-    // Forward all child item view events through the parent,
-    // prepending "itemview:" to the event name
-    this.listenTo(view, "all", function(){
-      var args = slice(arguments);
-      args[0] = prefix + ":" + args[0];
-      args.splice(1, 0, view);
-
-      Marionette.triggerMethod.apply(this, args);
-    }, this);
   },
 
   // render the item view

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -94,6 +94,20 @@ Marionette.View = Backbone.View.extend({
     return triggerEvents;
   },
 
+  // Provide a useful way to set up event forwarding for child views.
+  addChildViewEventForwarding: function(view, prefix){
+    
+    // Forward child item view events through the parent,
+    // prepending `prefix:` to the event name
+    this.listenTo(view, "all", function(){
+      var args = slice(arguments);
+      args[0] = prefix + ":" + args[0];
+      args.splice(1, 0, view);
+
+      Marionette.triggerMethod.apply(this, args);
+    }, this);
+  },
+
   // Overriding Backbone.View's delegateEvents to handle
   // the `triggers`, `modelEvents`, and `collectionEvents` configuration
   delegateEvents: function(events){


### PR DESCRIPTION
When developing with Marionette, child item views forward their
events to their parent composite/collection view.

Sometimes there is the need to manually create a subview in an ItemView
or Layout and in this situation it would be great to be able to use
event forwarding in the same way.

This pull request allows addChildViewEventForwarding to be used by
custom code in ItemViews or Layouts to setup the same functionality
provided by default in collection/composite views.

For example:

```
var ItemViewWithForwarding = Marionette.ItemView.extend({
    ...
    renderChildView: function(category) {
        var view = new FormCategoryListItemView({
            model: new Backbone.Model({category: category})
        });

        //Provide view reference and event prefix
        this.addChildViewEventForwarding(view, "childview");
        this.$('.event-actions').append(view.render().el);
    }
});
```

Would love to hear feedback on this.
