### PR TITLE
A Behavior's $el incorrectly calls the view's $el as a function

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -10,7 +10,7 @@ A `Behavior` is an  isolated set of DOM / user interactions that can be mixed in
 * [API](#api)
   * [Event proxy](#the-event-proxy)
   * [$](#$)
-  * [$el](#$el)
+  * [$el](#el)
   * [Defaults](#defaults)
   * [View](#view)
 
@@ -151,12 +151,12 @@ Marionette.Behavior.extend({
 	});
 ```
 
-### $el
-`$el` is a direct proxy of the views `el` cached as a jquery selector.
+### $el()
+`$el()` is convenience method to get the `$el` from the view.
 ```js
 Marionette.Behavior.extend({
 	onShow: function() {
-		this.$el.fadeOut('slow')
+		this.$el().fadeOut('slow');
 	}
 });
 ```
@@ -170,7 +170,7 @@ Marionette.Behavior.extend({
 	defaults: function() {
 		return {
 			'deepSpace': 9
-		}
+		};
 	}
 });
 ```

--- a/docs/marionette.behaviors.md
+++ b/docs/marionette.behaviors.md
@@ -47,7 +47,7 @@ This method has a default implementation that is simple to override. It is respo
 ```js
 getBehaviorClass: function(options, key) {
     if (options.BehaviorClass) {
-    return options.BehaviorClass;
+        return options.BehaviorClass;
     }
 
     return Behaviors.behaviorsLookup[key];

--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -324,4 +324,36 @@ describe("Behaviors", function(){
       expect(spy).toHaveBeenCalled();
     });
   });
+
+  describe("behavior $el", function() {
+
+    var spy, FakeView;
+
+    beforeEach(function() {
+      spy = sinon.spy();
+      var FakeBehavior = Marionette.Behavior.extend({
+        onRender: function() {
+          spy(this.$el());
+        }
+      });
+      Marionette.Behaviors.behaviorsLookup = {
+        FakeBehavior: FakeBehavior
+      };
+
+      FakeView = Marionette.View.extend({
+        behaviors: {
+          FakeBehavior: {}
+        }
+      });
+    });
+
+    it("proxies to the $el from the view", function() {
+      var view = new FakeView();
+
+      view.triggerMethod('render');
+
+      expect(spy).toHaveBeenCalledWith(view.$el);
+    });
+
+  });
 });

--- a/src/marionette.behavior.js
+++ b/src/marionette.behavior.js
@@ -11,7 +11,7 @@ Marionette.Behavior = (function(_, Backbone){
 
     // proxy behavior $el method to the view
     this.$el = function() {
-      return this.view.$el.apply(this.view, arguments);
+      return this.view.$el;
     };
 
     this.initialize.apply(this, arguments);


### PR DESCRIPTION
1. The current way `Behavior#$el` works is incorrect. It attempts to call `this.view.$el` as a function. However, it is a jQuery **object**, not a function. Therefore, you'd get an error when attempting to call `this.$el()` from inside of a Behavior. I've fixed `$el` to always return the `view.$el` as an object.
2. The documentation states that `$el` is a cached jQuery selector. However, it is defined as a function. I think that It _should_ be defined as function because the `$el` could change on the view. I've corrected the documentation for this.
