### PR TITLE
Replace static helper methods

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -4,9 +4,9 @@ describe('region', function() {
 
   describe('when creating a new region and no configuration has been provided', function() {
     it('should throw an exception saying an "el" is required', function() {
-      expect(
-        Backbone.Marionette.Region.extend({})
-      ).toThrow('An "el" must be specified for a region.');
+      expect(function () {
+        return new Backbone.Marionette.Region();
+      }).toThrow('An "el" must be specified for a region.');
     });
   });
 

--- a/src/marionette.application.js
+++ b/src/marionette.application.js
@@ -14,8 +14,6 @@ Marionette.Application = function(options) {
   this.submodules = {};
 
   _.extend(this, options);
-
-  this.triggerMethod = Marionette.triggerMethod;
 };
 
 _.extend(Marionette.Application.prototype, Backbone.Events, {
@@ -100,7 +98,11 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
     this.listenTo(this._regionManager, 'region:remove', function(name, region) {
       delete this[name];
     });
-  }
+  },
+
+  // import the `triggerMethod` to trigger events with corresponding
+  // methods if the method exists
+  triggerMethod: Marionette.triggerMethod
 });
 
 // Copy the `extend` function used by Backbone's classes

--- a/src/marionette.approuter.js
+++ b/src/marionette.approuter.js
@@ -23,7 +23,7 @@ Marionette.AppRouter = Backbone.Router.extend({
 
     this.options = options || {};
 
-    var appRoutes = Marionette.getOption(this, 'appRoutes');
+    var appRoutes = this.getOption('appRoutes');
     var controller = this._getController();
     this.processAppRoutes(controller, appRoutes);
     this.on('route', this._processOnRoute, this);
@@ -62,7 +62,7 @@ Marionette.AppRouter = Backbone.Router.extend({
   },
 
   _getController: function() {
-    return Marionette.getOption(this, 'controller');
+    return this.getOption('controller');
   },
 
   _addAppRoute: function(controller, route, methodName) {
@@ -73,5 +73,8 @@ Marionette.AppRouter = Backbone.Router.extend({
     }
 
     this.route(route, methodName, _.bind(method, controller));
-  }
+  },
+
+  // Proxy `getOption` to enable getting options from this or this.options by name.
+  getOption: Marionette.proxyGetOption
 });

--- a/src/marionette.behavior.js
+++ b/src/marionette.behavior.js
@@ -36,8 +36,18 @@ Marionette.Behavior = (function(_, Backbone) {
       this.stopListening();
     },
 
-    // Setup class level proxy for triggerMethod.
-    triggerMethod: Marionette.triggerMethod
+    // import the `triggerMethod` to trigger events with corresponding
+    // methods if the method exists
+    triggerMethod: Marionette.triggerMethod,
+
+    // Proxy `getOption` to enable getting options from this or this.options by name.
+    getOption: Marionette.proxyGetOption,
+
+    // Proxy `unbindEntityEvents` to enable binding view's events from another entity.
+    bindEntityEvents: Marionette.proxyBindEntityEvents,
+
+    // Proxy `unbindEntityEvents` to enable unbinding view's events from another entity.
+    unbindEntityEvents: Marionette.proxyUnbindEntityEvents
   });
 
   // Borrow Backbones extend implementation

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -164,7 +164,7 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Retrieve the empty view class
   getEmptyView: function() {
-    return Marionette.getOption(this, 'emptyView');
+    return this.getOption('emptyView');
   },
 
   // Render and show the emptyView. Similar to addChild method
@@ -173,8 +173,8 @@ Marionette.CollectionView = Marionette.View.extend({
   addEmptyView: function(child, EmptyView){
 
     // get the emptyViewOptions, falling back to childViewOptions
-    var emptyViewOptions = Marionette.getOption(this, 'emptyViewOptions') ||
-                          Marionette.getOption(this, 'childViewOptions');
+    var emptyViewOptions = this.getOption('emptyViewOptions') ||
+                          this.getOption('childViewOptions');
 
     if (_.isFunction(emptyViewOptions)){
       emptyViewOptions = emptyViewOptions.call(this);
@@ -193,7 +193,7 @@ Marionette.CollectionView = Marionette.View.extend({
     // call the 'show' method if the collection view
     // has already been shown
     if (this._isShown){
-      Marionette.triggerMethod.call(view, 'show');
+      this.triggerMethod.call(view, 'show');
     }
   },
 
@@ -201,7 +201,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // or from the `childView` in the object definition. The "options"
   // takes precedence.
   getChildView: function(child) {
-    var childView = Marionette.getOption(this, 'childView');
+    var childView = this.getOption('childView');
 
     if (!childView) {
       throwError('A "childView" must be specified', 'NoChildViewError');
@@ -215,7 +215,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // This will also update the indices of later views in the collection
   // in order to keep the children in sync with the collection.
   addChild: function(child, ChildView, index) {
-    var childViewOptions = Marionette.getOption(this, 'childViewOptions');
+    var childViewOptions = this.getOption('childViewOptions');
     if (_.isFunction(childViewOptions)) {
       childViewOptions = childViewOptions.call(this, child, index);
     }
@@ -273,7 +273,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this.renderChildView(view, index);
 
     if (this._isShown && !this.isBuffering) {
-      view.triggerMethod('show');
+      this.triggerMethod.call(this, 'show');
     }
 
     this.triggerMethod('after:child:added', view);
@@ -403,7 +403,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // Set up the child view event forwarding. Uses a "childview:"
   // prefix in front of all forwarded events.
   proxyChildEvents: function(view) {
-    var prefix = Marionette.getOption(this, 'childViewEventPrefix');
+    var prefix = this.getOption('childViewEventPrefix');
 
     // Forward all child view events through the parent,
     // prepending "childview:" to the event name
@@ -420,7 +420,7 @@ Marionette.CollectionView = Marionette.View.extend({
         childEvents[rootEvent].apply(this, args);
       }
 
-      Marionette.triggerMethod.apply(this, args);
+      this.triggerMethod.apply(this, args);
     }, this);
   }
 });

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -43,7 +43,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // `this.childView` or Marionette.CompositeView if no `childView`
   // has been defined
   getChildView: function(child) {
-    var childView = Marionette.getOption(this, 'childView') || this.constructor;
+    var childView = this.getOption('childView') || this.constructor;
 
     if (!childView) {
       throwError('A "childView" must be specified', 'NoChildViewError');

--- a/src/marionette.controller.js
+++ b/src/marionette.controller.js
@@ -27,6 +27,11 @@ _.extend(Marionette.Controller.prototype, Backbone.Events, {
     this.off();
   },
 
+  // import the `triggerMethod` to trigger events with corresponding
+  // methods if the method exists
+  triggerMethod: Marionette.triggerMethod,
+
   // Proxy `getOption` to enable getting options from this or this.options by name.
   getOption: Marionette.proxyGetOption
+
 });

--- a/src/marionette.layoutview.js
+++ b/src/marionette.layoutview.js
@@ -80,7 +80,7 @@ Marionette.LayoutView = Marionette.ItemView.extend({
     var that = this;
 
     var defaults = {
-      regionClass: Marionette.getOption(this, 'regionClass'),
+      regionClass: this.getOption('regionClass'),
       parentEl: function() { return that.$el; }
     };
 

--- a/src/marionette.module.js
+++ b/src/marionette.module.js
@@ -24,9 +24,6 @@ Marionette.Module = function(moduleName, app, options) {
   // By default modules start with their parents.
   this.startWithParent = true;
 
-  // Setup a proxy to the trigger method implementation.
-  this.triggerMethod = Marionette.triggerMethod;
-
   if (_.isFunction(this.initialize)) {
     this.initialize(moduleName, app, this.options);
   }
@@ -84,7 +81,7 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
     if (!this._isInitialized) { return; }
     this._isInitialized = false;
 
-    Marionette.triggerMethod.call(this, 'before:stop');
+    this.triggerMethod('before:stop');
 
     // stop the sub-modules; depth-first, to make sure the
     // sub-modules are stopped / finalized before parents
@@ -97,7 +94,7 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
     this._initializerCallbacks.reset();
     this._finalizerCallbacks.reset();
 
-    Marionette.triggerMethod.call(this, 'stop');
+    this.triggerMethod('stop');
   },
 
   // Configure the module with a definition function and any custom args
@@ -131,7 +128,11 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
   _setupInitializersAndFinalizers: function() {
     this._initializerCallbacks = new Marionette.Callbacks();
     this._finalizerCallbacks = new Marionette.Callbacks();
-  }
+  },
+
+  // import the `triggerMethod` to trigger events with corresponding
+  // methods if the method exists
+  triggerMethod: Marionette.triggerMethod
 });
 
 // Class methods to create modules

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -8,7 +8,7 @@
 
 Marionette.Region = function(options) {
   this.options = options || {};
-  this.el = Marionette.getOption(this, 'el');
+  this.el = this.getOption('el');
 
   if (!this.el) {
     throwError('An "el" must be specified for a region.', 'NoElError');
@@ -136,8 +136,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     }
 
     view.render();
-    Marionette.triggerMethod.call(this, 'before:show', view);
-    Marionette.triggerMethod.call(view, 'before:show');
+    this.triggerMethod('before:show', view);
+    this.triggerMethod.call(view, 'before:show');
 
     if (isDifferentView) {
       this.open(view);
@@ -145,8 +145,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     this.currentView = view;
 
-    Marionette.triggerMethod.call(this, 'show', view);
-    Marionette.triggerMethod.call(view, 'show');
+    this.triggerMethod('show', view);
+    this.triggerMethod.call(view, 'show');
   },
 
   ensureEl: function() {
@@ -177,13 +177,13 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     var view = this.currentView;
     if (!view || view.isDestroyed) { return; }
 
-    Marionette.triggerMethod.call(this, 'before:destroy', view);
+    this.triggerMethod('before:destroy', view);
 
     // call 'destroy' or 'remove', depending on which is found
     if (view.destroy) { view.destroy(); }
     else if (view.remove) { view.remove(); }
 
-    Marionette.triggerMethod.call(this, 'destroy', view);
+    this.triggerMethod('destroy', view);
 
     delete this.currentView;
   },
@@ -203,7 +203,14 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   reset: function() {
     this.destroy();
     delete this.$el;
-  }
+  },
+
+  // Proxy `getOption` to enable getting options from this or this.options by name.
+  getOption: Marionette.proxyGetOption,
+
+  // import the `triggerMethod` to trigger events with corresponding
+  // methods if the method exists
+  triggerMethod: Marionette.triggerMethod
 });
 
 // Copy the `extend` function used by Backbone's classes

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -25,20 +25,12 @@ Marionette.View = Backbone.View.extend({
     this.listenTo(this, 'show', this.onShowCalled);
   },
 
-  // import the "triggerMethod" to trigger events with corresponding
-  // methods if the method exists
-  triggerMethod: Marionette.triggerMethod,
-
-  // Imports the "normalizeMethods" to transform hashes of
-  // events=>function references/names to a hash of events=>function references
-  normalizeMethods: Marionette.normalizeMethods,
-
   // Get the template for this view
   // instance. You can set a `template` attribute in the view
   // definition or pass a `template: "whatever"` parameter in
   // to the constructor options.
   getTemplate: function() {
-    return Marionette.getOption(this, 'template');
+    return this.getOption('template');
   },
 
   // Mix in template helper methods. Looks for a
@@ -48,7 +40,7 @@ Marionette.View = Backbone.View.extend({
   // are copies to the object passed in.
   mixinTemplateHelpers: function(target) {
     target = target || {};
-    var templateHelpers = Marionette.getOption(this, 'templateHelpers');
+    var templateHelpers = this.getOption('templateHelpers');
     if (_.isFunction(templateHelpers)) {
       templateHelpers = templateHelpers.call(this);
     }
@@ -113,8 +105,8 @@ Marionette.View = Backbone.View.extend({
   // the `triggers`, `modelEvents`, and `collectionEvents` configuration
   delegateEvents: function(events) {
     this._delegateDOMEvents(events);
-    Marionette.bindEntityEvents(this, this.model, Marionette.getOption(this, 'modelEvents'));
-    Marionette.bindEntityEvents(this, this.collection, Marionette.getOption(this, 'collectionEvents'));
+    this.bindEntityEvents(this.model, this.getOption('modelEvents'));
+    this.bindEntityEvents(this.collection, this.getOption('collectionEvents'));
   },
 
   // internal method to delegate DOM events and triggers
@@ -139,8 +131,8 @@ Marionette.View = Backbone.View.extend({
   undelegateEvents: function() {
     var args = Array.prototype.slice.call(arguments);
     Backbone.View.prototype.undelegateEvents.apply(this, args);
-    Marionette.unbindEntityEvents(this, this.model, Marionette.getOption(this, 'modelEvents'));
-    Marionette.unbindEntityEvents(this, this.collection, Marionette.getOption(this, 'collectionEvents'));
+    this.unbindEntityEvents(this.model, this.getOption('modelEvents'));
+    this.unbindEntityEvents(this.collection, this.getOption('collectionEvents'));
   },
 
   // Internal method, handles the `show` event.
@@ -216,6 +208,14 @@ Marionette.View = Backbone.View.extend({
     this.ui = this._uiBindings;
     delete this._uiBindings;
   },
+
+  // import the `triggerMethod` to trigger events with corresponding
+  // methods if the method exists
+  triggerMethod: Marionette.triggerMethod,
+
+  // Imports the "normalizeMethods" to transform hashes of
+  // events=>function references/names to a hash of events=>function references
+  normalizeMethods: Marionette.normalizeMethods,
 
   // Proxy `getOption` to enable getting options from this or this.options by name.
   getOption: Marionette.proxyGetOption,


### PR DESCRIPTION
#### Resolves #1240

**Changes:**
- All proxy method references have been moved to the bottom of Class.prototype extends for consistency. ie:

``` js
_.extend(Marionette.Class.prototype, {
  // ... 
  triggerMethod: Marionette.triggerMethod,
  getOption: Marionette.proxyGetOption
});
```
- Classes always use their own helper methods instead of another Class'.\* This is due to the way we currently write our tests (with spies rather than mock classes). ie:

``` js
this.triggerMethod.call(foo, 'bar');
```
- Replaces all static helper method calls with proxy methods

---

*As I said before, I'm not a big fan of this, but it's the best I can do without breaking literally hundreds of tests
