### PR TITLE
Add hard dependency on underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "backbone.babysitter": "~0.0.6",
     "backbone.wreqr": "~0.2.0",
-    "backbone": "~1.1.0"
+    "backbone": "~1.1.0",
+    "underscore": ">=1.4.4"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
Without this dependency listed in the dependency field, browserifying this library on its own yields this error:

`$ browserify .
Error: module "underscore" not found from "backbone.marionette/lib/core/amd/backbone.marionette.js"`

... since `require('underscore')` is explicitly called in the UMD wrapper. This also keeps the dependencies field in sync with the fields for jam.
