### PR TITLE
Extract Underscore collection mixin

### DIFF
--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -11,6 +11,7 @@ a way to get the same behaviors and conventions from your own code.
 * [Marionette.getOption](#marionettegetoption)
 * [Marionette.triggerMethod](#marionettetriggermethod)
 * [Marionette.bindEntityEvent](#marionettebindentityevents)
+* [Marionette.actAsCollection](#marionetteactAsCollection)
 
 ## Marionette.extend
 
@@ -134,7 +135,7 @@ Backbone.View.extend({
 });
 ```
 
-The first paremter, `target`, must have a `listenTo` method from the
+The first parameter, `target`, must have a `listenTo` method from the
 EventBinder object.
 
 The second parameter is the entity (Backbone.Model or Backbone.Collection)
@@ -151,7 +152,7 @@ same hash with the function names replaced with the function references themselv
 
 This function is attached to the `Marionette.View` prototype by default. To use it from non-View classes you'll need to attach it yourself.
 
-```
+```js
 var View = Marionette.ItemView.extend({
 
   initialize: function() {
@@ -166,3 +167,41 @@ var View = Marionette.ItemView.extend({
 
 });
 ```
+
+## Marionette.actAsCollection
+
+Utility function for mixing in underscore collection behavior to an object.
+
+It works by taking an object and a property field, in this example 'list',
+and appending collection functions to the object so that it can
+delegate collection calls to its list.
+
+#### Object Literal
+```js
+obj = {
+  list: [1, 2, 3]
+}
+
+Marionette.actAsCollection(obj, 'list');
+
+var double = function(v){ return v*2};
+console.log(obj.map(double)); // [2, 4, 6]
+```
+
+#### Function Prototype
+```js
+var Func = function(list) {
+  this.list = list;
+};
+
+Marionette.actAsCollection(Func.prototype, 'list');
+var func = new Func([1,2,3]);
+
+
+var double = function(v){ return v*2};
+console.log(func.map(double)); // [2, 4, 6]
+```
+
+The first parameter is the object that will delegate underscore collection methods.
+
+The second parameter is the object field that will hold the list.

--- a/spec/javascripts/mixinUnderscoreCollection.spec.js
+++ b/spec/javascripts/mixinUnderscoreCollection.spec.js
@@ -1,0 +1,36 @@
+describe("Marionette.actAsCollection", function() {
+  var double = function(v){ return v*2 };
+
+  describe("object literal", function() {
+    var obj;
+
+    beforeEach(function() {
+      obj = {
+        list: [1, 2, 3]
+      }
+
+      Marionette.actAsCollection(obj, 'list');
+    });
+
+    it("should be able to map over list", function() {
+      expect(obj.map(double)).toEqual([2,4,6]);
+    });
+  });
+
+  describe("function prototype", function() {
+    var Func, func;
+
+    beforeEach(function() {
+      Func = function(list) {
+        this.list = list;
+      };
+
+      Marionette.actAsCollection(Func.prototype, 'list');
+      func = new Func([1,2,3]);
+    });
+
+    it("should be able to map over list", function() {
+      expect(func.map(double)).toEqual([2,4,6]);
+    });
+  });
+});

--- a/src/marionette.helpers.js
+++ b/src/marionette.helpers.js
@@ -75,3 +75,22 @@ Marionette.normalizeUIKeys = function(hash, ui) {
 
   return hash;
 };
+
+// Mix in methods from Underscore, for iteration, and other
+// collection related features.
+// Borrowing this code from Backbone.Collection:
+// http://backbonejs.org/docs/backbone.html#section-106
+Marionette.actAsCollection = function(object, listProperty) {
+  var methods = ['forEach', 'each', 'map', 'find', 'detect', 'filter',
+    'select', 'reject', 'every', 'all', 'some', 'any', 'include',
+    'contains', 'invoke', 'toArray', 'first', 'initial', 'rest',
+    'last', 'without', 'isEmpty', 'pluck'];
+
+  _.each(methods, function(method) {
+    object[method] = function() {
+      var list = _.values(_.result(this, listProperty));
+      var args = [list].concat(_.toArray(arguments));
+      return _[method].apply(_, args);
+    };
+  });
+};

--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -110,23 +110,7 @@ Marionette.RegionManager = (function(Marionette){
 
   });
 
-  // Borrowing this code from Backbone.Collection:
-  // http://backbonejs.org/docs/backbone.html#section-106
-  //
-  // Mix in methods from Underscore, for iteration, and other
-  // collection related features.
-  var methods = ['forEach', 'each', 'map', 'find', 'detect', 'filter',
-    'select', 'reject', 'every', 'all', 'some', 'any', 'include',
-    'contains', 'invoke', 'toArray', 'first', 'initial', 'rest',
-    'last', 'without', 'isEmpty', 'pluck'];
-
-  _.each(methods, function(method) {
-    RegionManager.prototype[method] = function() {
-      var regions = _.values(this._regions);
-      var args = [regions].concat(_.toArray(arguments));
-      return _[method].apply(_, args);
-    };
-  });
+  Marionette.actAsCollection(RegionManager.prototype, '_regions');
 
   return RegionManager;
 })(Marionette);


### PR DESCRIPTION
This is a small extraction that adds a general purpose Marionette function for making an object act like an underscore collection. 

The `RegionManager` previously had this logic inside its implementation. I believe this code was initially borrowed from Backbone's Collection object. 

This is a relatively low-priority change. If it goes in, hopefully some people will enjoy making  their own objects collection like. 
