### PR TITLE
Trigger 'onClose' with arguments supplied to 'close'

### DIFF
--- a/docs/marionette.controller.md
+++ b/docs/marionette.controller.md
@@ -52,30 +52,31 @@ unbinding all of the events that are directly attached to the controller
 instance, as well as those that are bound using the EventBinder from
 the controller.
 
-The `close` method will trigger a "close" event and corresponding
-`onClose` method call:
+Invoking the `close` method will trigger a "close" event and corresponding
+`onClose` method call. These calls will be passed any arguments `close`
+was invoked with.
 
 ```js
 // define a controller with an onClose method
 var MyController = Marionette.Controller.extend({
 
-  onClose: function(){
+  onClose: function(arg1, arg2){
     // put custom code here, to close this controller
   }
 
-})
+});
 
 // create a new controller instance
 var contr = new MyController();
 
 // add some event handlers
-contr.on("close", function(){ ... });
+contr.on("close", function(arg1, arg2){ ... });
 contr.listenTo(something, "bar", function(){...});
 
 // close the controller: unbind all of the
 // event handlers, trigger the "close" event and 
 // call the onClose method
-controller.close();
+controller.close(arg1, arg2);
 ```
 
 ## On The Name 'Controller'

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -101,23 +101,28 @@ are performed:
 * remove `this.el` from the DOM
 * unbind all `listenTo` events
 
-By providing an `onClose` event in your view definition, you can
+By providing an `onClose` method in your view definition, you can
 run custom code for your view that is fired after your view has been
-closed and cleaned up. This lets you handle any additional clean up
-code without having to override the `close` method.
+closed and cleaned up. The `onClose` method will be passed any arguments
+that `close` was invoked with. This lets you handle any additional clean
+up code without having to override the `close` method.
 
 ```js
-Backbone.Marionette.ItemView.extend({
-  onClose: function(){
+MyView = Backbone.Marionette.ItemView.extend({
+  onClose: function(arg1, arg2){
     // custom cleanup or closing code, here
   }
 });
+
+var v = new MyView();
+v.close(arg1, arg2);
 ```
 
 ## View onBeforeClose
 
 When closing a view, an `onBeforeClose` method will be called, if it
-has been provided. If this method returns `false`, the view will not
+has been provided. It will be passed any arguments that `close` was
+invoked with. If this method returns `false`, the view will not
 be closed. Any other return value (including null or undefined) will
 allow the view to be closed.
 

--- a/spec/javascripts/controller.spec.js
+++ b/spec/javascripts/controller.spec.js
@@ -74,7 +74,7 @@ describe("marionette controller", function(){
       spyOn(controller, "stopListening").andCallThrough();
       spyOn(controller, "unbind").andCallThrough();
 
-      controller.close();
+      controller.close(123, "second param");
     });
 
     it("should stopListening events", function(){
@@ -85,12 +85,12 @@ describe("marionette controller", function(){
       expect(controller.unbind).toHaveBeenCalled();
     });
 
-    it("should trigger a close event", function(){
-      expect(closeHandler).toHaveBeenCalled();
+    it("should trigger a close event with any arguments passed to close", function(){
+      expect(closeHandler).toHaveBeenCalledWith(123, "second param");
     });
 
-    it("should call an onClose method", function(){
-      expect(controller.onClose).toHaveBeenCalled();
+    it("should call an onClose method with any arguments passed to close", function(){
+      expect(controller.onClose).toHaveBeenCalledWith(123, "second param");
     });
   });
 

--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -48,17 +48,23 @@ describe("base view", function(){
     var close, view;
 
     beforeEach(function(){
-      view = new Marionette.View();
+      view = new (Marionette.View.extend({
+        onClose: jasmine.createSpy("onClose")
+      }));
 
       spyOn(view, "remove").andCallThrough();
       close = jasmine.createSpy("close");
       view.on("close", close);
 
-      view.close();
+      view.close(123, "second param");
     });
 
     it("should trigger the close event", function(){
       expect(close).toHaveBeenCalled();
+    });
+
+    it("should call an onClose method with any arguments passed to close", function(){
+      expect(view.onClose).toHaveBeenCalledWith(123, "second param");
     });
 
     it("should remove the view", function(){
@@ -114,11 +120,11 @@ describe("base view", function(){
         return undefined;
       };
 
-      view.close();
+      view.close(123, "second param");
     });
 
     it("should trigger the close event", function(){
-      expect(close).toHaveBeenCalled();
+      expect(close).toHaveBeenCalledWith(123, "second param");
     });
 
     it("should remove the view", function(){

--- a/src/marionette.controller.js
+++ b/src/marionette.controller.js
@@ -22,7 +22,8 @@ Marionette.Controller.extend = Marionette.extend;
 _.extend(Marionette.Controller.prototype, Backbone.Events, {
   close: function(){
     this.stopListening();
-    this.triggerMethod("close");
+    var args = Array.prototype.slice.call(arguments);
+    this.triggerMethod.apply(this, ["close"].concat(args));
     this.unbind();
   }
 });

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -160,9 +160,11 @@ Marionette.View = Backbone.View.extend({
   close: function(){
     if (this.isClosed) { return; }
 
+    var args = Array.prototype.slice.call(arguments);
+
     // allow the close to be stopped by returning `false`
     // from the `onBeforeClose` method
-    var shouldClose = this.triggerMethod("before:close");
+    var shouldClose = this.triggerMethod.apply(this, ["before:close"].concat(args));
     if (shouldClose === false){
       return;
     }
@@ -171,7 +173,7 @@ Marionette.View = Backbone.View.extend({
     // prevent infinite loops within "close" event handlers
     // that are trying to close other views
     this.isClosed = true;
-    this.triggerMethod("close");
+    this.triggerMethod.apply(this, ["close"].concat(args));
 
     // unbind UI elements
     this.unbindUIElements();


### PR DESCRIPTION
I have edited _marionette.view_ and _marionette.controller_ to trigger `onClose` with any arguments supplied to `close`. Only one line changed (in each file):

```
this.triggerMethod("close");
```

Became:

```
this.triggerMethod.apply(this, ["close"].concat(slice(arguments)));
```

---

**Why:** There are times when `onClose` may need to behave differently, depending on how it's invoked. This added flexibility allows for "smarter" cleanup, especially of child views. In the system I'm working on, we  often pass a boolean stating whether or not child views' `$el` should be removed from the DOM.

Contrived example:

```
var view = new (Marionette.View.extend({
  onClose: function(destroyChildren) {
    if (destroyChildren) {
      // do it
    }
  }
}));

view.close(true);
```

**How:** This issue is easily solved by appending `arguments` to the existing `triggerMethod("close")` calls.

```
close: function(){
  ...
  this.triggerMethod.apply(this, ["close"].concat(slice(arguments)));
  ...
}
```

Since other code (_marionette.itemview_, etc) takes care apply arguments when calling `close`, only _marionette.view_ needs to change.

I applied this same change to _marionette.controller_.

---

**Additional info:** The pull request is split into 3 commits Chronologically, they are:
1. Change to _marionette.view_ and updated test
2. Change to _marionette.controller_ and updated test
3. Files generated from running `grunt [default]` (updated lib, code coverage, etc). I'm not sure if these are generally committed with pull requests -- this is my first! The diff shows a bunch of `listenTo` syntax changes in the distribution files that are not related to my change. If it'd be better to submit the pull request without this commit, let me know.
