### PR TITLE
bugfix for CollectionView not proxy'ing close events (and others)

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -262,12 +262,11 @@ Marionette.CollectionView = Marionette.View.extend({
     // shut down the child view properly,
     // including events that the collection has from it
     if (view){
-      this.stopListening(view);
-
       // call 'close' or 'remove', depending on which is found
       if (view.close) { view.close(); }
       else if (view.remove) { view.remove(); }
 
+      this.stopListening(view);
       this.children.remove(view);
     }
 


### PR DESCRIPTION
All events from the ItemViews are proxied except for the `close` event.  It's lost because we `stopListening` to the view before the `close()` is invoked.  This change fixes that and lets the view issue events (as part of its teardown) which may be received by the parent `CollectionView`.
