### PR TITLE
add more robust normalizeUIKeys

### DIFF
--- a/spec/javascripts/view.uiEventAndTriggers.spec.js
+++ b/spec/javascripts/view.uiEventAndTriggers.spec.js
@@ -2,7 +2,7 @@ describe("view ui event trigger configuration", function(){
   "use strict";
 
   describe("@ui syntax within events and triggers", function() {
-    var view, view2, fooHandler, attackHandler;
+    var view, view2, fooHandler, attackHandler, tapHandler;
 
     var View = Backbone.Marionette.ItemView.extend({
       ui: {
@@ -15,7 +15,12 @@ describe("view ui event trigger configuration", function(){
       },
 
       events: {
-        "click @ui.bar": "attack"
+        "click @ui.bar": "attack",
+        "click div:not(@ui.bar)": "tapper"
+      },
+
+      tapper: function() {
+        tapHandler();
       },
 
       attack: function() {
@@ -23,7 +28,7 @@ describe("view ui event trigger configuration", function(){
       },
 
       render: function(){
-        this.$el.html("<button class='foo'></button><div id='tap'></div>");
+        this.$el.html("<button class='foo'></button><div id='tap'></div><div class='lap'></div>");
       }
     });
 
@@ -61,7 +66,7 @@ describe("view ui event trigger configuration", function(){
 
       fooHandler = jasmine.createSpy("do:foo event handler");
       attackHandler = jasmine.createSpy("attack handler");
-
+      tapHandler = jasmine.createSpy("tap handler");
       spyOn(view, "attack").andCallThrough();
       view.on("do:foo", fooHandler);
       view2.on("do:foo", fooHandler);
@@ -70,6 +75,11 @@ describe("view ui event trigger configuration", function(){
     it("should correctly trigger an event", function(){
       view.$(".foo").trigger("click");
       expect(fooHandler).toHaveBeenCalled();
+    });
+
+    it("should correctly trigger a complex event", function(){
+      view.$(".lap").trigger("click");
+      expect(tapHandler).toHaveBeenCalled();
     });
 
     it("should correctly call an event", function(){

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -57,17 +57,20 @@ Marionette.View = Backbone.View.extend({
   // a given key for triggers and events
   // swaps the @ui with the associated selector
   normalizeUIKeys: function(hash) {
+    var _this = this;
     if (typeof(hash) === "undefined") {
       return;
     }
 
     _.each(_.keys(hash), function(v) {
-      var split = v.split("@ui.");
-      if (split.length === 2) {
-        hash[split[0]+this.ui[split[1]]] = hash[v];
+      var pattern = /@ui.[a-zA-Z_$0-9]*/g;
+      if (v.match(pattern)) {
+        hash[v.replace(pattern, function(r) {
+          return _this.ui[r.slice(4)];
+        })] = hash[v];
         delete hash[v];
       }
-    }, this);
+    });
 
     return hash;
   },


### PR DESCRIPTION
now we can do things like

``` js
{"click div:not(@ui.bar)": "tapper"}
```

which is not great, but sometimes you need to do it.

[fixes #914]
