### PR TITLE
Fix Marionette functions doc actAsCollection Link

### DIFF
--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -13,7 +13,7 @@ a way to get the same behaviors and conventions from your own code.
 * [Marionette.bindEntityEvent](#marionettebindentityevents)
 * [Marionette.normalizeEvents](#marionettenormalizeevents)
 * [Marionette.normalizeUIKeys](#marionettenormalizeuikeys)
-* [Marionette.actAsCollection](#marionetteactAsCollection)
+* [Marionette.actAsCollection](#marionetteactascollection)
 
 ## Marionette.extend
 


### PR DESCRIPTION
Just a quick fix for this url: https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.functions.md#marionetteactascollection

---

**Changes:**
- Update Marionette functions doc index link

---

Please let me know if this pull request needs anything else. Thanks
