### PR TITLE
Add loadingView option to CollectionView

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -18,6 +18,7 @@ will provide features such as `onShow` callbacks, etc. Please see
 * [CollectionView's `itemView`](#collectionviews-itemview)
 * [CollectionView's `itemViewOptions`](#collectionviews-itemviewoptions)
 * [CollectionView's `emptyView`](#collectionviews-emptyview)
+* [CollectionView's `loadingView`](#collectionviews-loadingview)
 * [CollectionView's `buildItemView`](#collectionviews-builditemview)
 * [Callback Methods](#callback-methods)
   * [onBeforeRender callback](#onbeforerender-callback)
@@ -172,6 +173,21 @@ Backbone.Marionette.CollectionView.extend({
     // some logic to calculate if the view should be rendered as empty
     return someBoolean;
   }
+
+## CollectionView's `loadingView`
+
+When a collection is fetching elements you might want to indicate
+that. To do it you can specify `loadingView` attribute on your collection view.
+
+```js
+var LoadingView = Backbone.Marionette.ItemView.extend({
+  template: "#show-spinner-template"
+});
+
+Backbone.Marionette.CollectionView.extend({
+  // ...
+
+  loadingView: LoadingView
 });
 ```
 
@@ -657,4 +673,3 @@ Backbone.Marionette.CollectionView.extend({
   }
 });
 ```
-

--- a/spec/javascripts/collectionView.loadingView.spec.js
+++ b/spec/javascripts/collectionView.loadingView.spec.js
@@ -1,0 +1,104 @@
+describe("collectionview - loadingView", function(){
+  "use strict";
+
+  var ItemView = Backbone.Marionette.ItemView.extend({
+    tagName: "span",
+    render: function(){
+      this.$el.html(this.model.get("foo"));
+    },
+    onRender: function(){}
+  });
+
+  var EmptyView = Backbone.Marionette.ItemView.extend({
+    tagName: "span",
+    className: "isempty",
+    render: function(){}
+  });
+
+  var LoadingView = Backbone.Marionette.ItemView.extend({
+    tagName: "span",
+    className: "isloading",
+    render: function(){}
+  });
+
+  describe("when fetching collection with emptyView", function(){
+
+      var EmptyCollectionView = Backbone.Marionette.CollectionView.extend({
+          itemView: ItemView,
+          loadingView: LoadingView,
+          emptyView: EmptyView
+      });
+
+    var collection, collectionView, sync;
+
+    beforeEach(function(){
+
+      collection = new Backbone.Collection([], {
+          url: '/fake_collection_url',
+      });
+      collection.sync =  function(){ sync.apply(this, arguments) };
+
+      collectionView = new EmptyCollectionView({
+        collection: collection
+      });
+
+      collectionView.render();
+    });
+
+    it("should append the html for the loadingView", function(){
+      sync = function(_m, model, options){ model.trigger('request', model, null, options); };
+      collection.fetch();
+      expect($(collectionView.$el)).toHaveHtml("<span class=\"isloading\"></span>");
+    });
+
+    it("should remove the html for the loadingView when model is synced", function(){
+      var requestIsDone = false;
+      sync = function(_m, model, options){
+          model.trigger('request', model, null, options);
+          setTimeout(function(){
+              options.success([]);
+              model.trigger('sync', model, null, options);
+          }, 0);
+      };
+      collection.fetch();
+      waits(0);
+      runs(function() {
+        expect($(collectionView.$el)).toHaveHtml("<span class=\"isempty\"></span>");
+      });
+    });
+
+    it("should show items when collection is synced", function(){
+      var requestIsDone = false;
+      sync = function(_m, model, options){
+          model.trigger('request', model, null, options);
+          setTimeout(function(){
+              options.success([{ foo: 'bar' }]);
+              model.trigger('sync', model, null, options);
+          }, 0);
+      };
+      collection.fetch();
+      waits(0);
+      runs(function() {
+        expect($(collectionView.$el)).toHaveHtml("<span>bar</span>");
+      });
+    });
+
+    it("should show items when collection is synced with reset option", function(){
+      var requestIsDone = false;
+      sync = function(_m, model, options){
+          model.trigger('request', model, null, options);
+          setTimeout(function(){
+              options.success([{ foo: 'bar' }]);
+              model.trigger('sync', model, null, options);
+          }, 0);
+      };
+      collection.fetch({ reset: true });
+      waits(0);
+      runs(function() {
+        expect($(collectionView.$el)).toHaveHtml("<span>bar</span>");
+      });
+    });
+
+  });
+
+});

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -55,12 +55,16 @@ Marionette.CollectionView = Marionette.View.extend({
       this.listenTo(this.collection, "add", this.addChildView, this);
       this.listenTo(this.collection, "remove", this.removeItemView, this);
       this.listenTo(this.collection, "reset", this.render, this);
+      this.listenTo(this.collection, "request", this.showLoadingView, this);
+      this.listenTo(this.collection, "sync", this.closeLoadingView, this);
     }
   },
 
   // Handle a child item added to the collection
   addChildView: function(item, collection, options){
     this.closeEmptyView();
+    this.closeLoadingView();
+
     var ItemView = this.getItemView(item);
     var index = this.collection.indexOf(item);
     this.addItemView(item, ItemView, index);
@@ -106,6 +110,8 @@ Marionette.CollectionView = Marionette.View.extend({
     this.startBuffering();
 
     this.closeEmptyView();
+    this.closeLoadingView();
+
     this.closeChildren();
 
     if (!this.isEmpty(this.collection)) {
@@ -150,9 +156,38 @@ Marionette.CollectionView = Marionette.View.extend({
     }
   },
 
+  // Internal method to show an loading view in place of
+  // a collection of item views, when the collection is
+  // fetching from remote server
+  showLoadingView: function(){
+    var LoadingView = this.getLoadingView();
+
+    if (LoadingView && !this._showingLoadingView){
+      this._showingLoadingView = true;
+      this.closeChildren();
+      this.closeEmptyView();
+      var model = new Backbone.Model();
+      this.addItemView(model, LoadingView, 0);
+    }
+  },
+
+  // Internal method to close an existing loadingView instance
+  // if one exists.
+  closeLoadingView: function(){
+    if (this._showingLoadingView){
+      delete this._showingLoadingView;
+      this.closeChildren();
+    }
+  },
+
   // Retrieve the empty view type
   getEmptyView: function(){
     return Marionette.getOption(this, "emptyView");
+  },
+
+  // Retrieve the empty view type
+  getLoadingView: function(){
+    return Marionette.getOption(this, "loadingView");
   },
 
   // Retrieve the itemView type, either from `this.options.itemView`
@@ -338,4 +373,3 @@ Marionette.CollectionView = Marionette.View.extend({
     this.checkEmpty();
   }
 });
-


### PR DESCRIPTION
When a collection is fetching elements you might want to indicate
that. To do it you can specify `loadingView` attribute on your collection view.

``` js
var LoadingView = Backbone.Marionette.ItemView.extend({
  template: "#show-spinner-template"
});

Backbone.Marionette.CollectionView.extend({
  // ...

  loadingView: LoadingView
});
```
