### PR TITLE
Clarify Region documentation of onClose handler

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -189,7 +189,7 @@ closing views:
 
 * "show" / `onShow` - Called on the view instance when the view has been rendered and displayed.
 * "show" / `onShow` - Called on the region instance when the view has been rendered and displayed.
-* "close" / `onClose` - Called when the view has been closed.
+* "close" / `onClose` - Called on the view instance when the view has been closed.
 
 These events can be used to run code when your region 
 opens and closes views.


### PR DESCRIPTION
I spent a little while trying to figure out why my handler wasn't being called, so I thought it would be worth specifying what instance it's called on, especially since the other two lines are already explicit about it.
