### PR TITLE
internal listeners use _handle

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -271,7 +271,7 @@ describe('collection view', function() {
       spyOn(childView, 'destroy').andCallThrough();
       spyOn(EmptyView.prototype, 'render');
 
-      collectionView.onChildRemove(model);
+      collectionView._handleChildRemove(model);
     });
 
     it('should destroy the models view', function() {
@@ -380,7 +380,7 @@ describe('collection view', function() {
       collectionView.listenTo(collectionView, 'item:foo', collectionView.someItemViewCallback);
 
       spyOn(childView, 'destroy').andCallThrough();
-      spyOn(collectionView, 'onChildRemove').andCallThrough();
+      spyOn(collectionView, '_handleChildRemove').andCallThrough();
       spyOn(collectionView, 'stopListening').andCallThrough();
       spyOn(collectionView, 'remove').andCallThrough();
       spyOn(collectionView, 'someCallback').andCallThrough();

--- a/spec/javascripts/compositeView-childViewContainer.spec.js
+++ b/spec/javascripts/compositeView-childViewContainer.spec.js
@@ -218,16 +218,16 @@ describe('composite view - childViewContainer', function() {
       compositeView = new CompositeView({
         collection: collection
       });
-      spyOn(compositeView, 'onChildAdd').andCallThrough();
+      spyOn(compositeView, '_handleChildAdd').andCallThrough();
     });
 
     it('should not raise any errors when item is added to collection', function() {
       expect(addModel).not.toThrow();
     });
 
-    it('should not call onChildAdd when item is added to collection', function() {
+    it('should not call _handleChildAdd when item is added to collection', function() {
       addModel();
-      expect(compositeView.onChildAdd).not.toHaveBeenCalled();
+      expect(compositeView._handleChildAdd).not.toHaveBeenCalled();
     });
 
     it('should not raise any errors when item is removed from collection', function() {

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -56,26 +56,28 @@ Marionette.CollectionView = Marionette.View.extend({
   // binds to.
   _initialEvents: function() {
     if (this.collection) {
-      this.listenTo(this.collection, 'add', this.onChildAdd);
-      this.listenTo(this.collection, 'remove', this.onChildRemove);
+      this.listenTo(this.collection, 'add', this._handleChildAdd);
+      this.listenTo(this.collection, 'remove', this._handleChildRemove);
       this.listenTo(this.collection, 'reset', this.render);
 
       if (this.sort) {
-        this.listenTo(this.collection, 'sort', this._sortViews);
+        this.listenTo(this.collection, 'sort', this._handleSort);
       }
     }
   },
 
+  // Internal Method
   // Handle a child added to the collection
-  onChildAdd: function(child, collection, options) {
+  _handleChildAdd: function(child, collection, options) {
     this.destroyEmptyView();
     var ChildView = this.getChildView(child);
     var index = this.collection.indexOf(child);
     this.addChild(child, ChildView, index);
   },
 
+  // Internal Method
   // get the child view by model it holds, and remove it
-  onChildRemove: function(model) {
+  _handleChildRemove: function(model) {
     var view = this.children.findByModel(model);
     this.removeChildView(view);
     this.checkEmpty();
@@ -99,7 +101,7 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Internal method. This checks for any changes in the order of the collection.
   // If the index of any view doesn't match, it will render.
-  _sortViews: function(){
+  _handleSort: function(){
     // check for any changes in sort order of views
     var orderChanged = this.collection.find(function(item, index){
       var view = this.children.findByModel(item);

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -26,12 +26,12 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     // to nonexistent childViewContainer
     this.once('render', function() {
       if (this.collection) {
-        this.listenTo(this.collection, 'add', this.onChildAdd);
-        this.listenTo(this.collection, 'remove', this.onChildRemove);
+        this.listenTo(this.collection, 'add', this._handleChildAdd);
+        this.listenTo(this.collection, 'remove', this._handleChildRemove);
         this.listenTo(this.collection, 'reset', this._renderChildren);
 
         if (this.sort) {
-          this.listenTo(this.collection, 'sort', this._sortViews);
+          this.listenTo(this.collection, 'sort', this._handleSort);
         }
       }
     });


### PR DESCRIPTION
Fixes #1211

Changed internal listeners in `CollectionView` and `CompositeView` to use the `_handle` prefix. I can expand this to apply to all internal listeners in all classes if needs be, but at least this change lets us progress with bigger API changes.

ping @jmeas
