### PR TITLE
render according to comparator

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -244,6 +244,47 @@ describe("collection view", function(){
     });
   });
 
+describe("when a model is added to a non-empty collection with a comparator", function(){
+    var collectionView, collection, model, itemViewRender;
+
+    beforeEach(function(){
+      collection = new Backbone.Collection([{foo: 'abar'}, {foo: 'bbar'}, {foo: 'wbar'}]);
+      collection.comparator = 'foo';
+
+      collectionView = new CollectionView({
+        itemView: ItemView,
+        collection: collection
+      });
+      collectionView.render();
+
+      itemViewRender = jasmine.createSpy("itemview:render");
+      collectionView.on("itemview:render", itemViewRender);
+
+      spyOn(collectionView, "appendHtml").andCallThrough();
+
+      model = new Backbone.Model({foo: "fbar"});
+      collection.add(model);
+    });
+
+    it("should add the model to the list", function(){
+      expect(_.size(collectionView.children)).toBe(4);
+    });
+
+    it("should have the order in the dom", function(){
+      expect($(collectionView.$el.children()[0]).text()).toBe('abar');
+      expect($(collectionView.$el.children()[1]).text()).toBe('bbar');
+      expect($(collectionView.$el.children()[2]).text()).toBe('fbar');
+      expect($(collectionView.$el.children()[3]).text()).toBe('wbar');
+    });
+
+    afterEach(function(){
+      // reset comparator
+      collection.comparator = undefined;
+    });
+
+  });
+
+
   describe("when providing a custom render that adds children, without a collection object to use, and removing a child", function(){
     var collectionView;
     var childView;

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -135,7 +135,7 @@ Marionette.CollectionView = Marionette.View.extend({
     if (EmptyView && !this._showingEmptyView){
       this._showingEmptyView = true;
       var model = new Backbone.Model();
-      this.addItemView(model, EmptyView, 0);
+      this.addItemView(model, EmptyView, -1);
     }
   },
 
@@ -178,6 +178,16 @@ Marionette.CollectionView = Marionette.View.extend({
 
     // build the view
     var view = this.buildItemView(item, ItemView, itemViewOptions);
+
+    // assign the index to the view
+    view.index = index;
+
+    // increment the index of views after this one
+    this.children.each(function (view) {
+      if (view.index >= index) {
+        view.index++;
+      }
+    });
 
     // set up the child view event forwarding
     this.addChildViewEventForwarding(view);
@@ -303,9 +313,20 @@ Marionette.CollectionView = Marionette.View.extend({
       this._bufferedChildren.push(itemView);
     }
     else {
-      // If we've already rendered the main collection, just
-      // append the new items directly into the element.
-      this.$el.append(itemView.el);
+      // If we've already rendered the main collection, append
+      // the new item into the correct order.
+
+      // Find the view after this one
+      var currentView = this.children.find(function (view) {
+        return view.index === index + 1;
+      });
+
+      if (currentView) {
+        currentView.$el.before(itemView.el);
+      }
+      else {
+        this.$el.append(itemView.el);
+      }
     }
   },
 


### PR DESCRIPTION
[WIP] Needs more tests.

Fixes #1061

Idea here is assigning the index of the model to each view in `this.children` we can then use these to get the element that we need to insert the view before.

Open to suggestions on logic here.
