### PR TITLE
Setup proxy methods for getOption and bindEntityEvents

### DIFF
--- a/docs/marionette.controller.md
+++ b/docs/marionette.controller.md
@@ -8,6 +8,7 @@ and coordination of other objects, views, and more.
 
 * [Basic Use](#basic-use)
 * [Destroying A Controller](#destroying-a-controller)
+* [getOption](#getoption)
 * [On The Name 'Controller'](#on-the-name-controller)
 
 ## Basic Use
@@ -44,6 +45,11 @@ c.listenTo(c, "stuff:done", function(stuff){
 // do some stuff
 c.doStuff();
 ```
+
+## getOption
+Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
+
+More information [getOption](./marionette.functions.md)
 
 ## Destroying A Controller
 

--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -9,8 +9,10 @@ a way to get the same behaviors and conventions from your own code.
 
 * [Marionette.extend](#marionetteextend)
 * [Marionette.getOption](#marionettegetoption)
+* [Marionette.proxyGetOption](#marionetteproxygetoption)
 * [Marionette.triggerMethod](#marionettetriggermethod)
 * [Marionette.bindEntityEvent](#marionettebindentityevents)
+* [Marionette.proxyBindEntityEvent](#marionetteproxybindentityevents)
 * [Marionette.normalizeEvents](#marionettenormalizeevents)
 * [Marionette.normalizeUIKeys](#marionettenormalizeuikeys)
 * [Marionette.actAsCollection](#marionetteactascollection)
@@ -93,6 +95,24 @@ new M({}, { foo: f }); // => "bar"
 In this example, "bar" is returned both times because the second
 example has an undefined value for `f`.
 
+## Marionette.proxyGetOption
+
+This method proxies `Marionette.getOption` so that it can be easily added to an instance.
+
+Say you've written your own Pagination class and you always pass options to it.
+With `proxyGetOption`, you can easily give this class the `getOption` function.
+
+```js
+_.extend(Pagination.prototype, {
+
+  getFoo: function(){
+    return this.getOption("foo");
+  },
+
+  getOption: Marionette.proxyGetOption
+});
+```
+
 ## Marionette.triggerMethod
 
 Trigger an event and a corresponding method on the target object.
@@ -146,6 +166,24 @@ to bind the events from.
 The third parameter is a hash of { "event:name": "eventHandler" }
 configuration. Multiple handlers can be separated by a space. A
 function can be supplied instead of a string handler name.
+
+## Marionette.proxyBindEntityEvents
+This method proxies `Marionette.bindEntityEvents` so that it can easily be added to an instance.
+
+Say you've written your own Pagination class and you want to easily listen to some entities events.
+With `proxyBindEntityEvents`, you can easily give this class the `bindEntityEvents` function.
+
+```js
+_.extend(Pagination.prototype, {
+
+   bindSomething: function() {
+     this.bindEntityEvents(this.something, this.somethingEvents)
+   },
+
+   bindEntityEvents: Marionette.proxyBindEntityEvents
+
+});
+```
 
 ## Marionette.normalizeEvents
 

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -21,6 +21,8 @@ behaviors that are shared across all views.
 * [View.modelEvents and View.collectionEvents](#viewmodelevents-and-viewcollectionevents)
 * [View.serializeData](#viewserializedata)
 * [View.bindUIElements](#viewbinduielements)
+* [View.getOption](#viewgetoption)
+* [View.bindEntityEvents](#viewbindentityevents)
 * [View.templateHelpers](#viewtemplatehelpers)
   * [Basic Example](#basic-example)
   * [Accessing Data Within The Helpers](#accessing-data-within-the-helpers)
@@ -388,6 +390,16 @@ This functionality is provided via the `bindUIElements` method.
 Since View doesn't implement the render method, then if you directly extend
 from View you will need to invoke this method from your render method.
 In ItemView and CompositeView this is already taken care of.
+
+## View.getOption
+Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
+
+More information [getOption](./marionette.functions.md)
+
+## View.bindEntityEvents
+Helps bind a backbone "entity" to methods on a target object. bindEntityEvents is used to support `modelEvents` and `collectionEvents`.
+
+More information [bindEntityEvents](./marionette.functions.md)
 
 ## View.templateHelpers
 

--- a/spec/javascripts/bindEntityEvents.spec.js
+++ b/spec/javascripts/bindEntityEvents.spec.js
@@ -119,4 +119,22 @@ describe('Marionette.bindEntityEvents', function() {
       expect(target.listenTo).toHaveBeenCalledWith(entity, 'secondEventNameMock', target.bar);
     });
   });
+
+  describe('when bindEntityEvents is proxied', function() {
+    beforeEach(function() {
+      target = {
+        foo: sinon.spy(),
+        bar: sinon.spy(),
+        listenTo: sinon.spy(),
+        bindEntityEvents: Marionette.proxyBindEntityEvents
+      };
+
+      entity = sinon.spy();
+      target.bindEntityEvents(entity, {'eventNameMock': target.foo});
+    });
+
+    it('should bind an event to target\'s handler', function() {
+      expect(target.listenTo).toHaveBeenCalledWith(entity, 'eventNameMock', target.foo);
+    });
+  });
 });

--- a/spec/javascripts/getOption.spec.js
+++ b/spec/javascripts/getOption.spec.js
@@ -97,4 +97,19 @@ describe('get option', function() {
 
   });
 
+  describe('when proxying getOption', function() {
+    var target;
+
+    beforeEach(function() {
+      target = {
+        foo: 'bar',
+        getOption: Marionette.proxyGetOption
+      };
+    });
+
+    it('should return that definition\'s option', function(){
+      expect(target.getOption('foo')).toBe('bar');
+    });
+  });
+
 });

--- a/spec/javascripts/unbindEntityEvents.spec.js
+++ b/spec/javascripts/unbindEntityEvents.spec.js
@@ -111,4 +111,22 @@ describe('Marionette.unbindEntityEvents', function() {
       expect(target.stopListening).toHaveBeenCalledWith(entity, 'secondEventNameMock', target.bar);
     });
   });
+
+ describe('when unbindEntityEvents is proxied', function() {
+    beforeEach(function() {
+      target = {
+        foo: sinon.spy(),
+        bar: sinon.spy(),
+        stopListening: sinon.spy(),
+        unbindEntityEvents: Marionette.proxyUnbindEntityEvents
+      };
+
+      entity = sinon.spy();
+      target.unbindEntityEvents(entity, {'eventNameMock': target.foo});
+    });
+
+    it('should bind an event to target\'s handler', function() {
+      expect(target.stopListening).toHaveBeenCalledWith(entity, 'eventNameMock', target.foo);
+    });
+  });
 });

--- a/src/marionette.bindEntityEvents.js
+++ b/src/marionette.bindEntityEvents.js
@@ -90,4 +90,13 @@
     iterateEvents(target, entity, bindings, unbindToFunction, unbindFromStrings);
   };
 
+  // Proxy `bindEntityEvents`
+  Marionette.proxyBindEntityEvents = function(entity, bindings) {
+    return Marionette.bindEntityEvents(this, entity, bindings);
+  };
+
+  // Proxy `unbindEntityEvents`
+  Marionette.proxyUnbindEntityEvents = function(entity, bindings) {
+    return Marionette.unbindEntityEvents(this, entity, bindings);
+  };
 })(Marionette);

--- a/src/marionette.controller.js
+++ b/src/marionette.controller.js
@@ -25,5 +25,8 @@ _.extend(Marionette.Controller.prototype, Backbone.Events, {
     this.triggerMethod.apply(this, ['destroy'].concat(args));
     this.stopListening();
     this.off();
-  }
+  },
+
+  // Proxy `getOption` to enable getting options from this or this.options by name.
+  getOption: Marionette.proxyGetOption
 });

--- a/src/marionette.helpers.js
+++ b/src/marionette.helpers.js
@@ -36,6 +36,11 @@ Marionette.getOption = function(target, optionName) {
   return value;
 };
 
+// Proxy `Marionette.getOption`
+Marionette.proxyGetOption = function(optionName) {
+  return Marionette.getOption(this, optionName);
+};
+
 // Marionette.normalizeMethods
 // ----------------------
 

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -215,5 +215,14 @@ Marionette.View = Backbone.View.extend({
     // reset the ui element to the original bindings configuration
     this.ui = this._uiBindings;
     delete this._uiBindings;
-  }
+  },
+
+  // Proxy `getOption` to enable getting options from this or this.options by name.
+  getOption: Marionette.proxyGetOption,
+
+  // Proxy `unbindEntityEvents` to enable binding view's events from another entity.
+  bindEntityEvents: Marionette.proxyBindEntityEvents,
+
+  // Proxy `unbindEntityEvents` to enable unbinding view's events from another entity.
+  unbindEntityEvents: Marionette.proxyUnbindEntityEvents
 });


### PR DESCRIPTION
Taking another crack at proxying `getOption` and `bindEntityEvents`. 

The first attempt: overload the helper methods,
The second attempt: add seperate proxy methods to each class,
The third attempt: add instance level proxy methods in the helper files.

I like the third option the best because it does not affect the original static helper functions, but it does also express succinctly how they're being proxied on the objects.

this fixes #927.

note:
A lot of the initial work came from @fenduru. He did 90% of the work for this.
