### PR TITLE
Add keepRunner to gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,6 +119,7 @@ module.exports = function(grunt) {
           '<%= assets.babysitter %>',
           '<%= assets.wreqr %>',
         ],
+        keepRunner: true
       },
       coverage : {
         src : '<%= jasmine.marionette.src %>',


### PR DESCRIPTION
Before jasmine runs the tests through phantom, it creates a `_SpecRunner.html` file with the current marionette source and tests. If you're stuck trying to debug a test, it's totally fair game to open the runner file in chrome and set a breakpoint. 

The thing is, that by default jasmine-grunt will throw away the runner file. This config changes that so the runner file sticks around. `_SpecRunner.html` is already in the `.gitignore`. 

Leaving it around and maybe adding some documentation around this in the contributing guidelines should make it easier for anyone looking to hack on marionette. 

![](http://f.cl.ly/items/3S0D320s1e1E0e3s3q3p/Image%202014-03-03%20at%2011.39.09%20AM.png)
