### PR TITLE
Don't ignore default options in the view constructor when it's a function.

### DIFF
--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -137,9 +137,21 @@ describe("base view", function(){
         'lila': 'zoidberg'
       }
     });
+    var presetOptionsFn = Marionette.View.extend({
+      options: function () {
+        return { 'fry': 'bender' };
+      }
+    });
 
     it("should take and store view options", function() {
       var viewInstance = new view({"Guybrush": "Island"});
+      expect(viewInstance.options.Guybrush).toBe("Island");
+    });
+
+    it("should take and store view options as a function", function() {
+      var viewInstance = new view(function(){
+        return { "Guybrush": "Island" }
+      });
       expect(viewInstance.options.Guybrush).toBe("Island");
     });
 
@@ -151,6 +163,11 @@ describe("base view", function(){
     it("should retain options set on view class", function() {
       var viewInstance = new presetOptions;
       expect(viewInstance.options.lila).toBe("zoidberg");
+    });
+
+    it("should retain options set on view class as a function", function() {
+      var viewInstance = new presetOptionsFn;
+      expect(viewInstance.options.fry).toBe("bender");
     });
   });
 

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -13,7 +13,7 @@ Marionette.View = Backbone.View.extend({
     // this is a backfill since backbone removed the assignment
     // of this.options
     // at some point however this may be removed
-    this.options = _.extend({}, this.options, options);
+    this.options = _.extend({}, _.result(this, 'options'), _.isFunction(options) ? options.call(this) : options);
 
     // parses out the @ui DSL for events
     this.events = this.normalizeUIKeys(_.result(this, 'events'));


### PR DESCRIPTION
Fixed #818
