### PR TITLE
Re-names renderModel to _renderRoot

### DIFF
--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -193,11 +193,6 @@ themselves under the following conditions:
 * When the collection has a model added to it (the "add" event is fired), it will render that one child into the list
 * When the collection has a model removed (the "remove" event is fired), it will remove that one child from the rendered list
 
-You can also manually re-render either or both of them:
-
-* If you want to re-render everything, call the `.render()` method
-* If you want to re-render the model's view, you can call `.renderModel()`
-
 ## Events And Callbacks
 
 During the course of rendering a composite, several events will

--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -446,7 +446,7 @@ describe('composite view', function() {
 
       compositeView.render();
 
-      spyOn(compositeView, 'renderModel').andCallThrough();
+      spyOn(compositeView, '_renderRoot').andCallThrough();
     });
 
     describe('and then resetting the collection', function() {
@@ -457,7 +457,7 @@ describe('composite view', function() {
       });
 
       it('should not re-render the template with the model', function() {
-        expect(compositeView.renderModel).not.toHaveBeenCalled();
+        expect(compositeView._renderRoot).not.toHaveBeenCalled();
       });
 
       it('should render the collections items', function() {
@@ -474,7 +474,7 @@ describe('composite view', function() {
       });
 
       it('should not re-render the template with the model', function() {
-        expect(compositeView.renderModel).not.toHaveBeenCalled();
+        expect(compositeView._renderRoot).not.toHaveBeenCalled();
       });
 
       it('should add to the collections items', function() {
@@ -491,7 +491,7 @@ describe('composite view', function() {
       });
 
       it('should not re-render the template with the model', function() {
-        expect(compositeView.renderModel).not.toHaveBeenCalled();
+        expect(compositeView._renderRoot).not.toHaveBeenCalled();
       });
 
       it('should remove from the collections items', function() {

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -74,14 +74,8 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     this.resetChildViewContainer();
 
     this.triggerMethod('before:render', this);
-    var html = this.renderModel();
-    this.$el.html(html);
-    // the ui bindings is done here and not at the end of render since they
-    // will not be available until after the model is rendered, but should be
-    // available before the collection is rendered.
-    this.bindUIElements();
-    this.triggerMethod('composite:model:rendered');
 
+    this._renderRoot();
     this._renderChildren();
 
     this.triggerMethod('composite:rendered');
@@ -97,18 +91,23 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     }
   },
 
-  // Render an individual model, if we have one, as
-  // part of a composite view (branch / leaf). For example:
-  // a treeview.
-  renderModel: function() {
+  // Render the root template that the children
+  // views are appended to
+  _renderRoot: function() {
     var data = {};
     data = this.serializeData();
     data = this.mixinTemplateHelpers(data);
 
     var template = this.getTemplate();
-    return Marionette.Renderer.render(template, data);
-  },
+    var html = Marionette.Renderer.render(template, data);
+    this.$el.html(html);
 
+    // the ui bindings is done here and not at the end of render since they
+    // will not be available until after the model is rendered, but should be
+    // available before the collection is rendered.
+    this.bindUIElements();
+    this.triggerMethod('composite:model:rendered');
+  },
 
   // You might need to override this if you've overridden appendHtml
   appendBuffer: function(compositeView, buffer) {


### PR DESCRIPTION
CompositeView’s renderModel method was a confusing name. It has been
renamed to _renderRoot.

Fixes #1184
