### PR TITLE
Update module initialize to include moduleName and app

### DIFF
--- a/spec/javascripts/module.start.spec.js
+++ b/spec/javascripts/module.start.spec.js
@@ -368,11 +368,12 @@ describe("module start", function(){
   });
 
   describe("when passing an arbitrary set of arguments to `Application.module`", function(){
-    var MyApp, MyModule, moduleStart, initializer, options;
+    var MyApp, MyModule, moduleStart, initializer, options, moduleName;
 
     beforeEach(function(){
 
       MyApp = new Backbone.Marionette.Application();
+      moduleName = "MyModule";
       initializer = sinon.spy();
 
       options = {
@@ -382,13 +383,13 @@ describe("module start", function(){
         initialize: initializer
       };
 
-      MyApp.module("MyModule", options);
+      MyApp.module(moduleName, options);
 
       MyApp.start();
     });
 
     it("should pass them to the initialize function", function(){
-      expect(initializer).toHaveBeenCalledWithExactly(options);
+      expect(initializer).toHaveBeenCalledWithExactly(options, moduleName, MyApp);
     });
 
   });

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -20,7 +20,7 @@ Marionette.Module = function(moduleName, app, options){
   this.triggerMethod = Marionette.triggerMethod;
 
   if (_.isFunction(this.initialize)){
-    this.initialize(this.options);
+    this.initialize(this.options, moduleName, app);
   }
 };
 


### PR DESCRIPTION
This is helpful when using an object literal pattern for modules and you want a reference back to app. Should be backward compatable. 

``` js
var moduleClass = Backbone.Marionette.Module.extend({
    startWithParent: false,

    controller: {
        index: function() {}
    },

    initialize: function(options, moduleName, app) {
        this.app = app;
    },

    onStart: function() {},

    onStop: function() {},
});
```
