### PR TITLE
Allow options to be passed to the regionType when building a custom region

### DIFF
--- a/spec/javascripts/application.appRegions.spec.js
+++ b/spec/javascripts/application.appRegions.spec.js
@@ -61,7 +61,8 @@ describe("application regions", function(){
       MyApp.addRegions({
         MyRegion: {
           selector: '#region',
-          regionType: MyRegion
+          regionType: MyRegion,
+          specialOption: true
         }
       });
     });
@@ -77,6 +78,12 @@ describe("application regions", function(){
     it("should set the specified selector", function(){
       expect(MyApp.MyRegion.el).toBe("#region");
     });
+
+    it("should pass extra options to the custom regionType", function() {
+      expect(MyApp.MyRegion).toHaveOwnProperty("options");
+      expect(MyApp.MyRegion.options).toHaveOwnProperty("specialOption");
+      expect(MyApp.MyRegion.options.specialOption).toBeTruthy();
+    });    
   });
 
   describe("when an app has a region", function(){

--- a/spec/javascripts/layout.spec.js
+++ b/spec/javascripts/layout.spec.js
@@ -17,8 +17,7 @@ describe("layout", function(){
   var CustomRegion1 = function() {
   };
 
-  var CustomRegion2 = function() {
-  };
+  var CustomRegion2 = Backbone.Marionette.Region.extend();
 
   var LayoutNoDefaultRegion = Layout.extend({
     regions: {
@@ -68,7 +67,8 @@ describe("layout", function(){
         },
         regionTwo: {
           selector: '#regionTwo',
-          regionType: CustomRegion2
+          regionType: CustomRegion2,
+          specialOption: true
         },
         regionThree: {
           selector: '#regionThree'
@@ -101,6 +101,12 @@ describe("layout", function(){
       var layoutManagerNoDefault = new LayoutNoDefaultRegion();
       expect(layoutManagerNoDefault).toHaveOwnProperty("regionTwo");
       expect(layoutManagerNoDefault.regionTwo).toBeInstanceOf(Backbone.Marionette.Region);
+    });
+
+    it("should pass extra options to the custom regionType", function() {
+      expect(layoutManager.regionTwo).toHaveOwnProperty("options");
+      expect(layoutManager.regionTwo.options).toHaveOwnProperty("specialOption");
+      expect(layoutManager.regionTwo.options.specialOption).toBeTruthy();
     });
 
   });

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -62,6 +62,7 @@ _.extend(Marionette.Region, {
 
     if (regionConfig.selector) {
       selector = regionConfig.selector;
+      delete regionConfig.selector;
     }
 
     // get the type for the region
@@ -76,12 +77,17 @@ _.extend(Marionette.Region, {
 
     if (regionConfig.regionType) {
       RegionType = regionConfig.regionType;
+      delete regionConfig.regionType;
     }
 
+    if (regionIsString || regionIsType) {
+      regionConfig = {};
+    }
+
+    regionConfig.el = selector;
+
     // build the region instance
-    var region = new RegionType({
-      el: selector
-    });
+    var region = new RegionType(regionConfig);
 
     // override the `getEl` function if we have a parentEl
     // this must be overridden to ensure the selector is found


### PR DESCRIPTION
When using a custom regionType using the

``` javascript
{
  selector: "#custom",
  regionType: CustomRegion
}
```

syntax, it is not possible to pass extra configuration options to the custom region class.

This pull request allows you to pass extra options by simply including them into the region definition object. EG.

``` javascript
{
  selector: "#custom",
  regionType: CustomRegion,
  doSomethingAwesome: true
}
```
