### PR TITLE
Fix collectionView reset buffer itemView show condition

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -747,6 +747,37 @@ describe("collection view", function(){
     });
   });
 
+  describe("when a collection is reset itemViews should not be shown until the buffering is over", function() {
+    var isBuffering, iv, cv, collection, cvInstance;
+
+    iv = Marionette.ItemView.extend({
+        template: _.template("<div>hi mom</div>"),
+        onShow: function() {
+          isBuffering = cvInstance.isBuffering;
+        }
+    });
+
+    cv = Marionette.CollectionView.extend({
+      itemView: iv
+    });
+
+    beforeEach(function() {
+      isBuffering = null;
+      collection = new Backbone.Collection([{}]);
+      cvInstance = new cv({collection: collection});
+      cvInstance.render().trigger('show');
+    });
+
+    it("collectionView should not be buffering on itemView show", function() {
+      expect(isBuffering).toBe(false);
+    });
+
+    it("collectionView should not be buffering after reset on itemView show", function() {
+      collection.reset([{}]);
+      expect(isBuffering).toBe(false);
+    });
+  });
+
   describe("when a collection view is not rendered", function() {
     var collection, cv, model1, model2;
 

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -184,7 +184,7 @@ Marionette.CollectionView = Marionette.View.extend({
 
     // call the "show" method if the collection view
     // has already been shown
-    if (this._isShown){
+    if (this._isShown && !this.isBuffering){
       Marionette.triggerMethod.call(view, "show");
     }
 


### PR DESCRIPTION
When a collectionView was rendered and then reset, the itemView had
show called while it was still in the dom fragment.
Thus invalidating show and onDomRefresh

fixes #843
