### PR TITLE
Call the itemViewContainer in the context of the CompositeView

### DIFF
--- a/spec/javascripts/compositeView-itemViewContainer.spec.js
+++ b/spec/javascripts/compositeView-itemViewContainer.spec.js
@@ -218,4 +218,28 @@ describe("composite view - itemViewContainer", function(){
 
   });
 
+  describe("when a composite view has the `itemViewContainer` specified as a function", function() {
+
+    var CompositeView = Backbone.Marionette.CompositeView.extend({
+      itemView: ItemView,
+      template: "#composite-child-container-template"
+    });
+
+    it("calls the `itemViewContainer` in the context of the composite view", function() {
+      loadFixtures("compositeChildContainerTemplate.html");
+      var collection = new Collection([{ foo: "bar" }, { foo: "baz" }]);
+      var compositeView = new CompositeView({ collection: collection });
+      var context;
+      compositeView.itemViewContainer = function() {
+        context = this;
+        return "ul";
+      };
+
+      compositeView.render();
+
+      expect(context).toBe(compositeView);
+    });
+
+  });
+
 });

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -134,7 +134,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     var itemViewContainer = Marionette.getOption(containerView, "itemViewContainer");
     if (itemViewContainer){
 
-      var selector = _.isFunction(itemViewContainer) ? itemViewContainer() : itemViewContainer;
+      var selector = _.isFunction(itemViewContainer) ? itemViewContainer.call(this) : itemViewContainer;
       container = containerView.$(selector);
       if (container.length <= 0) {
         throwError("The specified `itemViewContainer` was not found: " + containerView.itemViewContainer, "ItemViewContainerMissingError");


### PR DESCRIPTION
If `itemViewContainer` is specified as a function, it is called in the global context, which isn't cool. This fixes this issue by ensuring that the `itemViewContainer` is called in the context of the `CompositeView`.
