### PR TITLE
moved babysitter and wreqr to devDependencies again (see pull #677)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,12 +37,12 @@
   "dependencies": {
     "backbone": "1.0.0 - 1.1.2",
     "underscore": "1.4.4 - 1.6.0",
-    "backbone.babysitter": "~0.1.0",
-    "backbone.wreqr": "~1.0.0",
     "jquery": "1.8.0 - 1.11.0"
   },
   "devDependencies": {
     "sinonjs": "1.7.3",
-    "jasmine-sinon": "0.3.1"
+    "jasmine-sinon": "0.3.1",
+    "backbone.babysitter": "~0.1.0",
+    "backbone.wreqr": "~1.0.0"
   }
 }


### PR DESCRIPTION
Installing marionette through bower will also install backbone.wreqr and backbone.babysitter, which is unnecessary since lib/backbone.marionette.js includes them already.
EDIT:
Turns out that #860 broke the original fix #677
Current (1.6.4) core amd version includes wreqr/babysitter as dependencies so both amd and non-amd  bower installs should be ok with this. (fingers crossed)
