### PR TITLE
Extended `module` functionality

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -22,9 +22,11 @@ your application, and serve as an event aggregator in themselves.
 * [Module Definitions](#module-definitions)
   * [Module Initializers](#module-initializers)
   * [Module Finalizers](#module-finalizers)
+  * [Initialize function](#initialize-function)
 * [The Module's `this` Argument](#the-modules-this-argument)
 * [Custom Arguments](#custom-arguments)
 * [Splitting A Module Definition Apart](#splitting-a-module-definition-apart)
+* [Extending Modules](#extending-modules)
 
 ## Basic Usage
 
@@ -332,6 +334,8 @@ console.log(MyApp.MyModule.someData); //=> public data
 MyApp.MyModule.someFunction(); //=> public data
 ```
 
+
+
 ### Module Initializers
 
 Modules have initializers, similarly to `Application` objects. A module's
@@ -366,6 +370,35 @@ MyApp.module("Foo", function(Foo){
 
 Calling the `stop` method on the module will run all that module's 
 finalizers. A module can have as many finalizers as you wish.
+
+### Initialize Function
+
+Modules have an `initialize` function which is distinct from its collection of initializers. `initialize` is immediately called when the Module is invoked, unlike initializers, which are only called once the module is started. You can think of the `initialize` function as an extension of the constructor.
+
+```js
+MyApp.module("Foo", {
+  startWithParent: false,
+  initialize: function( options ) {
+    // This code is immediately executed
+    this.someProperty = 'someValue';
+  },
+  define: function() {
+    // This code is not executed until the Module has started
+    console.log( this.someProperty ); // Logs 'someValue' once the module is started
+  }
+});
+```
+
+The `initialize` function is passed a single argument, which is the object literal definition of the module itself. This allows you to pass arbitrary values to it.
+
+```js
+MyApp.module("Foo", {
+  initialize: function( options ) {
+    console.log( options.someVar ); // Logs 'someString'
+  },
+  someVar: 'someString'
+});
+```
 
 ## The Module's `this` Argument
 
@@ -412,3 +445,26 @@ MyApp.module("MyModule", function(MyModule){
 MyApp.MyModule.definition1; //=> true
 MyApp.MyModule.definition2; //=> true
 ```
+
+## Extending Modules
+
+Modules can be extended. This allows you to make custom Modules to include in your Application.
+
+```
+var CustomModule = Marionette.Module.extend({
+  constructor: function() {
+    // Configure your module
+  }
+});
+```
+
+When attaching a Module to your Application you can specify what class to use with the parameter `moduleClass`.
+
+```
+MyApp.module("Foo", {
+  moduleClass: CustomModule,
+  define: function() {} // You can still use the definition function on custom modules
+});
+```
+
+When `moduleClass` is omitted, Marionette will default to instantiating a new `Marionette.Module`.

--- a/spec/javascripts/module.start.spec.js
+++ b/spec/javascripts/module.start.spec.js
@@ -222,4 +222,121 @@ describe("module start", function(){
 
   });
 
+  describe("when passing a custom module class in the object literal", function(){
+    var MyApp, MyModule, moduleStart, customModule, initializer;
+
+    beforeEach(function(){
+
+      MyApp = new Backbone.Marionette.Application();
+      initializer = sinon.spy();
+      customModule = Backbone.Marionette.Module.extend( { initialize: initializer } );
+
+      MyApp.module("MyModule", {
+        startWithParent: false,
+        moduleClass: customModule
+      });
+
+      MyApp.start();
+    });
+
+    it("should run the initialize function once", function(){
+      expect(initializer).toHaveBeenCalledOnce;
+    });
+  });
+
+  describe("when passing an extended custom module class in the object literal", function(){
+    var MyApp, MyModule, moduleStart,
+        customModule, customModuleTwo,
+        initializer, initializerTwo,
+        p1, p2, r1, r2;
+
+    beforeEach(function(){
+
+      p1 = 'val1';
+      p2 = 'val2';
+
+      MyApp = new Backbone.Marionette.Application();
+      initializer = sinon.spy();
+      initializerTwo = sinon.spy();
+      customModule = Backbone.Marionette.Module.extend({
+        initialize: initializer,
+        val1: p1,
+        val2: p1
+      });
+      customModuleTwo = customModule.extend({
+        initialize: initializerTwo,
+        val1: p2
+      });
+
+      MyApp.module("MyModule", {
+        startWithParent: false,
+        moduleClass: customModuleTwo,
+        define: function() {
+          r1 = this.val1;
+          r2 = this.val2;
+        }
+      });
+
+      MyApp.start();
+    });
+
+    it("should only run the latest initialize function once, and not the prototype initialize", function(){
+      expect(initializer).not.toHaveBeenCalled();
+      expect(initializerTwo).toHaveBeenCalledOnce;
+    });
+
+    it("should extend properties correctly", function() {
+      expect(r1).toBe(p2);
+      expect(r2).toBe(p1);
+    });
+
+  });
+
+  describe("when passing an initialize function as an option when calling `Application.module`", function(){
+    var MyApp, MyModule, moduleStart, initializer;
+
+    beforeEach(function(){
+
+      MyApp = new Backbone.Marionette.Application();
+      initializer = sinon.spy();
+
+      MyApp.module("MyModule", {
+        initialize: initializer
+      });
+
+      MyApp.start();
+    });
+
+    it("should run the initialize function once", function(){
+      expect(initializer).toHaveBeenCalledOnce;
+    });
+
+  });
+
+  describe("when passing an arbitrary set of arguments to `Application.module`", function(){
+    var MyApp, MyModule, moduleStart, initializer, options;
+
+    beforeEach(function(){
+
+      MyApp = new Backbone.Marionette.Application();
+      initializer = sinon.spy();
+
+      options = {
+        startWithParent: false,
+        p1: 'testValueOne',
+        p2: 'testValueTwo',
+        initialize: initializer
+      };
+
+      MyApp.module("MyModule", options);
+
+      MyApp.start();
+    });
+
+    it("should pass them to the initialize function", function(){
+      expect(initializer).toHaveBeenCalledWithExactly(options);
+    });
+
+  });
+
 });

--- a/src/marionette.application.js
+++ b/src/marionette.application.js
@@ -77,13 +77,20 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
 
   // Create a module, attached to the application
   module: function(moduleNames, moduleDefinition){
+    var ModuleClass = Marionette.Module;
+
+    // Overwrite the module class if the user specifies one
+    if (moduleDefinition) {
+      ModuleClass = moduleDefinition.moduleClass || ModuleClass;
+    }
+
     // slice the args, and add this application object as the
     // first argument of the array
     var args = slice(arguments);
     args.unshift(this);
 
     // see the Marionette.Module object for more information
-    return Marionette.Module.create.apply(Marionette.Module, args);
+    return ModuleClass.create.apply(ModuleClass, args);
   },
 
   // Internal method to set up the region manager


### PR DESCRIPTION
_Fixes the botched PR #844, which in turn adds the functionality described in #837._

-Modules now have the functionality of Marionette.extend.
-Upon creation, Modules will fire the `initialize` function, if it exists
-You may also pass a custom class to be instantiated as the Module when adding a new Module to the Application.

It breaks backwards compatibility in its current implementation, and has questionable unit tests.
