### PR TITLE
Removes unnecessary module params

### DIFF
--- a/docs/marionette.application.module.md
+++ b/docs/marionette.application.module.md
@@ -61,23 +61,17 @@ Definitions can either be a callback function or an object literal.
 ### Callback Function Definition
 
 The callback function definition will be invoked immediately on calling
-the `module` method.
-
-It will receive 6 parameters, in this order:
+the `module` method. It will receive the following parameters:
 
 * The module itself
 * The Application object
-* Backbone
-* Backbone.Marionette
-* jQuery
-* Underscore
 * Any custom arguments
 
 Within the callback you can attach both private and public
 functions and data directly to your module.
 
 ```js
-MyApp.module("MyModule", function(MyModule, MyApp, Backbone, Marionette, $, _){
+MyApp.module("MyModule", function(MyModule, MyApp){
 
   // The context of the function is also the module itself
   this === MyModule; // => true
@@ -117,7 +111,7 @@ Pass the additional arguments after the
 definition itself in the call to `module`.
 
 ```js
-MyApp.module("MyModule", function(MyModule, MyApp, Backbone, Marionette, $, _, Lib1, Lib2, LibEtc){
+MyApp.module("MyModule", function(MyModule, MyApp, Lib1, Lib2, LibEtc){
 
   // Lib1 === LibraryNumber1;
   // Lib2 === LibraryNumber2;
@@ -160,7 +154,7 @@ function through the `define` property.
 
 ```js
 MyApp.module("MyModule", {
-  define: function(MyModule, MyApp, Backbone, Marionette, $, _) {
+  define: function(MyModule, MyApp) {
     // Define your module here
   }
 });

--- a/spec/javascripts/module.spec.js
+++ b/spec/javascripts/module.spec.js
@@ -49,10 +49,6 @@ describe("application modules", function(){
           expect(defineSpy).toHaveBeenCalledWith(
             module,
             app,
-            Backbone,
-            Marionette,
-            Marionette.$,
-            _,
             additionalParam
           );
         });
@@ -96,10 +92,6 @@ describe("application modules", function(){
             expect(defineSpy).toHaveBeenCalledWith(
               module,
               app,
-              Backbone,
-              Marionette,
-              Marionette.$,
-              _,
               additionalParam
             );
           });

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -114,9 +114,6 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
     var args = _.flatten([
       this,
       this.app,
-      Backbone,
-      Marionette,
-      Backbone.$, _,
       customArgs
     ]);
 


### PR DESCRIPTION
Module function definitions are no longer passed Backbone, Marionette, jQuery, and Underscore as arguments.

Thoughts and considerations: do we want to pass the parent, whatever that may be? So, maybe something like:

myModule, myParentThing, app

myParentThing may just be `app` is app is the parent. If we did it this way, do we _just_ want to pass the parent? Or always the app, too?

Why are apps and modules two separate things?

Why are modules so disorganized?

Ahhh!

:scream: 
