### PR TITLE
Add support for extending className

### DIFF
--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -211,4 +211,75 @@ describe("base view", function(){
     });
   });
 
+
+  describe("when extending className", function() {
+    var ChildView, ParentView, GrandView, childView, parentView, grandView;
+
+    describe("when ancestors extend their className", function() {
+      beforeEach(function() {
+        GrandView = Marionette.View.extend({
+          className: 'grand',
+          constructor: function() {
+            this.extendClassName(GrandView.prototype);
+            Marionette.View.apply(this, arguments);
+          }
+        });
+
+        ParentView = GrandView.extend({
+          className: 'parent',
+          constructor: function() {
+            this.extendClassName(ParentView.prototype);
+            GrandView.apply(this, arguments);
+          }
+        });
+
+        ChildView = ParentView.extend({
+          className: 'child'
+        });
+
+        grandView = new GrandView();
+        parentView = new ParentView();
+        childView = new ChildView();
+      });
+
+      it('grand parent has its own className', function() {
+        expect(grandView.className()).toBe('grand');
+      });
+
+      it('parent has it and grands className', function() {
+        expect(parentView.className()).toBe('grand parent');
+      });
+
+      it('child has its ancestors classNames', function() {
+        expect(childView.className()).toBe('grand parent child');
+      });
+    });
+    describe("when child extends ancestors classNames", function() {
+      beforeEach(function() {
+        GrandView = Marionette.View.extend({
+          className: 'grand'
+        });
+
+        ParentView = GrandView.extend({
+          className: 'parent'
+        });
+
+        ChildView = ParentView.extend({
+          className: 'child',
+          initialize: function() {
+            this.extendClassName(ParentView.prototype, GrandView.prototype);
+          }
+        });
+
+        grandView = new GrandView();
+        parentView = new ParentView();
+        childView = new ChildView();
+      });
+
+      it('child has its ancestors classNames', function() {
+        expect(childView.className()).toBe('grand parent child');
+      });
+
+    });
+  });
 });

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -216,5 +216,19 @@ Marionette.View = Backbone.View.extend({
     // reset the ui element to the original bindings configuration
     this.ui = this._uiBindings;
     delete this._uiBindings;
+  },
+
+  mergeClassName: function() {
+    var classNames = _.map(arguments, function(className) {
+      return _.isFunction(className) ? className.call(this) : className;
+    }, this);
+
+    return _.uniq(classNames).join(' ');
+  },
+
+  extendClassName: function() {
+    _.each(arguments, function(prototype){
+      this.className = _.partial(prototype.mergeClassName, prototype.className, this.className);
+    }, this);
   }
 });


### PR DESCRIPTION
#### Overview

It's fair to say that both inheritance and mixin view strategies are common and have their flaws. One of the problems with inheritance is that Backbone extend doesn't provide any help when properties collide.

Recently, we've been dealing with views whose class names collide. The two things we want are 
- a way to specify if a className should be extended
- a hook for modifying how two classNames should be merged 

---
#### Examples

In practice this looks like this:

``` js
Overlay = Marionette.View.extend({
  className: 'overlay-view',
  constructor: function() {
    this.extendClassName(Overlay.prototype);
    Marionette.View.apply(this, arguments);
  }
});

OverlayStatus = Overlay.extend({
   className: 'status',
});

overlayStatus = new OverlayStatus();
overlayStatus->className(); // 'overlay-view status'
```

If extending child properties from a base class isn't your cup of tea, then this is for you:

``` js
Overlay = Marionette.View.extend({
  className: 'overlay-view'
});

OverlayStatus = Overlay.extend({
  className: 'status',
  initialize: function() {
    this.extendClassName(Overlay.prototype);
  }
});

overlayStatus = new OverlayStatus();
overlayStatus->className(); // 'overlay-view status'
```
#### Wins

What I like about this approach, is that it removes very common one off merge statements like `this.className = _.extend(Ovleray.prototype.className, this.className)` with something that is far more flexible going forward.

---
#### Subtle perks

These are pretty simple examples, so they skipped some nice wins that come with a more general solution.
- `extendClassName` wraps the initial className property, so it's infinitely extenable
- `mergeClassName` is invoked on the extended prototype, so each prototype can customize its merge strategy

---

This PR is based in part off of the discussion in #723. Curious to see what you guys think. Have you run into scenarios where this would break down?
