### PR TITLE
Add getRegion to Layout

### DIFF
--- a/spec/javascripts/layout.spec.js
+++ b/spec/javascripts/layout.spec.js
@@ -317,4 +317,15 @@ describe("layout", function(){
     });
   });
 
+  describe("when getting a region", function () {
+    beforeEach(function () {
+      this.layout = new Layout();
+      this.region = this.layout.regionOne;
+    });
+
+    it("should return the region", function () {
+      expect(this.layout.getRegion("regionOne")).toBe(this.region);
+    });
+  });
+
 });

--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -514,6 +514,22 @@ describe("region", function(){
     })
   })
 
+  describe("when getting a region", function () {
+    beforeEach(function () {
+      this.MyApp = new Backbone.Marionette.Application();
+      this.MyApp.addRegions({
+        MyRegion: "#region",
+        anotherRegion: "#region2"
+      });
+
+      this.region = this.MyApp.MyRegion;
+    });
+
+    it("should return the region", function () {
+      expect(this.MyApp.getRegion("MyRegion")).toBe(this.region);
+    });
+  });
+
   describe("when resetting a region", function(){
     var region;
 

--- a/src/marionette.layout.js
+++ b/src/marionette.layout.js
@@ -71,6 +71,13 @@ Marionette.Layout = Marionette.ItemView.extend({
     return this.regionManager.removeRegion(name);
   },
 
+  // Provides alternative access to regions
+  // Accepts the region name
+  // getRegion('main')
+  getRegion: function(region) {
+    return this.regionManager.get(region);
+  },
+
   // internal method to build regions
   _buildRegions: function(regions){
     var that = this;


### PR DESCRIPTION
Fixes #1127

---

**Changes**
- Added `getRegion` method to `Layout` (from [Application](https://github.com/marionettejs/backbone.marionette/blob/v1.7.4/src/marionette.application.js#L69-L74))
- Added  `Layout.getRegion` test to `layout.spec`
- Added `Application.getRegion` test to `region.spec` (probably doesn't belong there but thats where the rest of the Application region tests were... :kanye_shrug:)

---

Quick question: Since Application and Layout share a lot of RegionManager-related methods, should they be abstracted somewhere to be reused?

---

Let me know if this pull request needs anything else. Thanks!
