### PR TITLE
Normalize region this.el

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -73,6 +73,22 @@ var mgr = new Backbone.Marionette.Region({
 });
 ```
 
+The `el` option can also be a raw DOM node reference:
+
+```js
+var mgr = new Backbone.Marionette.Region({
+  el: document.querySelector("body")
+});
+```
+
+Or the `el` can also be a `jQuery` wrapped DOM node:
+
+```js
+var mgr = new Backbone.Marionette.Region({
+  el: $("body")
+});
+```
+
 ## Basic Use
 
 ### Showing a View

--- a/spec/javascripts/application.appRegions.spec.js
+++ b/spec/javascripts/application.appRegions.spec.js
@@ -76,7 +76,7 @@ describe('application regions', function() {
     });
 
     it('should set the specified selector', function() {
-      expect(MyApp.MyRegion.el).toBe('#region');
+      expect(MyApp.MyRegion.$el.selector).toBe('#region');
     });
 
     it('should pass extra options to the custom regionClass', function() {

--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -9,6 +9,46 @@ describe('region', function() {
     });
   });
 
+  describe('when passing an el DOM reference in directly', function() {
+    beforeEach(function() {
+      setFixtures('<div id="region"></div>');
+      this.el = $('#region')[0];
+
+      this.customRegion = new (Backbone.Marionette.Region.extend({
+        el: this.el
+      }))();
+
+      this.optionRegion = new Backbone.Marionette.Region({el: this.el});
+
+      this.optionRegionJquery = new Backbone.Marionette.Region({el: $(this.el)});
+    });
+
+    it('should work when el is passed in as an option', function() {
+      expect(this.optionRegionJquery.$el[0]).toEqual(this.el);
+      expect(this.optionRegionJquery.el).toEqual(this.el);
+    });
+
+    it('should handle when the el option is passed in as a jquery selector', function() {
+      expect(this.optionRegion.$el[0]).toEqual(this.el);
+    });
+
+    it('should work when el is set in the region extend', function() {
+      expect(this.customRegion.$el[0]).toEqual(this.el);
+    });
+
+    it('should complain if the el passed in as an option is invalid', function() {
+      expect(function() {
+        Backbone.Marionette.Region({el: $("the-ghost-of-lechuck")[0]});
+      }).toThrow();
+    });
+
+    it('should complain if the el passed in via an extended region is invalid', function() {
+      expect(function() {
+        (Backbone.Marionette.Region.extend({el: $("the-ghost-of-lechuck")[0]}))();
+      }).toThrow();
+    });
+  });
+
   describe('when creating a new region and the "el" does not exist in DOM', function() {
     var MyRegion = Backbone.Marionette.Region.extend({
       el: '#not-existed-region'
@@ -81,6 +121,10 @@ describe('region', function() {
 
     it('should render the view', function() {
       expect(view.render).toHaveBeenCalled();
+    });
+
+    it('should set $el and el', function() {
+      expect(myRegion.$el[0]).toEqual(myRegion.el);
     });
 
     it('should append the rendered HTML to the managers "el"', function() {
@@ -505,7 +549,7 @@ describe('region', function() {
     });
 
     it('should manage the specified el', function() {
-      expect(region.el).toBe(el);
+      expect(region.$el.selector).toBe(el);
     });
   });
 

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -10,9 +10,14 @@ Marionette.Region = function(options) {
   this.options = options || {};
   this.el = this.getOption('el');
 
+  // Handle when this.el is passed in as a $ wrapped element.
+  this.el = this.el instanceof Backbone.$ ? this.el[0] : this.el;
+
   if (!this.el) {
     throwError('An "el" must be specified for a region.', 'NoElError');
   }
+
+  this.$el = this.getEl(this.el);
 
   if (this.initialize) {
     var args = Array.prototype.slice.apply(arguments);
@@ -95,12 +100,15 @@ _.extend(Marionette.Region, {
     // literal to build the region, the element will not be
     // guaranteed to be in the DOM already, and will cause problems
     if (regionConfig.parentEl) {
-      region.getEl = function(selector) {
+      region.getEl = function(el) {
+        if (_.isObject(el)) {
+          return Backbone.$(el);
+        }
         var parentEl = regionConfig.parentEl;
         if (_.isFunction(parentEl)) {
           parentEl = parentEl();
         }
-        return parentEl.find(selector);
+        return parentEl.find(el);
       };
     }
 
@@ -156,19 +164,20 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   },
 
   ensureEl: function() {
-    if (!this.$el || this.$el.length === 0) {
+    if (!_.isObject(this.el)) {
       this.$el = this.getEl(this.el);
+      this.el = this.$el[0];
     }
 
-    if (this.$el.length === 0) {
-      throwError('An "el" ' + this.el + ' must exist in DOM');
+    if (!this.$el || this.$el.length === 0) {
+      throwError('An "el" ' + this.$el.selector + ' must exist in DOM');
     }
   },
 
   // Override this method to change how the region finds the
   // DOM element that it manages. Return a jQuery selector object.
-  getEl: function(selector) {
-    return Backbone.$(selector);
+  getEl: function(el) {
+    return Backbone.$(el);
   },
 
   // Override this method to change how the new view is
@@ -208,6 +217,11 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   // DOM for the region's `el`.
   reset: function() {
     this.destroy();
+
+    if (this.$el) {
+      this.el = this.$el.selector;
+    }
+
     delete this.$el;
   },
 


### PR DESCRIPTION
The big change here is the a regions this.el is a DOM node and not the selector
I still retain the selector in `this._el`

Let me know your thoughts and i will flush this out more.

fixes #1259
