### PR TITLE
Optimize Marionette.CollectionView..endBuffering

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -33,6 +33,9 @@ Marionette.CollectionView = Marionette.View.extend({
 
   endBuffering: function() {
     this.isBuffering = false;
+    if (!this._bufferedChildren.length) {
+      return;
+    }
     this.appendBuffer(this, this.elBuffer);
     this._triggerShowBufferedChildren();
     this.initRenderBuffer();


### PR DESCRIPTION
After upgrading from Marionette 1.1.0 to the latest version (1.6.2), the app broke down with the following error:

> Uncaught ItemViewContainerMissingError: The specified itemViewContainer was not found: tbody

(seems similar to #825).

In our case, the problem was solved after checking whether the buffer before continuing.
