### PR TITLE
Add before:close events to Regions

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -206,6 +206,7 @@ and closing views:
 * "before:show" / `onBeforeShow` - Called on the region instance after the view has been rendered, but before its been displayed.
 * "show" / `onShow` - Called on the view instance when the view has been rendered and displayed.
 * "show" / `onShow` - Called on the region instance when the view has been rendered and displayed.
+* "before:close" / `onBeforeClose` - Called on the region instance before the view has been closed.
 * "close" / `onClose` - Called when the view has been closed.
 
 These events can be used to run code when your region

--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -358,11 +358,12 @@ describe("region", function(){
       }
     });
 
-    var myRegion, view, closedSpy;
+    var myRegion, view, beforeCloseSpy, closeSpy;
 
     beforeEach(function(){
       setFixtures("<div id='region'></div>");
-      closedSpy = sinon.spy();
+      beforeCloseSpy = sinon.spy();
+      closeSpy = sinon.spy();
 
       view = new MyView();
 
@@ -370,22 +371,31 @@ describe("region", function(){
       spyOn(view, "remove");
 
       myRegion = new MyRegion();
-      myRegion.on("close", closedSpy);
+      myRegion.on("before:close", beforeCloseSpy);
+      myRegion.on("close", closeSpy);
       myRegion.show(view);
 
       myRegion.close();
     });
 
+    it("should trigger a 'before:close' event with the view that's being closed", function(){
+      expect(beforeCloseSpy).toHaveBeenCalledWith(view);
+    });
+
+    it("should set 'this' to the manager, from the before:close event", function(){
+      expect(beforeCloseSpy).toHaveBeenCalledOn(myRegion);
+    });
+
     it("should trigger a close event", function(){
-      expect(closedSpy).toHaveBeenCalled();
+      expect(closeSpy).toHaveBeenCalled();
     });
 
     it("should trigger a close event with the view that's being closed", function(){
-      expect(closedSpy).toHaveBeenCalledWith(view);
+      expect(closeSpy).toHaveBeenCalledWith(view);
     });
 
     it("should set 'this' to the manager, from the close event", function(){
-      expect(closedSpy).toHaveBeenCalledOn(myRegion);
+      expect(closeSpy).toHaveBeenCalledOn(myRegion);
     });
 
     it("should call 'close' on the already show view", function(){

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -170,6 +170,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     var view = this.currentView;
     if (!view || view.isClosed){ return; }
 
+    Marionette.triggerMethod.call(this, "before:close", view);
+
     // call 'close' or 'remove', depending on which is found
     if (view.close) { view.close(); }
     else if (view.remove) { view.remove(); }


### PR DESCRIPTION
I've added a trigger for `before:close` in `close()` of the `Region`. We have a couple of cases where the `Region` must perform an operation just before the current view is closed. 
