### PR TITLE
Fixes #877 - avoids re-rendering views on Region.show

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -150,8 +150,8 @@ describe("region", function(){
       expect(myRegion.open).not.toHaveBeenCalledWith(view);
     });
 
-    it("should call 'render' on the view", function(){
-      expect(view.render).toHaveBeenCalled();
+    it("should not call 'render' on the view", function(){
+      expect(view.render).not.toHaveBeenCalled();
     });
   });
 

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -126,9 +126,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
       this.close();
     }
 
-    view.render();
-
     if (isDifferentView || isViewClosed) {
+      view.render();
       this.open(view);
     }
 


### PR DESCRIPTION
As proposed by @jmeas in #877, Region.show(view) should not call view.render if the view is already shown in the region and is not closed.

Fixes #877
