### PR TITLE
Trigger Region close event with view that's being closed

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -245,7 +245,7 @@ describe("region", function(){
       }
     });
 
-    var myRegion, view, closed, closedContext;
+    var myRegion, view, closed, closedContext, closedView;
 
     beforeEach(function(){
       setFixtures("<div id='region'></div>");
@@ -256,7 +256,8 @@ describe("region", function(){
       spyOn(view, "remove");
 
       myRegion = new MyRegion();
-      myRegion.on("close", function(){
+      myRegion.on("close", function(view){
+        closedView = view;
         closed = true;
         closedContext = this;
       });
@@ -267,6 +268,10 @@ describe("region", function(){
 
     it("should trigger a close event", function(){
       expect(closed).toBeTruthy();
+    });
+
+    it("should trigger a close event with the view that's being closed", function(){
+      expect(closedView).toBe(view);
     });
 
     it("should set 'this' to the manager, from the close event", function(){

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -167,7 +167,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     if (view.close) { view.close(); }
     else if (view.remove) { view.remove(); }
 
-    Marionette.triggerMethod.call(this, "close");
+    Marionette.triggerMethod.call(this, "close", view);
 
     delete this.currentView;
   },


### PR DESCRIPTION
Not sure what devs might want with a closed view, but at least this is consistent and does what the docs say. Fixes #821.
