### PR TITLE
Add before:show events

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -187,6 +187,8 @@ MyApp.someRegion.attachView(myView);
 A region will raise a few events when showing and
 closing views:
 
+* "before:show" / `onBeforeShow` - Called on the view instance after the view has been rendered, but before its been displayed.
+* "before:show" / `onBeforeShow` - Called on the region instance after the view has been rendered, but before its been displayed.
 * "show" / `onShow` - Called on the view instance when the view has been rendered and displayed.
 * "show" / `onShow` - Called on the region instance when the view has been rendered and displayed.
 * "close" / `onClose` - Called when the view has been closed.
@@ -195,6 +197,11 @@ These events can be used to run code when your region
 opens and closes views.
 
 ```js
+MyApp.mainRegion.on("before:show", function(view){
+  // manipulate the `view` or do something extra
+  // with the region via `this`
+});
+
 MyApp.mainRegion.on("show", function(view){
   // manipulate the `view` or do something extra
   // with the region via `this`
@@ -208,12 +215,19 @@ MyApp.mainRegion.on("close", function(view){
 MyRegion = Backbone.Marionette.Region.extend({
   // ...
 
+  onBeforeShow: function(view) {
+    // the `view` has not been shown yet
+  },
+
   onShow: function(view){
     // the `view` has been shown
   }
 });
 
 MyView = Marionette.ItemView.extend({
+  onBeforeShow: function() {
+    // called before the view has been shown
+  },
   onShow: function(){
     // called when the view has been shown
   }

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -127,6 +127,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     }
 
     view.render();
+    Marionette.triggerMethod.call(this, "before:show", view);
+    Marionette.triggerMethod.call(view, "before:show");
 
     if (isDifferentView || isViewClosed) {
       this.open(view);


### PR DESCRIPTION
Earlier today, jarrodpayne raised an issue in #marionette and stackOverflow [question](https://stackoverflow.com/questions/22442198/can-i-render-views-to-layout-regions-before-showing-that-layout-in-a-parent-regi) about rendering a nested layout before its added to the DOM. 

I think a "before:show" event in `region.show` would be an elegant way to solve the problem. 

``` js
var LayoutView = Marionette.Layout.extend({
    template: "#layout-template",
    regions: {
        one: ".one",
        two: ".two",
        three: ".three"
    },

    onBeforeShow: function() {
       this.one.show(new SubView());
        var col = new Backbone.Collection([{ p: 1}, {p: 2}, {p: 3}]);
        this.two.show(new CollectionView({
            collection: col
        }));
        this.three.show(new SubView());
    }
});
```

This way, `layout.el` would be fully rendered before `region.$el` is reset. 
