### PR TITLE
Remove BitDeli badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -251,5 +251,3 @@ LosTechies.com blog.
 Copyright (c) 2012-2014 Derick Bailey; Muted Solutions, LLC
 
 Distributed under [MIT license](http://mutedsolutions.mit-license.org/).
-
-[![bitdeli analytics](https://d2weczhvl823v0.cloudfront.net/marionettejs/backbone.marionette/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
BitDeli is essentially dead due to updates by GitHub in January. Relevant articles:
http://blog.bitdeli.com/post/77717727361/on-githubs-image-proxy
https://github.com/blog/1672-introducing-github-traffic-analytics
