### PR TITLE
Ensure that behavior events are bound to the behavior.

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -77,7 +77,7 @@ var CloseWarn = Marionette.Behavior.extend({
 		"message": "you are closing!"
 	},
 
-	// behaviors have events that are bound to the views DOM
+	// Behaviors have events that are bound to the behavior instance
 	events: {
 		"click .close": "warnBeforeClose"
 	},

--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -164,8 +164,8 @@ describe("Behaviors", function(){
       v.render();
       v.$el.click();
 
-      expect(spy).toHaveBeenCalled();
-      expect(spy2).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledOn(sinon.match.instanceOf(Marionette.Behavior));
+      expect(spy2).toHaveBeenCalledOn(sinon.match.instanceOf(Marionette.Behavior));
     });
 
     it("should call the behaviors event when event handler is a string", function() {
@@ -173,7 +173,7 @@ describe("Behaviors", function(){
       v.render();
       v.$el.click();
 
-      expect(spy3).toHaveBeenCalled();
+      expect(spy3).toHaveBeenCalled(sinon.match.instanceOf(Marionette.Behavior));
     });
   });
 

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -89,7 +89,7 @@ Marionette.Behaviors = (function(Marionette, _) {
           var eventKey   = key + whitespace;
           var handler    = _.isFunction(behaviorEvents[key]) ? behaviorEvents[key] : b[behaviorEvents[key]];
 
-          _events[eventKey] = handler;
+          _events[eventKey] = _.bind(handler, b);
         });
 
         _behaviorsEvents = _.extend(_behaviorsEvents, _events);


### PR DESCRIPTION
According to [the docs](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.behavior.md#using), Behaviors have their events bound to the View:

```
// behaviors have events that are bound to the views DOM
events: {
  "click .close": "warnBeforeClose"
},
```

However, the next function uses a reference to the _Behavior_:

```
warnBeforeClose: function() {
    alert(this.options.message);
    // every Behavior has a hook into the
    // view that it is attached to
    this.view.close();
}
```

If the function is the desired behavior (:smirk:) and events should be bound to the **behavior**, this PR fixes the issue. If not, I can fix up the function in the docs.

FYI - I couldn't update the Behaviors specs. I would have normally used `expect(spy).toHaveBeenCalledOn(behavior)`, but there aren't any references to the Behaviors (that I know of).
