### PR TITLE
Pass module classes directly to app.module

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -10,6 +10,7 @@ and to build individual components of your app.
 * [Module Definitions](#module-definitions)
   * [Callback Function Definition](#callback-function-definition)
   * [Object Literal Definition](#object-literal-definition)
+* [Module Classes](#module-classes)
 * [Defining Sub-Modules](#defining-sub-modules)
 * [Starting and Stopping Modules](#starting-and-stopping-modules)
 * [Starting Modules](#starting-modules)
@@ -183,25 +184,6 @@ MyApp.module("Foo", {
 
 When `moduleClass` is omitted Marionette will default to instantiating a new `Marionette.Module`.
 
-#### Custom Module Classes
-
-The extend function of a Module is identical to the extend functions on other Backbone and Marionette classes.
-
-A particularly important property when creating a new Module class is the `constructor` function, which for Modules
-receives three arguments:
-
-* The Module name
-* The Application
-* The entire object literal definition of the Module
-
-```
-var CustomModule = Marionette.Module.extend({
-  constructor: function( moduleName, app, options ) {
-    // Configure your Module
-  }
-});
-```
-
 #### Initialize Function
 
 Modules have an `initialize` function which is immediately called when the Module is invoked. You can think of the `initialize` function as an extension of the constructor.
@@ -243,6 +225,35 @@ var CustomModule = Marionette.Module.extend({
   initialize: function() {} // This, on the other hand, will be inherited
 });
 ```
+
+## Module Classes
+
+Module classes can be used as an alternative to the define pattern.
+
+The extend function of a Module is identical to the extend functions on other Backbone and Marionette classes. This allows module lifecyle events like `onStart` and `onStop` to be called directly.
+
+```
+var FooModule = Marionette.Module.extend({
+  startWithParent: false,
+
+  constructor: function(moduleName, app, options) {
+  },
+
+  initialize: function(options, app, moduleName) {
+  },
+
+  onStart: function(options) {
+  },
+
+  onStop: function(options) {
+  },
+});
+
+MyApp.module("Foo", FooModule);
+```
+
+If all of the module's functionality is defined inside its class, then the class can be passed in directly. `MyApp.module("Foo", FooModule)`
+
 
 ## Defining Sub-Modules
 

--- a/spec/javascripts/module.spec.js
+++ b/spec/javascripts/module.spec.js
@@ -33,6 +33,106 @@ describe("application modules", function(){
     });
   });
 
+  describe("when specifying a module on an application with a define function", function(){
+    var MyApp, ModuleClass, myModule, initializeBefore, initializeAfter;
+
+    beforeEach(function(){
+      initializeBefore = jasmine.createSpy("before handler");
+      initializeAfter = jasmine.createSpy("after handler");
+
+      MyApp = new Backbone.Marionette.Application();
+      myModule = MyApp.module("MyModule", function(MyModule, MyApp) {
+          MyModule.on("before:start", initializeBefore);
+          MyModule.on("start", initializeAfter);
+      });
+
+      myModule.start();
+    });
+
+    it("should notify me before initialization starts", function(){
+      expect(initializeBefore).toHaveBeenCalled();
+    });
+
+    it("should notify me after initialization", function(){
+      expect(initializeAfter).toHaveBeenCalled();
+    });
+
+    it("should add an object of that name to the app", function(){
+      expect(MyApp.MyModule).not.toBeUndefined();
+    });
+
+    it("should return the module", function(){
+      expect(myModule).toBe(MyApp.MyModule);
+    });
+  });
+  describe("when specifying a module on an application with options object", function(){
+    var MyApp, ModuleClass, myModule, initializeBefore, initializeAfter;
+
+    beforeEach(function(){
+      initializeBefore = jasmine.createSpy("before handler");
+      initializeAfter = jasmine.createSpy("after handler");
+
+      MyApp = new Backbone.Marionette.Application();
+      ModuleClass = Backbone.Marionette.Module.extend({
+          onBeforeStart: initializeBefore,
+          onStart: initializeAfter
+      });
+      myModule = MyApp.module("MyModule", {moduleClass: ModuleClass});
+
+      myModule.start();
+    });
+
+    it("should notify me before initialization starts", function(){
+      expect(initializeBefore).toHaveBeenCalled();
+    });
+
+    it("should notify me after initialization", function(){
+      expect(initializeAfter).toHaveBeenCalled();
+    });
+
+    it("should add an object of that name to the app", function(){
+      expect(MyApp.MyModule).not.toBeUndefined();
+    });
+
+    it("should return the module", function(){
+      expect(myModule).toBe(MyApp.MyModule);
+    });
+  });
+
+  describe("when specifying a module on an application with a module class", function(){
+    var MyApp, ModuleClass, myModule, initializeBefore, initializeAfter;
+
+    beforeEach(function(){
+      initializeBefore = jasmine.createSpy("before handler");
+      initializeAfter = jasmine.createSpy("after handler");
+
+      MyApp = new Backbone.Marionette.Application();
+      ModuleClass = Backbone.Marionette.Module.extend({
+          onBeforeStart: initializeBefore,
+          onStart: initializeAfter
+      });
+      myModule = MyApp.module("MyModule", ModuleClass);
+
+      myModule.start();
+    });
+
+    it("should notify me before initialization starts", function(){
+      expect(initializeBefore).toHaveBeenCalled();
+    });
+
+    it("should notify me after initialization", function(){
+      expect(initializeAfter).toHaveBeenCalled();
+    });
+
+    it("should add an object of that name to the app", function(){
+      expect(MyApp.MyModule).not.toBeUndefined();
+    });
+
+    it("should return the module", function(){
+      expect(myModule).toBe(MyApp.MyModule);
+    });
+  });
+
   describe("when specifying sub-modules with a . notation", function(){
     var MyApp, lastModule, parentModule, childModule;
 

--- a/src/marionette.application.js
+++ b/src/marionette.application.js
@@ -77,12 +77,9 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
 
   // Create a module, attached to the application
   module: function(moduleNames, moduleDefinition){
-    var ModuleClass = Marionette.Module;
 
     // Overwrite the module class if the user specifies one
-    if (moduleDefinition) {
-      ModuleClass = moduleDefinition.moduleClass || ModuleClass;
-    }
+    var ModuleClass = Marionette.Module.getClass(moduleDefinition);
 
     // slice the args, and add this application object as the
     // first argument of the array

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -157,11 +157,8 @@ _.extend(Marionette.Module, {
   },
 
   _getModule: function(parentModule, moduleName, app, def, args){
-    var ModuleClass = Marionette.Module;
     var options = _.extend({}, def);
-    if (def) {
-      ModuleClass = def.moduleClass || ModuleClass;
-    }
+    var ModuleClass = this.getClass(def);
 
     // Get an existing module of this name if we have one
     var module = parentModule[moduleName];
@@ -175,6 +172,20 @@ _.extend(Marionette.Module, {
     }
 
     return module;
+  },
+
+  getClass: function(moduleDefinition) {
+    var ModuleClass = Marionette.Module;
+
+    if (!moduleDefinition) {
+      return ModuleClass;
+    }
+
+    if (moduleDefinition.prototype instanceof ModuleClass) {
+      return moduleDefinition;
+    }
+
+    return moduleDefinition.moduleClass || ModuleClass;
   },
 
   _addModuleDefinition: function(parentModule, module, def, args){


### PR DESCRIPTION
This is admittedly a small thing, but it would be nice to setup modules directly like this `app.module('Items', ItemModule)`. 

As background, we're currently defining modules with `extend` and setting them up with an `app#module` options map. e.g.

``` js
var ItemModule = Marionette.Module.extend({
  startWithParent: false,
  initialize: function(options) {},  
  onStart: function() {}
});

// ...

this.app.module('Items', {moduleClass: ItemModule});
```

It would be nice to setup modules more directly like this: 

``` js
var ItemModule = Marionette.Module.extend({
  startWithParent: false,
  initialize: function(options) {},  
  onStart: function() {}
});

// ...

this.app.module('Items', ItemModule);
```

This is not a big deal, but I think there are a couple benefits. 
1. It's slightly nicer on the eyes
2. It makes it clear to the reader that the module functionality will come from the module class and not module option properties like `define` or `initialize`.
3. `Module.getClass` removes a small amout of duplication :)

cheers!
