### PR TITLE
v2 - Removes unnecessary param in appendHtml

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -88,7 +88,7 @@ describe("collection view", function(){
     });
 
     it("should provide the index for each itemView, when appending", function(){
-      expect(collectionView.appendHtml.calls[0].args[2]).toBe(0);
+      expect(collectionView.appendHtml.calls[0].args[1]).toBe(0);
     });
 
     it("should reference each of the rendered view items", function(){
@@ -198,7 +198,7 @@ describe("collection view", function(){
     });
 
     it("should provide the index for each itemView, when appending", function(){
-      expect(collectionView.appendHtml.calls[0].args[2]).toBe(0);
+      expect(collectionView.appendHtml.calls[0].args[1]).toBe(0);
     });
 
     it("should trigger the itemview:render event from the collectionView", function(){
@@ -236,7 +236,7 @@ describe("collection view", function(){
     });
 
     it("should provide the index for each itemView, when appending", function(){
-      expect(collectionView.appendHtml.calls[0].args[2]).toBe(1);
+      expect(collectionView.appendHtml.calls[0].args[1]).toBe(1);
     });
 
     it("should trigger the itemview:render event from the collectionView", function(){
@@ -447,8 +447,8 @@ describe("collection view", function(){
     var PrependHtmlView = Backbone.Marionette.CollectionView.extend({
       itemView: ItemView,
 
-      appendHtml: function(collectionView, itemView){
-        collectionView.$el.prepend(itemView.el);
+      appendHtml: function(itemView){
+        this.$el.prepend(itemView.el);
       }
     });
 

--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -522,8 +522,8 @@ describe("composite view", function(){
       template: "#grid-template",
       itemView: GridRow,
 
-      appendHtml: function(cv, iv){
-        cv.$("tbody").append(iv.el);
+      appendHtml: function(iv){
+        this.$("tbody").append(iv.el);
       }
     });
 

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -240,7 +240,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // render the item view
   renderItemView: function(view, index) {
     view.render();
-    this.appendHtml(this, view, index);
+    this.appendHtml(view, index);
   },
 
   // Build an `itemView` for every model in the collection.
@@ -295,18 +295,18 @@ Marionette.CollectionView = Marionette.View.extend({
   // Append the HTML to the collection's `el`.
   // Override this method to do something other
   // then `.append`.
-  appendHtml: function(collectionView, itemView, index){
-    if (collectionView.isBuffering) {
+  appendHtml: function(itemView, index){
+    if (this.isBuffering) {
       // buffering happens on reset events and initial renders
       // in order to reduce the number of inserts into the
       // document, which are expensive.
-      collectionView.elBuffer.appendChild(itemView.el);
-      collectionView._bufferedChildren.push(itemView);
+      this.elBuffer.appendChild(itemView.el);
+      this._bufferedChildren.push(itemView);
     }
     else {
       // If we've already rendered the main collection, just
       // append the new items directly into the element.
-      collectionView.$el.append(itemView.el);
+      this.$el.append(itemView.el);
     }
   },
 

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -111,15 +111,15 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // `itemViewContainer` (a jQuery selector). Override this method to
   // provide custom logic of how the child item view instances have their
   // HTML appended to the composite view instance.
-  appendHtml: function(compositeView, itemView, index){
-    if (compositeView.isBuffering) {
-      compositeView.elBuffer.appendChild(itemView.el);
-      compositeView._bufferedChildren.push(itemView);
+  appendHtml: function(itemView, index){
+    if (this.isBuffering) {
+      this.elBuffer.appendChild(itemView.el);
+      this._bufferedChildren.push(itemView);
     }
     else {
       // If we've already rendered the main collection, just
       // append the new items directly into the element.
-      var $container = this.getItemViewContainer(compositeView);
+      var $container = this.getItemViewContainer(this);
       $container.append(itemView.el);
     }
   },


### PR DESCRIPTION
Would anyone ever call:

`someCv.appendHtml( someOtherCv, ... );`

or

`Marionette.CollectionView.prototype.appendHtml( someCv, ... );`?

Probably not, right? Should be changed in v2, methinks.
