### PR TITLE
Adds support for string-based itemEvents

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -467,13 +467,14 @@ events or model change events, and then triggering an event
 of its own based on that.
 
 ## CollectionView's `itemEvents`
-You can specify an `itemEvents` hash or method which allows you to capture all bubbling itemEvents without having to manually set bindings.
+You can specify an `itemEvents` hash or method which allows you to capture all bubbling itemEvents without having to manually set bindings. The keys of the hash can either be a function or a string that is the name of a method on the collection view.
 
 ```js
 itemEvents: {
   "render": function() {
     console.log("an itemView has been rendered");
-  }
+  },
+  "onItemClose": "someFn" // where the collection view has a method `someFn`
 }
 ```
 

--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -144,3 +144,25 @@ The third parameter is a hash of { "event:name": "eventHandler" }
 configuration. Multiple handlers can be separated by a space. A
 function can be supplied instead of a string handler name. 
 
+## Marionette.normalizeEvents
+
+Receives a hash of event names and functions and/or function names, and returns the
+same hash with the function names replaced with the function references themselves.
+
+```
+var View = Marionette.ItemView.extend({
+
+  initialize: function() {
+    this.someFn = function() {};
+    this.someOtherFn = function() {};
+    var hash = {
+      eventOne: "someFn", // This will become a reference to `this.someFn`
+      eventTwo: this.someOtherFn
+    };
+    this.normalizedHash = Marionette.normalizeMethods(hash, this);
+  }
+
+});
+```
+
+The first parameter is the hash to normalize. The second parameter is the context; the object to search for methods on.

--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -795,6 +795,52 @@ describe("collection view", function(){
     });
   });
 
+  describe("calling itemEvents via the itemEvents hash with a string of the function name", function(){
+    var someFn;
+
+    var CV = Marionette.CollectionView.extend({
+      itemView: ItemView,
+      itemEvents: {
+        "render": "someFn"
+      }
+    });
+
+    beforeEach(function() {
+      someFn = sinon.spy();
+      CV.prototype.someFn = someFn;
+      var cv = new CV({
+        collection: (new Backbone.Collection([{}]))
+      });
+
+      cv.render();
+    });
+
+    it("should call the associated itemEvent function when defined", function() {
+      expect(someFn).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("calling itemEvents via the itemEvents hash with a string of a nonexistent function name", function(){
+
+    var CV = Marionette.CollectionView.extend({
+      itemView: ItemView,
+      itemEvents: {
+        "render": "nonexistentFn"
+      }
+    });
+
+    beforeEach(function() {
+      var cv = new CV({
+        collection: (new Backbone.Collection([{}]))
+      });
+      cv.render();
+    });
+
+    it("should not break", function() {
+      // Intentionally left blank
+    });
+  });
+
   describe("has a valid inheritance chain back to Marionette.View", function(){
     var constructor;
 

--- a/spec/javascripts/normalizeMethods.spec.js
+++ b/spec/javascripts/normalizeMethods.spec.js
@@ -1,0 +1,40 @@
+describe("normalizeMethods", function(){
+
+  describe("when normalizeMethods is called with a hash of functions and strings", function(){
+
+    var hash, normalizedHash, view;
+
+    var View = Backbone.Marionette.ItemView.extend({
+      initialize: function( options ) {
+        this.two = function() {};
+        var hash = _.extend({
+          eventTwo: this.two
+        }, options.hash);
+        this.normalizedHash = Marionette.normalizeMethods(hash, this);
+      },
+      one: function() {}
+    });
+
+    beforeEach(function(){
+
+      hash = {
+        "eventOne": "one",
+        "eventThree": "three"
+      };
+
+      view = new View({
+        hash: hash
+      });
+
+    });
+
+    it("should convert the strings that exist as functions to functions", function(){
+      expect(view.normalizedHash.eventOne).toBeDefined();
+      expect(view.normalizedHash.eventTwo).toBeDefined();
+    });
+    it("should ignore strings that don't exist as functions on the context", function() {
+      expect(view.normalizedHash.eventThree).not.toBeDefined();
+    });
+  });
+
+});

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -215,7 +215,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this.listenTo(view, "all", function(){
       var args = slice(arguments);
       var rootEvent = args[0];
-      var itemEvents = this.getItemEvents();
+      var itemEvents = Marionette.normalizeMethods(this.getItemEvents(), this);
 
       args[0] = prefix + ":" + rootEvent;
       args.splice(1, 0, view);

--- a/src/marionette.helpers.js
+++ b/src/marionette.helpers.js
@@ -36,3 +36,23 @@ Marionette.getOption = function(target, optionName){
 
   return value;
 };
+
+// Marionette.normalizeMethods
+// ----------------------
+
+// Pass in a mapping of events => functions or function names
+// and return a mapping of events => functions
+Marionette.normalizeMethods = function(hash, context) {
+  var normalizedHash = {}, method;
+  _.each(hash, function(fn, name) {
+    method = fn;
+    if (!_.isFunction(method)) {
+      method = this[method];
+    }
+    if (!method) {
+      return;
+    }
+    normalizedHash[name] = method;
+  }, context);
+  return normalizedHash;
+};


### PR DESCRIPTION
There’s a new Marionette.helper in town, and it allows you to specify
function names as strings in the itemEvents hash as well as the usual
function references.

Fixes #872 
