### PR TITLE
Add @ui interpolation for behavior events

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -26,24 +26,24 @@ Here is an example of a simple `itemView`. Let's take a stab at simplifying it, 
 
 ```js
 var MyView = Marionette.ItemView.extend({
-	ui: {
-        "close": ".close-btn"
-	},
+  ui: {
+    "close": ".close-btn"
+  },
 
-	events: {
-	    "click @ui.close": "warnBeforeClose"
-	},
+  events: {
+    "click @ui.close": "warnBeforeClose"
+  },
 
-	warnBeforeClose: function() {
-	    alert("you are closing all your data is now gone!");
-	    this.close();
-	},
+  warnBeforeClose: function() {
+    alert("you are closing all your data is now gone!");
+    this.close();
+  },
 
-	onShow: function() {
-	   this.$('.tooltip').tooltip({
-	     text: "what a nice mouse you have"
-	   });
-	}
+  onShow: function() {
+    this.ui.close.tooltip({
+      text: "what a nice mouse you have"
+    });
+  }
 });
 ```
 
@@ -55,14 +55,18 @@ The options for each behavior are also passed to said Behavior during initializa
 
 ```js
 var MyView = Marionette.ItemView.extend({
-	behaviors: {
-		CloseWarn: {
-			message: "you are closing all your data is now gone!"
-		},
-		ToolTip: {
-			text: "what a nice mouse you have"
-		}
-	}
+  ui: {
+    "close": ".close-btn"
+  },
+
+  behaviors: {
+    CloseWarn: {
+      message: "you are closing all your data is now gone!"
+    },
+    ToolTip: {
+      text: "what a nice mouse you have"
+    }
+  }
 });
 ```
 
@@ -70,24 +74,24 @@ Now let's create the `CloseWarn` behavior.
 
 ```js
 var CloseWarn = Marionette.Behavior.extend({
-	// you can set default options
-	// just like you can in your Backbone Models
-	// they will be overriden if you pass in an option with the same key
-	defaults: {
-		"message": "you are closing!"
-	},
+  // you can set default options
+  // just like you can in your Backbone Models
+  // they will be overriden if you pass in an option with the same key
+  defaults: {
+    "message": "you are closing!"
+  },
 
-	// Behaviors have events that are bound to the behavior instance
-	events: {
-		"click .close": "warnBeforeClose"
-	},
+  // behaviors have events that are bound to the views DOM
+  events: {
+    "click @ui.close": "warnBeforeClose"
+  },
 
-	warnBeforeClose: function() {
-		alert(this.options.message);
-	  	// every Behavior has a hook into the
-	  	// view that it is attached to
-	  	this.view.close();
-	}
+  warnBeforeClose: function() {
+    alert(this.options.message);
+    // every Behavior has a hook into the
+    // view that it is attached to
+    this.view.close();
+  }
 });
 ```
 
@@ -95,14 +99,15 @@ And onto the `Tooltip` behavior.
 
 ```js
 var ToolTip = Marionette.Behavior.extend({
-	onShow: function() {
-		// this.$ is another example of something
-		// that is exposed to each behavior instance
-  		// of the view
-  		this.$('.tooltip').tooltip({
-	     	text: this.options.text
-  		});
-	}
+  ui: {
+    tooltip: '.tooltip'
+  },
+
+  onShow: function() {
+    this.ui.tooltip.tooltip({
+      text: this.options.text
+    });
+  }
 });
 ```
 

--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -178,28 +178,51 @@ describe("Behaviors", function(){
   });
 
   describe("behavior UI", function() {
-    var V, hold, spy, onShowSpy, onCloseSpy, Layout;
+    var V, hold, spy, onShowSpy, onCloseSpy, Layout, testBehavior;
 
     beforeEach(function() {
       hold = {};
       spy = new sinon.spy();
       onShowSpy = new sinon.spy();
       onCloseSpy = new sinon.spy();
+      onDogeClickSpy = new sinon.spy();
+      onCoinsClickSpy = new sinon.spy();
+
       hold.test = Marionette.Behavior.extend({
         ui: {
-          'doge': '.doge'
+          doge: '.doge'
         },
+
+        initialize: function() {
+          testBehavior = this;
+        },
+
+        events: {
+          'click @ui.doge': 'onDogeClick',
+          'click @ui.coins': 'onCoinsClick'
+        },
+
         onRender: function() {
           spy(this.ui.doge.length);
         },
+
         onShow: onShowSpy,
-        onClose: onCloseSpy
+
+        onClose: onCloseSpy,
+
+        onDogeClick: onDogeClickSpy,
+
+        onCoinsClick: onCoinsClickSpy
+
       });
 
       Marionette.Behaviors.behaviorsLookup = hold;
 
       V = Marionette.ItemView.extend({
-        template: _.template('<div class="doge"></div>'),
+        template: _.template('<div class="doge"></div><div class="coins"></div>'),
+        ui: {
+          coins: '.coins'
+        },
         behaviors: {
           test: {}
         }
@@ -220,6 +243,22 @@ describe("Behaviors", function(){
       v = new V;
       v.render();
       expect(spy).toHaveBeenCalled(1);
+    });
+
+    it("should handle behavior ui click event", function() {
+      v = new V;
+      v.render();
+      v.$el.find('.doge').click();
+
+      expect(onDogeClickSpy).toHaveBeenCalledOn(testBehavior);
+    });
+
+    it("should handle view ui click event", function() {
+      v = new V;
+      v.render();
+      v.$el.find('.coins').click();
+
+      expect(onCoinsClickSpy).toHaveBeenCalledOn(testBehavior);
     });
 
     it("should call onShow", function() {

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -77,10 +77,15 @@ Marionette.Behaviors = (function(Marionette, _) {
 
     behaviorEvents: function(behaviorEvents, behaviors) {
       var _behaviorsEvents = {};
+      var viewUI = _.result(this, 'ui');
 
       _.each(behaviors, function(b, i) {
-        var behaviorEvents = _.result(b, 'events') || {};
         var _events = {};
+        var behaviorEvents = _.result(b, 'events') || {};
+        var behaviorUI = _.result(b, 'ui');
+        var ui = _.extend({}, viewUI, behaviorUI);
+
+        behaviorEvents = Marionette.normalizeUIKeys(behaviorEvents, ui);
 
         _.each(_.keys(behaviorEvents), function(key) {
           // append white-space at the end of each key to prevent behavior key collisions

--- a/src/marionette.helpers.js
+++ b/src/marionette.helpers.js
@@ -53,3 +53,25 @@ Marionette.normalizeMethods = function(hash) {
   }, this);
   return normalizedHash;
 };
+
+
+// allows for the use of the @ui. syntax within
+// a given key for triggers and events
+// swaps the @ui with the associated selector
+Marionette.normalizeUIKeys = function(hash, ui) {
+  if (typeof(hash) === "undefined") {
+    return;
+  }
+
+  _.each(_.keys(hash), function(v) {
+    var pattern = /@ui.[a-zA-Z_$0-9]*/g;
+    if (v.match(pattern)) {
+      hash[v.replace(pattern, function(r) {
+        return ui[r.slice(4)];
+      })] = hash[v];
+      delete hash[v];
+    }
+  });
+
+  return hash;
+};

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -55,26 +55,10 @@ Marionette.View = Backbone.View.extend({
     return _.extend(target, templateHelpers);
   },
 
-  // allows for the use of the @ui. syntax within
-  // a given key for triggers and events
-  // swaps the @ui with the associated selector
+
   normalizeUIKeys: function(hash) {
-    var _this = this;
-    if (typeof(hash) === "undefined") {
-      return;
-    }
-
-    _.each(_.keys(hash), function(v) {
-      var pattern = /@ui.[a-zA-Z_$0-9]*/g;
-      if (v.match(pattern)) {
-        hash[v.replace(pattern, function(r) {
-          return _.result(_this, "ui")[r.slice(4)];
-        })] = hash[v];
-        delete hash[v];
-      }
-    });
-
-    return hash;
+    var ui = _.result(this, 'ui');
+    return Marionette.normalizeUIKeys(hash, ui);
   },
 
   // Configure `triggers` to forward DOM events to view


### PR DESCRIPTION
Fixes #1055

This makes `test.events` work. 

``` js
V = Marionette.ItemView.extend({
  template: _.template('<div class="doge"></div><div class="coins"></div>'),
  ui: {
    coins: '.coins'
  },
  behaviors: {
    test: {}
  }
});

test = Marionette.Behavior.extend({
  ui: {
    doge: '.doge'
  },

  events: {
    'click @ui.doge': 'onDogeClick',
    'click @ui.coins': 'onCoinsClick'
  },

  onDogeClick: onDogeClickSpy,

  onCoinsClick: onCoinsClickSpy

});
```
