### PR TITLE
Refactor type checks to use underscore type fncs

### DIFF
--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -189,7 +189,7 @@ _.extend(Marionette.Module, {
     } else if (_.isObject(def)){
       // if an object is supplied
       fn = def.define;
-      startWithParent = (typeof def.startWithParent !== 'undefined') ? def.startWithParent : true;
+      startWithParent = !_.isUndefined(def.startWithParent) ? def.startWithParent : true;
 
     } else {
       // if nothing is supplied

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -41,10 +41,10 @@ _.extend(Marionette.Region, {
   // ```
   //
   buildRegion: function(regionConfig, defaultRegionType){
-    var regionIsString = (typeof regionConfig === "string");
-    var regionSelectorIsString = (typeof regionConfig.selector === "string");
-    var regionTypeIsUndefined = (typeof regionConfig.regionType === "undefined");
-    var regionIsType = (typeof regionConfig === "function");
+    var regionIsString = _.isString(regionConfig);
+    var regionSelectorIsString = _.isString(regionConfig.selector);
+    var regionTypeIsUndefined = _.isUndefined(regionConfig.regionType);
+    var regionIsType = _.isFunction(regionConfig);
 
     if (!regionIsType && !regionIsString && !regionSelectorIsString) {
       throw new Error("Region must be specified as a Region type, a selector string or an object with selector property");

--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -17,7 +17,7 @@ Marionette.RegionManager = (function(Marionette){
       var regions = {};
 
       _.each(regionDefinitions, function(definition, name){
-        if (typeof definition === "string"){
+        if (_.isString(definition)){
           definition = { selector: definition };
         }
 


### PR DESCRIPTION
This is a small change that shouldn't affect any existing functionality. Personally, I find the underscore `isX` api easier on the eyes and their type checks really sensible. 
