### PR TITLE
Revert "- Remove reference to dev branch from contrib doc"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,15 @@ pull request on a topic branch. If your pull request contains
 commits or other changes that are not related to the pull 
 request, we will ask you to re-do your pull request.
 
+### Branch from "dev" not "master"
+
+The "master" branch of the Marionette repository is for 
+production release code, and documentation updates only. Never 
+create a pull request from the master branch. Always create 
+a branch for your work from the "dev" branch. This will 
+facilitate easier pull request management for the continuous 
+work that is done in the dev branch.
+
 ### Submit Specs With Your Pull Request
 
 Whenever possible, submit the specs (unit tests) that 


### PR DESCRIPTION
This reverts commit c21a5c465e266f5c7aaf858edb0c6a9fcee019d1.

We are using the dev branch again.
