### PR TITLE
Use the proper method from Backbone.Events

### DIFF
--- a/src/marionette.controller.js
+++ b/src/marionette.controller.js
@@ -24,6 +24,6 @@ _.extend(Marionette.Controller.prototype, Backbone.Events, {
     this.stopListening();
     var args = Array.prototype.slice.call(arguments);
     this.triggerMethod.apply(this, ["close"].concat(args));
-    this.unbind();
+    this.off();
   }
 });


### PR DESCRIPTION
Marionette.Controller is calling this.unbind in the close method. But Backbone.Events.unbind is an alias for Backbone.Events.off. This change makes the code more clear.

Note: ".unbind" was the original name to ".off". The method was renamed on Backbone 0.9.0 (over 2 years ago!)
