### PR TITLE
Change CollectionView#checkEmpty to be overridable

### DIFF
--- a/spec/javascripts/collectionView.emptyView.spec.js
+++ b/spec/javascripts/collectionView.emptyView.spec.js
@@ -67,7 +67,7 @@ describe("collectionview - emptyView", function(){
     });
   });
 
-  describe("when the emptyView has been rendered for an empty collection and then collection reset, recieving some values. Then adding an item to the collection", function () {
+  describe("when the emptyView has been rendered for an empty collection and then collection reset, receiving some values. Then adding an item to the collection", function () {
     var collectionView, closeSpy;
 
     beforeEach(function () {
@@ -202,6 +202,56 @@ describe("collectionview - emptyView", function(){
       collection.reset(data);
 
       expect($(collectionView.$el)).toHaveHtml("<span>bar</span><span>baz</span>");
+    });
+  });
+
+  describe("checkEmpty", function(){
+    var collectionView, closeSpy;
+
+    beforeEach(function(){
+      var collection = new Backbone.Collection();
+
+      collectionView = new EmptyCollectionView({
+        collection: collection
+      });
+
+      collectionView.render();
+    });
+
+    it("should return true when the collection is empty", function(){
+      expect(collectionView.checkEmpty()).toEqual(true);
+    });
+
+    it("should return false when the collection is not empty", function(){
+      collectionView.collection.add({ foo: "wut" });
+      expect(collectionView.checkEmpty()).toEqual(false);
+    });
+  });
+
+  describe("overriding checkEmpty with a populated collection", function(){
+    var collectionView, closeSpy;
+
+    beforeEach(function(){
+      var collection = new Backbone.Collection([{foo: "wut"}, {foo: "wat"}]);
+
+      var OverriddenCheckEmptyCollectionView = EmptyCollectionView.extend({
+        checkEmpty: function () {
+          return true;
+        }
+      });
+      collectionView = new OverriddenCheckEmptyCollectionView({
+        collection: collection
+      });
+
+      collectionView.render();
+    });
+
+    it("should append the html for the emptyView", function(){
+      expect($(collectionView.$el)).toHaveHtml("<span class=\"isempty\"></span>");
+    });
+
+    it("should reference each of the rendered view items", function(){
+      expect(_.size(collectionView.children)).toBe(1);
     });
   });
 

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -76,7 +76,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this.closeEmptyView();
     this.closeChildren();
 
-    if (this.collection && this.collection.length > 0) {
+    if (!this.checkEmpty()) {
       this.showCollection();
     } else {
       this.showEmptyView();
@@ -196,7 +196,9 @@ Marionette.CollectionView = Marionette.View.extend({
   removeItemView: function(item){
     var view = this.children.findByModel(item);
     this.removeChildView(view);
-    this.checkEmpty();
+    if (this.checkEmpty()){
+      this.showEmptyView();
+    }
   },
 
   // Remove the child view and close it
@@ -217,13 +219,10 @@ Marionette.CollectionView = Marionette.View.extend({
     this.triggerMethod("item:removed", view);
   },
 
-  // helper to show the empty view if the collection is empty
+  // helper to check if the collection is empty
   checkEmpty: function() {
-    // check if we're empty now, and if we are, show the
-    // empty view
-    if (!this.collection || this.collection.length === 0){
-      this.showEmptyView();
-    }
+    // check if we're empty now
+    return !this.collection || this.collection.length === 0;
   },
 
   // Append the HTML to the collection's `el`.


### PR DESCRIPTION
Change CollectionView#checkEmpty to be overridable as a means of controlling when the empty view is rendered.

This is useful when you would like to exclude collection items from being rendered without actually changing the collection. Below is an example:

``` javascript
var MyCollectionView = Marionette.CollectionView.extend({
  checkEmpty : function () {
    return !this.collection || !this.collection.reject(function (model) {
      return model.get("disabled");
    }).length;
  }
});

var collection = new Backbone.Collection([{foo : "bar", disabled : true}]);

// Empty view is rendered because there are only disabled items in the collection
var view = new MyCollectionView({collection : collection}).render();
```
