### PR TITLE
Add BehaviorClass property

### DIFF
--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -6,42 +6,73 @@ describe("Behaviors", function(){
   });
 
   describe("behavior parsing", function() {
-    var V, Obj, V2
+    var Obj, View, Tooltip;
 
     beforeEach(function() {
+      ToolTip = sinon.spy();
       Obj = {
-        ToolTip: sinon.spy()
+        ToolTip: ToolTip
       };
+      Marionette.Behaviors.behaviorsLookup = Obj;
+    });
 
-      V = Marionette.ItemView.extend({
-        behaviors: {
+    describe("when one behavior", function() {
+      beforeEach(function() {
+        View = Marionette.ItemView.extend({
+          behaviors: {
             ToolTip: {
               position: "top"
             }
           }
+        });
+
+        new View;
       });
 
-      V2 = Marionette.ItemView.extend({
-        behaviors: {
-          ToolTip: {
-            position: "top"
+      it("should instantiate the tooltip behavior", function() {
+        expect(Obj.ToolTip).toHaveBeenCalled();
+      });
+    });
+
+    describe("when multiple behaviors", function() {
+      beforeEach(function() {
+        View = Marionette.ItemView.extend({
+          behaviors: [
+            {
+              ToolTip: {
+                position: "top"
+              }
+
+            }
+          ]
+        });
+
+        new View;
+      });
+
+      it("should instantiate the tooltip behavior", function() {
+        expect(Obj.ToolTip).toHaveBeenCalled();
+      });
+    });
+
+    describe("when behavior class is provided", function() {
+      beforeEach(function() {
+        View = Marionette.ItemView.extend({
+          behaviors: {
+            ToolTip: {
+              BehaviorClass: ToolTip,
+              position: "top"
+            }
           }
-        }
+        });
+
+        new View;
       });
 
-      Marionette.Behaviors.behaviorsLookup = Obj;
+      it("should instantiate the tooltip behavior", function() {
+        expect(Obj.ToolTip).toHaveBeenCalled();
+      });
     });
-
-    it("should instantiate the tooltip behavior", function() {
-      new V;
-      expect(Obj.ToolTip).toHaveBeenCalled();
-    });
-
-    it("should instantiate the tooltip behavior on a non ordered behavior list", function() {
-      new V2;
-      expect(Obj.ToolTip).toHaveBeenCalled();
-    });
-
   });
 
   describe("behavior initialize", function() {

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -119,9 +119,29 @@ Marionette.Behaviors = (function(Marionette, _) {
       throw new Error("You must define where your behaviors are stored. See http://www.marionette.com/using-behaviors");
     },
 
-    parseBehaviors: function(view, behaviors) {
-      return _.map(behaviors, function(options, key) {
-        return new (_.result(Behaviors, "behaviorsLookup")[key])(options, view);
+    getBehaviorClass: function(options, key) {
+      if (options.BehaviorClass) {
+        return options.BehaviorClass;
+      }
+
+      return Behaviors.behaviorsLookup[key];
+    },
+
+    parseBehaviors: function(view, behaviors){
+      // if behaviors is an array
+      if (_.isArray(behaviors)) {
+        return _.map(behaviors, function(v){
+          var key     = _.keys(v)[0];
+          var options = _.values(v)[0];
+          var BehaviorClass = Behaviors.getBehaviorClass(options, key);
+          return new BehaviorClass(options, view);
+        });
+      }
+
+      // if behaviors is a flat object
+      return _.map(behaviors, function(options, key){
+        var BehaviorClass = Behaviors.getBehaviorClass(options, key);
+        return new BehaviorClass(options, view);
       });
     }
   });


### PR DESCRIPTION
There are times when you want to circumvent behaviorLookup, and provide the Behavior class directly. One example of this is when building bundles with requirejs. It's nice to be able to specify in the dependency that you want a view to have a behavior.

``` js
define(
   ['Backbone', 'OverlayBehavior'], 
   function(Backbone, OverlayBehavior) {

   var StatusOverlay = Backbone.Marionette.ItemView.extend({
       behaviors: {
           Overlay: {
              BehaviorClass: OverlayBehavior
           }
        },

        // other stuff
    });
});
```
