### PR TITLE
Added a test to verify that layout.removeRegion removes the region from ...

### DIFF
--- a/spec/javascripts/layout.dynamicRegions.spec.js
+++ b/spec/javascripts/layout.dynamicRegions.spec.js
@@ -175,6 +175,7 @@ describe("layout - dynamic regions", function(){
 
     it("should remove the region", function(){
       expect(layout.foo).toBeUndefined();
+      expect(layout.regions.foo).toBeUndefined();
       expect(layout.regionManager.get("foo")).toBeUndefined();
     });
   });


### PR DESCRIPTION
### Why

Upon researching the layout.removeRegion function to see if it removes from layout.regions, I noticed that it does in the dev branch, but there wasn't a test for it.
### What

This PR is 1 expect added to the layout.dynamicRegions test specs
### How

It adds the missing test
### Discussion

I don't see how this would cause any problems with anything else.
