### PR TITLE
Revert "Call stopListening on module stop"

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -442,8 +442,7 @@ MyApp.module("Foo.Bar").start();
 A module can be stopped, or shut down, to clear memory and resources when
 the module is no longer needed. Like the starting of modules, stopping is done
 in a depth-first hierarchy traversal. That is, a hierarchy of modules like
-`Foo.Bar.Baz` will stop `Baz` first, then `Bar`, and finally `Foo`. Also `stopListening`
-will be called to unbind all events binded using `listenTo` method.
+`Foo.Bar.Baz` will stop `Baz` first, then `Bar`, and finally `Foo`.
 
 To stop a module and its children, call the `stop` method of a module.
 

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -89,8 +89,6 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
     this._initializerCallbacks.reset();
     this._finalizerCallbacks.reset();
 
-    this.stopListening();
-
     Marionette.triggerMethod.call(this, "stop");
   },
 


### PR DESCRIPTION
This reverts commit b8075a2fef4d366d19ba986cd201eb904497d69f.

per comments from @disruptek about this being breaking from him. 
https://github.com/marionettejs/backbone.marionette/pull/1022#issuecomment-39014298

The "breaking" change was due to the module docs being vague.

This behavior will be placed into the 2.x release as part of the larger module rework to introduce a more fine grained concept of a lifecycle and a "Stop" much like  https://github.com/marionettejs/backbone.marionette/pull/801

As modules stand right now they represent a significant potential for memory headaches, since right now "stop" does not clear the modules footprint as @dmytroyarmak pointed out.
