### PR TITLE
Add underscore to component dependencies

### DIFF
--- a/component.json
+++ b/component.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "marionettejs/backbone.babysitter": "*",
     "marionettejs/backbone.wreqr": "*",
-    "jashkenas/backbone": "*"
+    "jashkenas/backbone": "*",
+    "jashkenas/underscore": "*"
   },
   "scripts": [
     "lib/core/amd/backbone.marionette.js"


### PR DESCRIPTION
It seems that marionette cannot use backbone's underscore, so we have to declare the dependency in order to be able to use it.
