### PR TITLE
v2 - Changed signature of Module.prototype.initialize to match Module.prototype.constructor

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -211,7 +211,7 @@ The initialize function is only available through the object literal definition 
 ```js
 MyApp.module("Foo", {
   startWithParent: false,
-  initialize: function( options, moduleName, app ) {
+  initialize: function( moduleName, app, options ) {
     this.someProperty = 'someValue';
   },
   // You can still set a define function
@@ -221,14 +221,14 @@ MyApp.module("Foo", {
 });
 ```
 
-The `initialize` function is passed three arguments.
-  * The object literal definition of the Module itself (which allows you to pass arbitrary values to your Module)
+The `initialize` function is passed the same arguments as the constructor.
   * The moduleName
-  * The app.
+  * The app
+  * The object literal definition of the Module itself (which allows you to pass arbitrary values to your Module)
 
 ```js
 MyApp.module("Foo", {
-  initialize: function( options, moduleName, app ) {
+  initialize: function( moduleName, app, options ) {
     console.log( options.someVar ); // Logs 'someString'
   },
   someVar: 'someString'

--- a/spec/javascripts/module.start.spec.js
+++ b/spec/javascripts/module.start.spec.js
@@ -389,7 +389,7 @@ describe("module start", function(){
     });
 
     it("should pass them to the initialize function", function(){
-      expect(initializer).toHaveBeenCalledWithExactly(options, moduleName, MyApp);
+      expect(initializer).toHaveBeenCalledWithExactly(moduleName, MyApp, options);
     });
 
   });

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -20,7 +20,7 @@ Marionette.Module = function(moduleName, app, options){
   this.triggerMethod = Marionette.triggerMethod;
 
   if (_.isFunction(this.initialize)){
-    this.initialize(this.options, moduleName, app);
+    this.initialize(moduleName, app, this.options);
   }
 };
 


### PR DESCRIPTION
Fixes #899. For v2.
