### PR TITLE
Fix behaviors so that they respond to Model and Collection events

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -9,6 +9,8 @@ A `Behavior` is an  isolated set of DOM / user interactions that can be mixed in
 * [Using Behaviors](#using)
 * [API](#api)
   * [Event proxy](#the-event-proxy)
+  * [Model Events](#model-events)
+  * [Collection Events](#model-events)
   * [$](#$)
   * [$el](#$el)
   * [Defaults](#defaults)
@@ -145,6 +147,32 @@ Marionette.Behavior.extend({
 });
 ```
 
+### Model Events
+`modelEvents` will respond to the view's model events.
+```js
+  Marionette.Behavior.extend({
+    modelEvents: {
+      "change:doge": "onDogeChange"
+    },
+
+    onDogeChange: function() {
+      // buy more doge...
+    }
+  });
+```
+
+### Collection Events
+`collectionEvents` will respond to the view's collection events.
+```js
+  Marionette.Behavior.extend({
+    collectionEvents: {
+      add: "onCollectionAdd"
+    },
+
+    onCollectionAdd: function() {
+    }
+  });
+```
 
 ### $
 `$` is a direct proxy of the views `$` lookup method.

--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -343,17 +343,26 @@ describe("Behaviors", function(){
   });
 
   describe("behavior model events", function() {
-    var spy, V, hold, m;
+    var modelSpy, collectionSpy, V, hold, m, testBehavior;
     beforeEach(function() {
-      spy = sinon.spy();
+      modelSpy = sinon.spy();
+      collectionSpy = sinon.spy();
+      fooChangedSpy = sinon.spy();
+
       hold = {}
+
       hold.test = Marionette.Behavior.extend({
+        initialize: function() {
+          testBehavior = this;
+        },
         modelEvents: {
-          change: spy
+          change: modelSpy,
+          "change:foo": "fooChanged"
         },
         collectionEvents: {
-          reset: spy
-        }
+          reset: collectionSpy
+        },
+        fooChanged: fooChangedSpy
       });
 
       CV = Marionette.CollectionView.extend({
@@ -382,11 +391,17 @@ describe("Behaviors", function(){
         model: m
       });
 
-      v.delegateEvents();
-
       m.set("name", "doge");
+      expect(modelSpy).toHaveBeenCalledOn(testBehavior);
+    });
 
-      expect(spy).toHaveBeenCalled();
+    it ("should proxy model events w/ string cbk", function() {
+      v = new V({
+        model: m
+      });
+
+      m.set("foo", "doge");
+      expect(fooChangedSpy).toHaveBeenCalledOn(testBehavior);
     });
 
     it ("should proxy collection events", function() {
@@ -394,11 +409,8 @@ describe("Behaviors", function(){
         collection: c
       });
 
-      v.delegateEvents();
-
       c.reset();
-
-      expect(spy).toHaveBeenCalled();
+      expect(collectionSpy).toHaveBeenCalledOn(testBehavior);
     });
 
   });

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -86,8 +86,8 @@ Marionette.Behaviors = (function(Marionette, _) {
       delegateEvents.apply(this, args);
 
       _.each(behaviors, function(b){
-        Marionette.bindEntityEvents(this, this.model, Marionette.getOption(b, "modelEvents"));
-        Marionette.bindEntityEvents(this, this.collection, Marionette.getOption(b, "collectionEvents"));
+        Marionette.bindEntityEvents(b, this.model, Marionette.getOption(b, "modelEvents"));
+        Marionette.bindEntityEvents(b, this.collection, Marionette.getOption(b, "collectionEvents"));
       }, this);
     },
 


### PR DESCRIPTION
The way `delegateEvents` and `unDelegateEvents` were setup, they were not properly delegating to the behavior. This problem was masked by some tests that were less than clear. 

``` js
Marionette.Behavior.extend({
  modelEvents: {
    change: spy
  },
  collectionEvents: {
    reset: spy
  }
});
```

Fixes #1117, reported by @fschollmeyer.
