### PR TITLE
Added default bower directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 npm-debug.log
 _SpecRunner.html
 components/
+bower_components/


### PR DESCRIPTION
Bower defaults to install in `bower_components`, so this location has been added to the .gitignore.
