### PR TITLE
Added asynchronous module initializers.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,7 +136,8 @@ module.exports = function(grunt) {
           'src/marionette.module.js',
           'src/marionette.templatecache.js',
           'src/marionette.renderer.js',
-          'src/marionette.callbacks.js'
+          'src/marionette.callbacks.js',
+          'src/marionette.promises.js'
         ],
       }
     },

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -9,7 +9,25 @@ Marionette.Module = function(moduleName, app){
   // store sub-modules
   this.submodules = {};
 
+  //setup a deferred object for asynchronous initializers
+  this._deferReady = new $.Deferred();
+  //provide a promise other objects can use to wait for asynchronous initialization
+  //this executes handlers which are attached after initialization,
+  //and combined with $.when() allows for dependency on multiple asynchronously intialized
+  //modules before handler execution
+  //eg. $.when(module_1.ready, module_2.ready).then(function(){ /* do something */ })
+  this.ready = this._deferReady.promise();
+  //ensure that ready is triggered when module asynchronous intializers are all resolved
+  this.ready
+    .fail(function(){
+      throwError('Object initialization error. The ready promise was rejected.', 'ready-reject');
+    })
+    .done(_(function(){
+        this.triggerMethod('ready');
+    }).bind(this));
+
   this._setupInitializersAndFinalizers();
+
 
   // store the configuration for this module
   this.app = app;
@@ -26,6 +44,12 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
   // module's `start` method is called.
   addInitializer: function(callback){
     this._initializerCallbacks.add(callback);
+  },
+  // Asynchronous initializers nitializers are run when the module 
+  // `start` method is called. A ready event is triggered on the 
+  // module when all async promises have resolved.
+  addAsyncInitializer: function(callback){
+    this._initializerPromises.add(callback);
   },
 
   // Finalizers are run when a module is stopped. They are used to teardown
@@ -52,6 +76,14 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
     this.triggerMethod("before:start", options);
 
     this._initializerCallbacks.run(options, this);
+    this._initializerPromises.run(options, this)
+      .fail(_(function(err){
+        this._deferReady.reject(err);
+      }).bind(this))
+      .always(_(function(){
+        this._deferReady.resolve();
+      }).bind(this));
+
     this._isInitialized = true;
 
     this.triggerMethod("start", options);
@@ -110,7 +142,10 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
   _setupInitializersAndFinalizers: function(){
     this._initializerCallbacks = new Marionette.Callbacks();
     this._finalizerCallbacks = new Marionette.Callbacks();
+    this._initializerPromises = new Marionette.Promises();
   }
+
+  
 });
 
 // Type methods to create modules

--- a/src/marionette.promises.js
+++ b/src/marionette.promises.js
@@ -1,0 +1,71 @@
+// Promises
+// ---------
+
+// Modelled closely on Marionette.Callbacks to provide a
+// stack of promises which all must be resolved/rejected before
+// before the whole is resolved/rejected
+Marionette.Promises = function(){
+  this._deferred = new $.Deferred();
+  this._callbacks = [];
+  this._promises = [];
+};
+
+_.extend(Marionette.Promises.prototype, {
+
+  // Add a callback to be executed. Callbacks added here are
+  // guaranteed to execute, even if they are added after the 
+  // `run` method is called.
+  // The callback must return a promise object!
+  add: function(callback, contextOverride){
+    this._callbacks.push({cb: callback, ctx: contextOverride});
+    //when this._deferred is resolved, call all callbacks and add their return
+    //value to the stack of promises
+    //any functions which do not return a promise will simply be evaluated as 
+    //immediately resolved
+    this._deferred
+      .done(_(function(context, options){
+        if (contextOverride){ context = contextOverride; }
+        //call the callback and add it's return value (should be a promise)
+        //to the promises stack
+        //for convenience, the callback is provided with a deferred object
+        //it can use to resolve/reject a non-promise asychronous dependency
+        this._promises.push( callback.call(context, options, new $.Deferred()) );
+      }).bind(this));
+  },
+
+  // Run all registered callbacks with the context specified. 
+  // Additional callbacks can be added after this has been run 
+  // and they will still be executed.
+  // This method returns a single promise which will be resolved
+  // or rejected when the result of all callbacks 
+  run: function(options, context){
+    var deferred = new $.Deferred();
+    this._deferred.resolve(context, options);
+
+    //when all promises returned by the callbacks are resolved/rejected,
+    //resolve/reject the promise returned by this method
+    $.when.apply(this, this._promises)
+      .done(function(){
+        deferred.resolve();
+      })
+      .fail(function(){
+        deferred.reject();
+      });
+
+    return deferred.promise();
+  },
+
+  // Resets the list of callbacks to be run, allowing the same list
+  // to be run multiple times - whenever the `run` method is called.
+  reset: function(){
+    var that = this;
+    var callbacks = this._callbacks;
+    this._deferred = $.Deferred();
+    this._callbacks = [];
+    this._promises = [];
+    _.each(callbacks, function(cb){
+      that.add(cb.cb, cb.ctx);
+    });
+  }
+});
+


### PR DESCRIPTION
This pull request adds asynchronous module initializers using jQuery Deferred objects.

It adds three new properties to Marionette.Module:
##### `_deferReady`

This is a jQuery Deferred object intended for internal use by Marionette.Module.
##### `ready`

This is a jQuery Promise object which will be resolved or rejected based on the result of any defined asynchronous initializers. It is intended for use as a "public" property.
##### `_initializerPromises`

This is a Marionette.Promises instance (see below)

---

It adds one event and corresponding triggerMethod:
- `ready`

The ready event will be triggered when the ready promise has been resolved.

It adds one new method:
- addAsyncInitializer

This adds an asynchronous initializer. The callback function should return a promise which will be resolved or rejected when complete. If it returns any other value it will be marked as resolved, but in that case a standard initializer should be used anyway.

---

It adds one new Marionette object
- Marionette.Promises

This is modelled very closely on Marionette.Callbacks, and indeed there may be some way to combine their functionality, but I didn't want to mess with such a core dependency. Essentially it's the same, but the run method adds the return value of the callback to an array, and returns a new promise. When all items in the array are resolved, the promise will be marked as resolved.

This pull request allows application code (other modules, routers, etc) to wait until all asynchronous module dependencies have resolved before continuing. Eg.
`MyModule.ready.done(function(){ /*do something*/ });`
or
`MyModule.on('ready', fn)` 
The downside to the event-based approach is that only handlers bound _before_ the event will be notified. By using the `ready` promise object one can use `MyModule.ready.done(fn)` without caring whether the module has just started, or was started and resolved long ago.

Additionally, using the promise objects with jQuery.when can define multiple module dependencies
Eg.
`$.when(FirstModule.ready, SecondModule.ready).done(function(){ /* do something */ });`
