### PR TITLE
compositeview onChildAdd binding

### DIFF
--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -414,8 +414,8 @@ describe('composite view', function() {
     });
   });
 
-  describe('when rendering a composite with a collection and then resetting the collection', function() {
-    var compositeView;
+  describe('when rendering a composite with a collection', function() {
+    var compositeView, collection;
 
     var ChildView = Backbone.Marionette.ItemView.extend({
       tagName: 'span',
@@ -436,7 +436,8 @@ describe('composite view', function() {
 
       var m1 = new Model({foo: 'bar'});
       var m2 = new Model({foo: 'baz'});
-      var collection = new Collection([m2]);
+
+      collection = new Collection([m2]);
 
       compositeView = new CompositeView({
         model: m1,
@@ -446,20 +447,56 @@ describe('composite view', function() {
       compositeView.render();
 
       spyOn(compositeView, 'renderModel').andCallThrough();
-
-      var m3 = new Model({foo: 'quux'});
-      var m4 = new Model({foo: 'widget'});
-      collection.reset([m3, m4]);
     });
 
-    it('should not re-render the template with the model', function() {
-      expect(compositeView.renderModel).not.toHaveBeenCalled();
+    describe('and then resetting the collection', function() {
+      beforeEach(function() {
+        var m3 = new Model({foo: 'quux'});
+        var m4 = new Model({foo: 'widget'});
+        collection.reset([m3, m4]);
+      });
+
+      it('should not re-render the template with the model', function() {
+        expect(compositeView.renderModel).not.toHaveBeenCalled();
+      });
+
+      it('should render the collections items', function() {
+        expect(compositeView.$el).not.toHaveText(/baz/);
+        expect(compositeView.$el).toHaveText(/quux/);
+        expect(compositeView.$el).toHaveText(/widget/);
+      });
     });
 
-    it('should render the collections items', function() {
-      expect(compositeView.$el).not.toHaveText(/baz/);
-      expect(compositeView.$el).toHaveText(/quux/);
-      expect(compositeView.$el).toHaveText(/widget/);
+    describe('and then adding to the collection', function() {
+      beforeEach(function() {
+        var m3 = new Model({foo: 'quux'});
+        collection.add(m3);
+      });
+
+      it('should not re-render the template with the model', function() {
+        expect(compositeView.renderModel).not.toHaveBeenCalled();
+      });
+
+      it('should add to the collections items', function() {
+        expect(compositeView.$el).toHaveText(/bar/);
+        expect(compositeView.$el).toHaveText(/baz/);
+        expect(compositeView.$el).toHaveText(/quux/);
+      });
+    });
+
+    describe('and then removing from the collection', function() {
+      beforeEach(function() {
+        var model = collection.at(0);
+        collection.remove(model);
+      });
+
+      it('should not re-render the template with the model', function() {
+        expect(compositeView.renderModel).not.toHaveBeenCalled();
+      });
+
+      it('should remove from the collections items', function() {
+        expect(compositeView.$el).not.toHaveText(/baz/);
+      });
     });
   });
 

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -23,7 +23,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     // to nonexistent childViewContainer
     this.once('render', function() {
       if (this.collection) {
-        this.listenTo(this.collection, 'add', this.addChildView);
+        this.listenTo(this.collection, 'add', this.onChildAdd);
         this.listenTo(this.collection, 'remove', this.onChildRemove);
         this.listenTo(this.collection, 'reset', this._renderChildren);
       }


### PR DESCRIPTION
Fixes #1208

Changed binding for `this.collection` `add` so that it calls the `onChildAdd` function. Also added tests around adding and removing from collections when rendering a `CompositeView`
