### PR TITLE
Auto-starts obj. lit. module definitions

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -59,7 +59,8 @@ module that you need in your tests.
 
 Starting a module is done in one of two ways:
 
-1. Automatically with the parent module (or Application) `.start()` method
+1. Automatically with the parent module (or Application) `.start()` method. This is the
+default behavior
 2. Manually call the `.start()` method on the module
 
 In this example, the module will be started automatically with the parent
@@ -121,8 +122,9 @@ mod.start(options);
 
 ### Preventing Auto-Start Of Modules
 
+The default behavior of modules is that they start with the application.
 If you wish to manually start a module instead of having the application
-start it, you can tell the module definition not to start with the parent:
+start it, you can do so with the `startWithParent` property:
 
 ```js
 var fooModule = MyApp.module("Foo", function(){

--- a/spec/javascripts/module.start.spec.js
+++ b/spec/javascripts/module.start.spec.js
@@ -1,6 +1,60 @@
 describe("module start", function(){
   "use strict";
 
+  describe("when starting an application with a module definition", function(){
+    var MyApp, myModule, start;
+
+    beforeEach(function(){
+
+      MyApp = new Backbone.Marionette.Application();
+      myModule = MyApp.module("MyModule");
+      start = sinon.stub( myModule, "start" );
+
+      MyApp.start();
+    });
+
+    it("the module should start with it", function(){
+      expect(start).toHaveBeenCalled();
+    });
+
+  });
+
+  describe("when starting an application with a module defined with a function", function(){
+    var MyApp, myModule, start;
+
+    beforeEach(function(){
+
+      MyApp = new Backbone.Marionette.Application();
+      myModule = MyApp.module("MyModule", function() {});
+      start = sinon.stub( myModule, "start" );
+
+      MyApp.start();
+    });
+
+    it("the module should start with it", function(){
+      expect(start).toHaveBeenCalled();
+    });
+
+  });
+
+  describe("when starting an application with a module defined with an object literal", function(){
+    var MyApp, myModule, start;
+
+    beforeEach(function(){
+
+      MyApp = new Backbone.Marionette.Application();
+      myModule = MyApp.module("MyModule", {});
+      start = sinon.stub( myModule, "start" );
+
+      MyApp.start();
+    });
+
+    it("the module should start with it", function(){
+      expect(start).toHaveBeenCalled();
+    });
+
+  });
+
   describe("when starting a module", function(){
     var MyApp, myModule, initializer;
 

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -189,7 +189,7 @@ _.extend(Marionette.Module, {
     } else if (_.isObject(def)){
       // if an object is supplied
       fn = def.define;
-      startWithParent = def.startWithParent;
+      startWithParent = (typeof def.startWithParent !== 'undefined') ? def.startWithParent : true;
 
     } else {
       // if nothing is supplied


### PR DESCRIPTION
Also adds unit tests & clears up the docs.

Fixes #890
