### PR TITLE
Remove unnecessary jquery dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "backbone.babysitter": "~0.1.0",
     "backbone.wreqr": "~1.0.0",
     "backbone": "1.0.0 - 1.1.2",
-    "underscore": "1.4.4 - 1.6.0",
-    "jquery": "1.8.0 - 1.11.0"
+    "underscore": "1.4.4 - 1.6.0"
   },
   "devDependencies": {
     "grunt": "0.4.2",


### PR DESCRIPTION
Since Marionette simply uses `Backbone.$`, and doesn't explicitly `require('jquery')`, this dependency [is no longer needed](https://github.com/jashkenas/backbone/issues/2997) in the package json.

Also, the wreqr and babysitter versions referenced here each pull in their own jquery as well. Updating to the latest versions of these libraries which don't include jquery (for the same reasons) would be great.
