### PR TITLE
BabySitter and Wreqr as dependencies. Fixes #860

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -56,9 +56,7 @@
 
   "dependencies" : {
     "backbone": "~1.1.0",
-    "underscore": "~1.5.1"
-  },
-  "devDependencies": {
+    "underscore": "~1.5.1",
     "backbone.babysitter": "~0.0.6",
     "backbone.wreqr": "~0.2.0"
   }


### PR DESCRIPTION
backbone.babysitter and backbone.wreqr specified as dependences instead of devDependencies.
