### PR TITLE
Fix arg order in #initialize Module Classes example

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -239,7 +239,7 @@ var FooModule = Marionette.Module.extend({
   constructor: function(moduleName, app, options) {
   },
 
-  initialize: function(options, app, moduleName) {
+  initialize: function(options, moduleName, app) {
   },
 
   onStart: function(options) {


### PR DESCRIPTION
Fixes the argument order in the #initialize method in the Module Classes example.
