### PR TITLE
Call stopListening on module stop

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -431,7 +431,8 @@ MyApp.module("Foo.Bar").start();
 A module can be stopped, or shut down, to clear memory and resources when
 the module is no longer needed. Like the starting of modules, stopping is done
 in a depth-first hierarchy traversal. That is, a hierarchy of modules like
-`Foo.Bar.Baz` will stop `Baz` first, then `Bar`, and finally `Foo`.
+`Foo.Bar.Baz` will stop `Baz` first, then `Bar`, and finally `Foo`. Also `stopListening`
+will be called to unbind all events binded using `listenTo` method.
 
 To stop a module and its children, call the `stop` method of a module.
 

--- a/spec/javascripts/module.stop.spec.js
+++ b/spec/javascripts/module.stop.spec.js
@@ -22,6 +22,8 @@ describe("module stop", function(){
       mod1.on("before:stop", beforeStop);
       mod1.on("stop", stop);
 
+      spyOn(mod1, "stopListening");
+
       mod2 = App.module("Mod1.Mod2");
       mod3 = App.module("Mod1.Mod3");
 
@@ -57,6 +59,9 @@ describe("module stop", function(){
       expect(App.module("Mod1")).toBe(mod1);
     });
 
+    it("should call stopListening", function(){
+      expect(mod1.stopListening).toHaveBeenCalledWith();
+    });
   });
 
   describe("when stopping a module that has not been started", function(){

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -89,6 +89,8 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
     this._initializerCallbacks.reset();
     this._finalizerCallbacks.reset();
 
+    this.stopListening();
+
     Marionette.triggerMethod.call(this, "stop");
   },
 


### PR DESCRIPTION
When answering [the question on stack overflow about event unbinding](http://stackoverflow.com/questions/22410200/marionette-js-questions-about-events-and-how-to-correctly-unbind-them/22435769) I've noticed that we don't unbind events when calling stop on module.

The documentation said that:

> A module can be stopped, or shut down, to clear memory and resources when the module is no longer needed.

But actually it doesn't and it can be reason for some memory leaks.

So I propose to call `stopListening` on module in `stop` method.
