### PR TITLE
onDomRefresh should only trigger if the view.el is actually in the DOM

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -679,6 +679,7 @@ describe("collection view", function(){
       collectionView = new ColView({
         collection: col
       });
+      $("body").append(collectionView.el);
 
       collectionView.render();
       collectionView.onShow();
@@ -688,6 +689,10 @@ describe("collection view", function(){
 
       col.add(m2);
       view = collectionView.children.findByIndex(1);
+    });
+
+    afterEach(function(){
+      collectionView.remove();
     });
 
     it("should not use the render buffer", function() {

--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -349,18 +349,23 @@ describe("item view", function(){
       template: function(){return "<div>foo</div>"; }
     });
 
-    var renderUpdate;
+    var renderUpdate, view;
 
     beforeEach(function(){
       renderUpdate = jasmine.createSpy("dom:refresh");
 
-      var view = new View();
+      view = new View();
+      $("body").append(view.el);
 
       view.on("dom:refresh", renderUpdate);
       view.render();
       view.triggerMethod("show");
 
       view.render();
+    });
+
+    afterEach(function(){
+      view.remove();
     });
 
     it("should trigger a dom:refresh event", function(){

--- a/spec/javascripts/onDomRefresh.spec.js
+++ b/spec/javascripts/onDomRefresh.spec.js
@@ -1,0 +1,36 @@
+describe("onDomRefresh", function(){
+  var view;
+
+  var View = Backbone.Marionette.ItemView.extend({
+    onDomRefresh: function() {}
+  });
+
+  beforeEach(function(){
+    spyOn(View.prototype, "onDomRefresh").andCallThrough();
+    view = new View();
+    view.trigger("show");
+    view.trigger("render");
+  });
+
+  afterEach(function() {
+    view.remove();
+  });
+
+  describe("when the view is not in the DOM", function(){
+    it("should never trigger onDomRefresh", function(){
+      expect(View.prototype.onDomRefresh).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the view is in the DOM", function(){
+    beforeEach(function(){
+      $("body").append(view.$el);
+      view.trigger("show");
+      view.trigger("render");
+    });
+
+    it("should trigger onDomRefresh if 'show' and 'render' have both been triggered on the view", function(){
+      expect(View.prototype.onDomRefresh).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/marionette.domRefresh.js
+++ b/src/marionette.domRefresh.js
@@ -5,7 +5,7 @@
 // in the DOM, trigger a "dom:refresh" event every time it is
 // re-rendered.
 
-Marionette.MonitorDOMRefresh = (function(){
+Marionette.MonitorDOMRefresh = (function(documentElement){
   // track when the view has been shown in the DOM,
   // using a Marionette.Region (or by other means of triggering "show")
   function handleShow(view){
@@ -21,11 +21,15 @@ Marionette.MonitorDOMRefresh = (function(){
 
   // Trigger the "dom:refresh" event and corresponding "onDomRefresh" method
   function triggerDOMRefresh(view){
-    if (view._isShown && view._isRendered){
+    if (view._isShown && view._isRendered && isInDOM(view)){
       if (_.isFunction(view.triggerMethod)){
         view.triggerMethod("dom:refresh");
       }
     }
+  }
+
+  function isInDOM(view) {
+    return documentElement.contains(view.el);
   }
 
   // Export public API
@@ -38,4 +42,4 @@ Marionette.MonitorDOMRefresh = (function(){
       handleRender(view);
     });
   };
-})();
+})(document.documentElement);


### PR DESCRIPTION
So like 10 months later, I've finally got around to fixing this. :)

`onDomRefresh` never actually checked if the view.el was in the DOM, but just assumed it was based on events that had fired on the view (`show` and `render`).

This PR does an additional check in `onDomRefresh` against the DOM so we can guarantee it really is in the DOM.

FYI `document.documentElement` and `document.documentElement.contains(x)` should be [safe to use](http://www.quirksmode.org/dom/core/#miscellaneous).

I added a call to `view.remove()` so we didn't clog the page up with elements. Looks like there's lots of memory leaks in the tests... do we care about this? I always remove any views I created in my own tests.

Fixed #748 and fixes #479 and #505.
