### PR TITLE
Allow for behaviors to have behaviors

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -1,7 +1,7 @@
 # Marionette.Behavior
 
 
-A `Behavior` is an  isolated set of DOM / user interactions that can be mixed into any `View`. `Behaviors` allow you to blackbox `View` specific interactions into portable logical chunks, keeping your `views` simple and your code DRY.
+A `Behavior` is an  isolated set of DOM / user interactions that can be mixed into any `View` or another `Behavior`. `Behaviors` allow you to blackbox `View` specific interactions into portable logical chunks, keeping your `views` simple and your code DRY.
 
 ## Documentation Index
 
@@ -129,6 +129,20 @@ window.Behaviors.ToolTip = ToolTip;
 window.Behaviors.CloseWarn = CloseWarn;
 ```
 
+Note than in addition to extending a `View` with `Behavior`, a `Behavior` can itself use other behaviors. The syntax is identical to that used for a `View`:
+
+```js
+var Modal = Marionette.Behavior.extend({
+  behaviors: {
+    CloseWarn: {
+       message: "Whoa! You sure about this?"
+    }
+  }
+});
+```
+
+Nested behaviors act as if they were direct behaviors of the parent behavior's view instance.
+
 ## API
 
 ### the event proxy
@@ -170,6 +184,16 @@ Marionette.Behavior.extend({
     },
 
     onCollectionAdd: function() {
+    }
+  });
+```
+
+### Nested Behaviors
+`behaviors` allows your behavior to use other behaviors.
+```js
+  Marionette.Behavior.extend({
+    behaviors: {
+      SomeBehavior: {}
     }
   });
 ```

--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -471,4 +471,91 @@ describe("Behaviors", function(){
       expect(spy).toHaveBeenCalledOn(b);
     });
   });
+
+  describe("behavior with behavior", function() {
+    var initSpy, renderSpy, entityEventSpy, viewEventSpy;
+    var View, v, m, c, hold, parentBehavior, childBehavior;
+    beforeEach(function() {
+      initSpy = sinon.spy();
+      renderSpy = sinon.spy();
+      entityEventSpy = sinon.spy();
+      viewEventSpy = sinon.spy();
+
+      hold = {};
+      hold.parentB = Marionette.Behavior.extend({
+        initialize: function() {
+          parentBehavior = this;
+        },
+        behaviors: {
+          childB: {}
+        }
+      });
+      hold.childB = Marionette.Behavior.extend({
+        initialize: function() {
+          initSpy();
+          childBehavior = this;
+        },
+        onRender: renderSpy,
+        ui: {
+          child: '.child'
+        },
+        modelEvents: {
+          'change': entityEventSpy
+        },
+        collectionEvents: {
+          'sync': entityEventSpy
+        },
+        events: {
+          'click @ui.view': viewEventSpy,
+          'click @ui.child': viewEventSpy
+        },
+      });
+
+      Marionette.Behaviors.behaviorsLookup = hold;
+
+      View = Marionette.CompositeView.extend({
+        template: _.template('<div class="view"></div><div class="child"></div>'),
+        ui: {
+          view: '.view'
+        },
+        behaviors: {
+          parentB: {}
+        }
+      });
+
+      m = new Backbone.Model;
+      c = new Backbone.Collection;
+      v = new View({model: m, collection: c});
+      v.render();
+    });
+
+    it("should call initialize on child behavior", function() {
+      expect(initSpy).toHaveBeenCalled();
+    });
+
+    it("should call onRender on child behavior", function() {
+      v.triggerMethod("render");
+      expect(renderSpy).toHaveBeenCalledOn(childBehavior);
+    });
+
+    it("should proxy modelEvents to child behavior", function() {
+      m.trigger("change");
+      expect(entityEventSpy).toHaveBeenCalledOn(childBehavior);
+    });
+
+    it("should proxy collectionEvents to child behavior", function() {
+      c.trigger("sync");
+      expect(entityEventSpy).toHaveBeenCalledOn(childBehavior);
+    });
+
+    it("should proxy view UI events to child behavior", function() {
+      v.$('.view').trigger('click');
+      expect(viewEventSpy).toHaveBeenCalledOn(childBehavior);
+    });
+
+    it("should proxy child behavior UI events to child behavior", function() {
+      v.$('.child').trigger('click');
+      expect(viewEventSpy).toHaveBeenCalledOn(childBehavior);
+    });
+  });
 });

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -9,21 +9,27 @@
 
 Marionette.Behaviors = (function(Marionette, _) {
 
-  function Behaviors(view) {
+  function Behaviors(view, behaviors) {
     // Behaviors defined on a view can be a flat object literal
     // or it can be a function that returns an object.
-    this.behaviors = Behaviors.parseBehaviors(view, _.result(view, 'behaviors'));
+    behaviors = Behaviors.parseBehaviors(view, behaviors || _.result(view, 'behaviors'));
 
     // Wraps several of the view's methods
     // calling the methods first on each behavior
     // and then eventually calling the method on the view.
-    Behaviors.wrap(view, this.behaviors, [
+    Behaviors.wrap(view, behaviors, [
       'bindUIElements', 'unbindUIElements',
       'delegateEvents', 'undelegateEvents',
       'onShow', 'onDestroy',
       'behaviorEvents', 'triggerMethod',
       'setElement'
     ]);
+
+    _.each(behaviors, function(b) {
+      if (!_.isUndefined(_.result(b, 'behaviors'))) {
+        new Behaviors(view, _.result(b, 'behaviors'));
+      }
+    });
   }
 
   var methods = {


### PR DESCRIPTION
Gonna put a behavior on your behavior.

This implementation unfolds a tree of behavior dependencies and attaches them directly to the view. Child behaviors should proxy `$`, entity (i.e. model and collection) and UI events as per the general contract.

We have a particular use-case that would benefit from this: two behaviors – `Modal` and `HotKeys` – where a modal needs the hotkeys behavior. Setup might look like:

``` js
var HotKeys = Marionette.Behavior.extend({});

var Modal = Marionette.Behavior.extend({
    behaviors: {
        HotKeys: { behaviorClass: HotKeys }
    }
});

var View = Marionette.ItemView.extend({
    behaviors: {
        Modal: { behaviorClass: Modal }
    }
});
```

This does not address the possibility of circular references.
