### PR TITLE
Return the newly added view from addItemView in CollectionView.

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -800,4 +800,24 @@ describe("collection view", function(){
     });
   });
 
+  describe("when returning the view from addItemView", function(){
+    var childView;
+
+    beforeEach(function(){
+      var model = new Backbone.Model({foo: "bar"});
+
+      var CollectionView = Backbone.Marionette.CollectionView.extend({
+        itemView: ItemView
+      });
+
+      var collectionView = new CollectionView({});
+
+      childView = collectionView.addItemView(model, ItemView, 0);
+    });
+
+    it("should return the item view for the model", function(){
+      expect(childView.$el).toHaveText("bar");
+    });
+  });
+
 });

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -190,6 +190,8 @@ Marionette.CollectionView = Marionette.View.extend({
 
     // this view was added
     this.triggerMethod("after:item:added", view);
+
+    return view;
   },
 
   // Set up the child view event forwarding. Uses an "itemview:"


### PR DESCRIPTION
In situations when the CollectionView is extended heavily, it makes life easier to be able to get a reference to the view created when calling addItemView.
