### PR TITLE
Remove reference to dev branch from contrib doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,15 +104,6 @@ pull request on a topic branch. If your pull request contains
 commits or other changes that are not related to the pull 
 request, we will ask you to re-do your pull request.
 
-### Branch from "dev" not "master"
-
-The "master" branch of the Marionette repository is for 
-production release code, and documentation updates only. Never 
-create a pull request from the master branch. Always create 
-a branch for your work from the "dev" branch. This will 
-facilitate easier pull request management for the continuous 
-work that is done in the dev branch.
-
 ### Submit Specs With Your Pull Request
 
 Whenever possible, submit the specs (unit tests) that 


### PR DESCRIPTION
The dev branch does not appear to be the correct branch to work against anymore. Removed section of contributing.md that indicates that is the correct practice.
