### PR TITLE
Resolves an issue where a module's initialize would be called twice

### DIFF
--- a/spec/javascripts/module.spec.js
+++ b/spec/javascripts/module.spec.js
@@ -18,10 +18,12 @@ describe("application modules", function(){
 
     it("should notify me before initialization starts", function(){
       expect(initializeBefore).toHaveBeenCalled();
+      expect(initializeBefore.callCount).toBe(1);
     });
 
     it("should notify me after initialization", function(){
       expect(initializeAfter).toHaveBeenCalled();
+      expect(initializeAfter.callCount).toBe(1);
     });
 
     it("should add an object of that name to the app", function(){
@@ -51,10 +53,12 @@ describe("application modules", function(){
 
     it("should notify me before initialization starts", function(){
       expect(initializeBefore).toHaveBeenCalled();
+      expect(initializeBefore.callCount).toBe(1);
     });
 
     it("should notify me after initialization", function(){
       expect(initializeAfter).toHaveBeenCalled();
+      expect(initializeAfter.callCount).toBe(1);
     });
 
     it("should add an object of that name to the app", function(){
@@ -66,14 +70,16 @@ describe("application modules", function(){
     });
   });
   describe("when specifying a module on an application with options object", function(){
-    var MyApp, ModuleClass, myModule, initializeBefore, initializeAfter;
+    var MyApp, ModuleClass, myModule, initializer, initializeBefore, initializeAfter;
 
     beforeEach(function(){
+      initializer = jasmine.createSpy("initialize handler");
       initializeBefore = jasmine.createSpy("before handler");
       initializeAfter = jasmine.createSpy("after handler");
 
       MyApp = new Backbone.Marionette.Application();
       ModuleClass = Backbone.Marionette.Module.extend({
+          initialize: initializer,
           onBeforeStart: initializeBefore,
           onStart: initializeAfter
       });
@@ -82,12 +88,19 @@ describe("application modules", function(){
       myModule.start();
     });
 
+    it("should run the initialize function one time", function(){
+      expect(initializer).toHaveBeenCalled();
+      expect(initializer.callCount).toBe(1);
+    });
+
     it("should notify me before initialization starts", function(){
       expect(initializeBefore).toHaveBeenCalled();
+      expect(initializeBefore.callCount).toBe(1);
     });
 
     it("should notify me after initialization", function(){
       expect(initializeAfter).toHaveBeenCalled();
+      expect(initializeAfter.callCount).toBe(1);
     });
 
     it("should add an object of that name to the app", function(){
@@ -100,14 +113,16 @@ describe("application modules", function(){
   });
 
   describe("when specifying a module on an application with a module class", function(){
-    var MyApp, ModuleClass, myModule, initializeBefore, initializeAfter;
+    var MyApp, ModuleClass, myModule, initializer, initializeBefore, initializeAfter;
 
     beforeEach(function(){
+      initializer = jasmine.createSpy("initialize");
       initializeBefore = jasmine.createSpy("before handler");
       initializeAfter = jasmine.createSpy("after handler");
 
       MyApp = new Backbone.Marionette.Application();
       ModuleClass = Backbone.Marionette.Module.extend({
+          initialize: initializer,
           onBeforeStart: initializeBefore,
           onStart: initializeAfter
       });
@@ -116,12 +131,19 @@ describe("application modules", function(){
       myModule.start();
     });
 
+    it("should run the initialize function one time", function(){
+      expect(initializer).toHaveBeenCalled();
+      expect(initializer.callCount).toBe(1);
+    });
+
     it("should notify me before initialization starts", function(){
       expect(initializeBefore).toHaveBeenCalled();
+      expect(initializeBefore.callCount).toBe(1);
     });
 
     it("should notify me after initialization", function(){
       expect(initializeAfter).toHaveBeenCalled();
+      expect(initializeAfter.callCount).toBe(1);
     });
 
     it("should add an object of that name to the app", function(){

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -192,7 +192,7 @@ _.extend(Marionette.Module, {
     var fn;
     var startWithParent;
 
-    if (_.isFunction(def)){
+    if (_.isFunction(def) && !(def.prototype instanceof Marionette.Module)){
       // if a function is supplied for the module definition
       fn = def;
       startWithParent = true;


### PR DESCRIPTION
#975 describes an issue regarding modules being initialized with a custom class as the second parameter. ~~@jasonLaster brought to light a _second_ issue regarding sub modules.~~ This PR is for the _first_ issue brought up there. ~~A second commit/PR will follow for submodules.~~

Resolves #975 

**Upon further research it was determined that the second issue does not exist**
