### PR TITLE
Normalize "Types" to "Classes"

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -25,8 +25,8 @@ MyApp = new Backbone.Marionette.Application();
   * [Accessing the Global Channel](#accessing-the-global-channel)
 * [Regions And The Application Object](#regions-and-the-application-object)
   * [jQuery Selector](#jquery-selector)
-  * [Custom Region Type](#custom-region-type)
-  * [Custom Region Type And Selector](#custom-region-type-and-selector)
+  * [Custom Region Class](#custom-region-class)
+  * [Custom Region Class And Selector](#custom-region-class-and-selector)
   * [Get Region By Name](#get-region-by-name)
   * [Removing Regions](#removing-regions)
 
@@ -218,9 +218,9 @@ MyApp.addRegions({
 });
 ```
 
-### Custom Region Type
+### Custom Region Class
 
-The second is to specify a custom region type, where the region type has
+The second is to specify a custom region class, where the region class has
 already specified a selector:
 
 ```js
@@ -233,9 +233,9 @@ MyApp.addRegions({
 });
 ```
 
-### Custom Region Type And Selector
+### Custom Region Class And Selector
 
-The third method is to specify a custom region type, and a jQuery selector
+The third method is to specify a custom region class, and a jQuery selector
 for this region instance, using an object literal:
 
 ```js
@@ -245,12 +245,12 @@ MyApp.addRegions({
 
   someRegion: {
     selector: "#foo",
-    regionType: MyCustomRegion
+    regionClass: MyCustomRegion
   },
 
   anotherRegion: {
     selector: "#bar",
-    regionType: MyCustomRegion
+    regionClass: MyCustomRegion
   }
 
 });

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -193,11 +193,11 @@ takes three parameters and returns a view instance to be used as the
 child view.
 
 ```js
-buildChildView: function(child, ChildViewType, childViewOptions){
-  // build the final list of options for the childView type
+buildChildView: function(child, ChildViewClass, childViewOptions){
+  // build the final list of options for the childView class
   var options = _.extend({model: child}, childViewOptions);
   // create the child view instance
-  var view = new ChildViewType(options);
+  var view = new ChildViewClass(options);
   // return it
   return view;
 },
@@ -237,7 +237,7 @@ Backbone.Marionette.CollectionView.extend({
 
 ### CollectionView's `getEmptyView`
 
-If you need the `emptyView`'s type chosen dynamically, specify `getEmptyView`:
+If you need the `emptyView`'s class chosen dynamically, specify `getEmptyView`:
 
 ```js
 Backbone.Marionette.CollectionView.extend({

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -172,7 +172,7 @@ For more information on this method, see the [CollectionView's documentation](ht
 The default rendering mode for a `CompositeView` assumes a
 hierarchical, recursive structure. If you configure a composite
 view without specifying an `childView`, you'll get the same
-composite view type rendered for each child in the collection. If
+composite view class rendered for each child in the collection. If
 you need to override this, you can specify a `childView` in the
 composite view's definition:
 

--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -31,7 +31,7 @@ var Foo = function(){};
 // Backbone and Marionette objects
 Foo.extend = Marionette.extend;
 
-// Now Foo can be extended to create a new type, with methods
+// Now Foo can be extended to create a new class, with methods
 var Bar = Foo.extend({
 
   someMethod: function(){ ... }

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -29,7 +29,7 @@ will provide features such as `onShow` callbacks, etc. Please see
   * [Avoid Re-Rendering The Entire Layout](#avoid-re-rendering-the-entire-layout)
 * [Nested LayoutViews And Views](#nested-layoutviewss-and-views)
 * [Destroying A LayoutView](#destroying-a-layoutview)
-* [Custom Region Type](#custom-region-type)
+* [Custom Region Class](#custom-region-class)
 * [Region Naming](#region-naming)
 
 ## Basic Usage
@@ -179,15 +179,15 @@ one, the same it will destroy a view.
 All of this ensures that layoutViews and the views that they
 contain are cleaned up correctly.
 
-## Custom Region Type
+## Custom Region Class
 
 If you have the need to replace the `Region` with a region class of
 your own implementation, you can specify an alternate class to use
-with the `regionType` property of the `LayoutView`.
+with the `regionClass` property of the `LayoutView`.
 
 ```js
 MyLayoutView = Backbone.Marionette.LayoutView.extend({
-  regionType: SomeCustomRegion
+  regionClass: SomeCustomRegion
 });
 ```
 
@@ -197,16 +197,16 @@ You can also specify custom `Region` classes for each `region`:
 AppLayoutView = Backbone.Marionette.LayoutView.extend({
   template: "#layout-view-template",
 
-  regionType: SomeDefaultCustomRegion,
+  regionClass: SomeDefaultCustomRegion,
 
   regions: {
     menu: {
       selector: "#menu",
-      regionType: CustomRegionTypeReference
+      regionClass: CustomRegionClassReference
     },
     content: {
       selector: "#content",
-      regionType: CustomRegionType2Reference
+      regionClass: CustomRegionClass2Reference
     }
   }
 });
@@ -281,7 +281,7 @@ complete list refer to the API documentation for each Class on the prototype cha
 
 * attributes
 * constructor
-* regionType
+* regionClass
 * render
 * destroy
 * addRegion

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -19,8 +19,8 @@ Using the `LayoutView` class you can create nested regions.
   * [Call `attachView` On Region](#call-attachview-on-region)
 * [Region Events And Callbacks](#region-events-and-callbacks)
   * [Events raised during `show`](#events-raised-during-show)
-* [Custom Region Types](#custom-region-types)
-  * [Attaching Custom Region Types](#attaching-custom-region-types)
+* [Custom Region Classes](#custom-region-classes)
+  * [Attaching Custom Region Classes](#attaching-custom-region-classes)
   * [Instantiate Your Own Region](#instantiate-your-own-region)
 
 ## Defining An Application Region
@@ -250,16 +250,16 @@ MyView = Marionette.ItemView.extend({
 });
 ```
 
-## Custom Region Types
+## Custom Region Classes
 
 You can define a custom region by extending from
 `Region`. This allows you to create new functionality,
 or provide a base set of functionality for your app.
 
-### Attaching Custom Region Types
+### Attaching Custom Region Classes
 
-Once you define a region type, you can attach the
-new region type by specifying the region type as the
+Once you define a region class, you can attach the
+new region class by specifying the region class as the
 value. In this case, `addRegions` expects the constructor itself, not an instance.
 
 ```js
@@ -283,7 +283,7 @@ var FooterRegion = Backbone.Marionette.Region.extend({
 MyApp.addRegions({
   footerRegion: {
     selector: "#footer",
-    regionType: FooterRegion
+    regionClass: FooterRegion
   }
 });
 ```

--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -82,7 +82,7 @@ var regions = rm.addRegions({
   foo: "#bar",
   bar: {
     selector: "#quux",
-    regionType: MyRegionType
+    regionClass: MyRegionClass
   }
 });
 
@@ -106,7 +106,7 @@ pairs that will be applied to every region added.
 var rm = new Marionette.RegionManager();
 
 var defaults = {
-  regionType: MyRegionType
+  regionClass: MyRegionClass
 };
 
 var regions = {
@@ -118,7 +118,7 @@ rm.addRegions(regions, defaults);
 ```
 
 In this example, all regions will be added as
-instances of `MyRegionType`.
+instances of `MyRegionClass`.
 
 ## RegionManager.get
 

--- a/docs/marionette.templatecache.md
+++ b/docs/marionette.templatecache.md
@@ -15,7 +15,7 @@ the speed of subsequent calls to get a template.
 ## Basic Usage
 
 To use the `TemplateCache`, call the `get` method on TemplateCache directly.
-Internally, instances of the TemplateCache type will be created and stored
+Internally, instances of the TemplateCache class will be created and stored
 but you do not have to manually create these instances yourself. `get` will
 return a compiled template function.
 

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -1,11 +1,11 @@
 # Marionette.View
 
-Marionette has a base `Marionette.View` type that other views extend from.
+Marionette has a base `Marionette.View` class that other views extend from.
 This base view provides some common and core functionality for
 other views to take advantage of.
 
-**Note:** The `Marionette.View` type is not intended to be
-used directly. It exists as a base view for other view types
+**Note:** The `Marionette.View` class is not intended to be
+used directly. It exists as a base view for other view classes
 to be extended from, and to provide a common location for
 behaviors that are shared across all views.
 
@@ -236,7 +236,7 @@ Backbone.Marionette.ItemView.extend({
 });
 ```
 
-Triggers work with all View types that extend from the base
+Triggers work with all View classes that extend from the base
 Marionette.View.
 
 ### Trigger Handler Arguments
@@ -432,7 +432,7 @@ view.render(); //=> "I think that Backbone.Marionette is the coolest!";
 ```
 
 The `templateHelpers` can also be provided as a constructor parameter
-for any Marionette view type that supports the helpers.
+for any Marionette view class that supports the helpers.
 
 ```js
 var MyView = Marionette.ItemView.extend({
@@ -501,4 +501,4 @@ MyView = Backbone.Marionette.ItemView.extend({
 });
 ```
 
-This applies to all view types.
+This applies to all view classes.

--- a/spec/javascripts/application.appRegions.spec.js
+++ b/spec/javascripts/application.appRegions.spec.js
@@ -50,7 +50,7 @@ describe('application regions', function() {
     });
   });
 
-  describe('when adding custom region types to an app, with selectors', function() {
+  describe('when adding custom region classes to an app, with selectors', function() {
     var MyApp = new Backbone.Marionette.Application();
     var MyRegion = Backbone.Marionette.Region.extend({});
 
@@ -61,7 +61,7 @@ describe('application regions', function() {
       MyApp.addRegions({
         MyRegion: {
           selector: '#region',
-          regionType: MyRegion,
+          regionClass: MyRegion,
           specialOption: true
         }
       });
@@ -71,7 +71,7 @@ describe('application regions', function() {
       expect(MyApp.MyRegion).not.toBeUndefined();
     });
 
-    it('should create an instance of the specified region type', function() {
+    it('should create an instance of the specified region class', function() {
       expect(MyApp.MyRegion).toBeInstanceOf(MyRegion);
     });
 
@@ -79,7 +79,7 @@ describe('application regions', function() {
       expect(MyApp.MyRegion.el).toBe('#region');
     });
 
-    it('should pass extra options to the custom regionType', function() {
+    it('should pass extra options to the custom regionClass', function() {
       expect(MyApp.MyRegion).toHaveOwnProperty('options');
       expect(MyApp.MyRegion.options).toHaveOwnProperty('specialOption');
       expect(MyApp.MyRegion.options.specialOption).toBeTruthy();

--- a/spec/javascripts/layoutView.spec.js
+++ b/spec/javascripts/layoutView.spec.js
@@ -23,7 +23,7 @@ describe('layoutView', function() {
     regions: {
       regionOne: {
         selector: '#regionOne',
-        regionType: CustomRegion1
+        regionClass: CustomRegion1
       },
       regionTwo: '#regionTwo'
     }
@@ -59,15 +59,15 @@ describe('layoutView', function() {
 
   describe('on instantiation with custom region managers', function() {
     var LayoutViewCustomRegion = LayoutView.extend({
-      regionType: CustomRegion1,
+      regionClass: CustomRegion1,
       regions: {
         regionOne: {
           selector: '#regionOne',
-          regionType: CustomRegion1
+          regionClass: CustomRegion1
         },
         regionTwo: {
           selector: '#regionTwo',
-          regionType: CustomRegion2,
+          regionClass: CustomRegion2,
           specialOption: true
         },
         regionThree: {
@@ -97,13 +97,13 @@ describe('layoutView', function() {
       expect(layoutViewManager.regionThree).toBeInstanceOf(CustomRegion1);
     });
 
-    it('should instantiate marionette regions is no regionType is specified', function() {
+    it('should instantiate marionette regions is no regionClass is specified', function() {
       var layoutViewManagerNoDefault = new LayoutViewNoDefaultRegion();
       expect(layoutViewManagerNoDefault).toHaveOwnProperty('regionTwo');
       expect(layoutViewManagerNoDefault.regionTwo).toBeInstanceOf(Backbone.Marionette.Region);
     });
 
-    it('should pass extra options to the custom regionType', function() {
+    it('should pass extra options to the custom regionClass', function() {
       expect(layoutViewManager.regionTwo).toHaveOwnProperty('options');
       expect(layoutViewManager.regionTwo.options).toHaveOwnProperty('specialOption');
       expect(layoutViewManager.regionTwo.options.specialOption).toBeTruthy();

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -162,12 +162,12 @@ Marionette.CollectionView = Marionette.View.extend({
     }
   },
 
-  // Retrieve the empty view type
+  // Retrieve the empty view class
   getEmptyView: function() {
     return Marionette.getOption(this, 'emptyView');
   },
 
-  // Retrieve the childView type, either from `this.options.childView`
+  // Retrieve the childView class, either from `this.options.childView`
   // or from the `childView` in the object definition. The "options"
   // takes precedence.
   getChildView: function(child) {
@@ -256,9 +256,9 @@ Marionette.CollectionView = Marionette.View.extend({
   },
 
   // Build a `childView` for a model in the collection.
-  buildChildView: function(child, ChilddViewType, childViewOptions) {
+  buildChildView: function(child, ChildViewClass, childViewOptions) {
     var options = _.extend({model: child}, childViewOptions);
-    return new ChilddViewType(options);
+    return new ChildViewClass(options);
   },
 
   // Remove the child view and destroy it.

--- a/src/marionette.layoutview.js
+++ b/src/marionette.layoutview.js
@@ -4,11 +4,11 @@
 // Used for managing application layoutViews, nested layoutViews and
 // multiple regions within an application or sub-application.
 //
-// A specialized view type that renders an area of HTML and then
+// A specialized view class that renders an area of HTML and then
 // attaches `Region` instances to the specified `regions`.
 // Used for composite view management and sub-application areas.
 Marionette.LayoutView = Marionette.ItemView.extend({
-  regionType: Marionette.Region,
+  regionClass: Marionette.Region,
 
   // Ensure the regions are available when the `initialize` method
   // is called.
@@ -80,7 +80,7 @@ Marionette.LayoutView = Marionette.ItemView.extend({
     var that = this;
 
     var defaults = {
-      regionType: Marionette.getOption(this, 'regionType'),
+      regionClass: Marionette.getOption(this, 'regionClass'),
       parentEl: function() { return that.$el; }
     };
 

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -134,7 +134,7 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
   }
 });
 
-// Type methods to create modules
+// Class methods to create modules
 _.extend(Marionette.Module, {
 
   // Create a module, hanging off the app parameter as the parent object.

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -21,37 +21,37 @@ Marionette.Region = function(options) {
 };
 
 
-// Region Type methods
+// Region Class methods
 // -------------------
 
 _.extend(Marionette.Region, {
 
   // Build an instance of a region by passing in a configuration object
-  // and a default region type to use if none is specified in the config.
+  // and a default region class to use if none is specified in the config.
   //
   // The config object should either be a string as a jQuery DOM selector,
-  // a Region type directly, or an object literal that specifies both
-  // a selector and regionType:
+  // a Region class directly, or an object literal that specifies both
+  // a selector and regionClass:
   //
   // ```js
   // {
   //   selector: "#foo",
-  //   regionType: MyCustomRegion
+  //   regionClass: MyCustomRegion
   // }
   // ```
   //
-  buildRegion: function(regionConfig, defaultRegionType) {
+  buildRegion: function(regionConfig, defaultRegionClass) {
     var regionIsString = _.isString(regionConfig);
     var regionSelectorIsString = _.isString(regionConfig.selector);
-    var regionTypeIsUndefined = _.isUndefined(regionConfig.regionType);
-    var regionIsType = _.isFunction(regionConfig);
+    var regionClassIsUndefined = _.isUndefined(regionConfig.regionClass);
+    var regionIsClass = _.isFunction(regionConfig);
 
-    if (!regionIsType && !regionIsString && !regionSelectorIsString) {
-      throwError('Region must be specified as a Region type,' +
+    if (!regionIsClass && !regionIsString && !regionSelectorIsString) {
+      throwError('Region must be specified as a Region class,' +
         'a selector string or an object with selector property');
     }
 
-    var selector, RegionType;
+    var selector, RegionClass;
 
     // get the selector for the region
 
@@ -64,29 +64,29 @@ _.extend(Marionette.Region, {
       delete regionConfig.selector;
     }
 
-    // get the type for the region
+    // get the class for the region
 
-    if (regionIsType) {
-      RegionType = regionConfig;
+    if (regionIsClass) {
+      RegionClass = regionConfig;
     }
 
-    if (!regionIsType && regionTypeIsUndefined) {
-      RegionType = defaultRegionType;
+    if (!regionIsClass && regionClassIsUndefined) {
+      RegionClass = defaultRegionClass;
     }
 
-    if (regionConfig.regionType) {
-      RegionType = regionConfig.regionType;
-      delete regionConfig.regionType;
+    if (regionConfig.regionClass) {
+      RegionClass = regionConfig.regionClass;
+      delete regionConfig.regionClass;
     }
 
-    if (regionIsString || regionIsType) {
+    if (regionIsString || regionIsClass) {
       regionConfig = {};
     }
 
     regionConfig.el = selector;
 
     // build the region instance
-    var region = new RegionType(regionConfig);
+    var region = new RegionClass(regionConfig);
 
     // override the `getEl` function if we have a parentEl
     // this must be overridden to ensure the selector is found

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -2,7 +2,7 @@
 // Marionette.View
 // ---------------
 
-// The core view type that other Marionette views extend from.
+// The core view class that other Marionette views extend from.
 Marionette.View = Backbone.View.extend({
 
   constructor: function(options) {


### PR DESCRIPTION
#### Resolves #1233 & #1237

I went through and changed every instance where we called a class a "type". 95% of these changes are just from `regionType` because we mention it all over the place.

---

**Changes:**
- Rename `regionType` to `regionClass`
  - Update all of src, docs, and specs
- "TemplateCache type" to "TemplateCache class"
- `ChildViewType` to `ChildViewClass`
  - Fixes typo (#1237)
  - Update all of src, docs, and specs
- Misc uses of types instead of classes
