### PR TITLE
Fix Typo in Changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -135,7 +135,7 @@ Version 1.7 represents a significant step in formalizing the ways to improve you
       ```js
         ui: function() {
           return {
-            "click @ui.foo": "attack"
+            "foo": ".foo"
           }
         }
       ```


### PR DESCRIPTION
1.6.3 example showed a function returning an `events` hash when it should have been returning a `ui` hash, according to the description directly above it.
