### PR TITLE
allow for string based behavior events

### DIFF
--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -125,6 +125,7 @@ describe("Behaviors", function(){
     beforeEach(function() {
       spy = sinon.spy();
       spy2 = sinon.spy();
+      spy3 = sinon.spy();
 
       Obj = {
         ToolTip: Marionette.Behavior.extend({
@@ -136,6 +137,13 @@ describe("Behaviors", function(){
           events: {
             "click": spy2
           }
+        }),
+        Hover: Marionette.Behavior.extend({
+          events: {
+            "click": "onClick"
+          },
+
+          onClick: spy3
         })
       };
 
@@ -143,7 +151,8 @@ describe("Behaviors", function(){
         template: _.template(""),
         behaviors: {
           ToolTip: {},
-          DropDown: {}
+          DropDown: {},
+          Hover: {}
         }
       });
 
@@ -157,6 +166,14 @@ describe("Behaviors", function(){
 
       expect(spy).toHaveBeenCalled();
       expect(spy2).toHaveBeenCalled();
+    });
+
+    it("should call the behaviors event when event handler is a string", function() {
+      v = new V();
+      v.render();
+      v.$el.click();
+
+      expect(spy3).toHaveBeenCalled();
     });
   });
 

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -86,7 +86,10 @@ Marionette.Behaviors = (function(Marionette, _) {
           // append white-space at the end of each key to prevent behavior key collisions
           // this is relying on the fact backbone events considers "click .foo" the same  "click .foo "
           var whitespace = (new Array(i+1)).join(" ");
-          _events[key + whitespace] = behaviorEvents[key];
+          var eventKey   = key + whitespace;
+          var handler    = _.isFunction(behaviorEvents[key]) ? behaviorEvents[key] : b[behaviorEvents[key]];
+
+          _events[eventKey] = handler;
         });
 
         _behaviorsEvents = _.extend(_behaviorsEvents, _events);


### PR DESCRIPTION
fixes #1041

problem was caused by backbone's  `delegateEvents`. It expects if
the method is not a function that the named function is a property of
the view.
