### PR TITLE
Added passing original event at "triggers" section

### DIFF
--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -95,6 +95,7 @@ Marionette.View = Backbone.View.extend({
 
         // build the args for the event
         var args = {
+          event: e,
           view: this,
           model: this.model,
           collection: this.collection


### PR DESCRIPTION
Why is this useful? Because in some situations you want to know where the event originated from (e.target).
