### PR TITLE
Update Grouped Behavior setup.

### DIFF
--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -479,14 +479,12 @@ describe('Behaviors', function() {
   });
 
   describe('behavior trigger calls', function() {
-    var spy, View, hold;
+    var onRenderSpy, View, hold;
     beforeEach(function() {
-      spy = sinon.spy();
+      onRenderSpy = sinon.spy();
       hold = {};
       hold.testB = Marionette.Behavior.extend({
-        onRender: function() {
-          spy();
-        }
+        onRender: onRenderSpy
       });
 
       View = Marionette.View.extend({
@@ -501,7 +499,7 @@ describe('Behaviors', function() {
     it('should call onRender when a view is rendered', function() {
       var view = new View();
       view.triggerMethod('render');
-      expect(spy).toHaveBeenCalled();
+      expect(onRenderSpy).toHaveBeenCalled();
     });
   });
 
@@ -536,19 +534,28 @@ describe('Behaviors', function() {
   });
 
   describe('behavior with behavior', function() {
-    var initSpy, renderSpy, childRenderSpy, entityEventSpy, viewEventSpy;
+    var initSpy, renderSpy, childRenderSpy, entityEventSpy;
+    var viewEventSpy, childEventSpy, parentEventSpy;
     var View, v, m, c, hold, parentBehavior, childBehavior;
     beforeEach(function() {
       initSpy = sinon.spy();
       renderSpy = sinon.spy();
       childRenderSpy = sinon.spy();
       entityEventSpy = sinon.spy();
+      childEventSpy = sinon.spy();
+      parentEventSpy = sinon.spy();
       viewEventSpy = sinon.spy();
 
       hold = {};
       hold.parentB = Marionette.Behavior.extend({
         initialize: function() {
           parentBehavior = this;
+        },
+        ui: {
+          parent: '.parent'
+        },
+        events: {
+          'click @ui.parent': parentEventSpy
         },
         behaviors: {
           childB: {}
@@ -571,17 +578,19 @@ describe('Behaviors', function() {
           'sync': entityEventSpy
         },
         events: {
-          'click @ui.view': viewEventSpy,
-          'click @ui.child': viewEventSpy
+          'click @ui.child': childEventSpy
         },
       });
 
       Marionette.Behaviors.behaviorsLookup = hold;
 
       View = Marionette.CompositeView.extend({
-        template: _.template('<div class="view"></div><div class="child"></div>'),
+        template: _.template('<div class="view"></div><div class="parent"></div><div class="child"></div>'),
         ui: {
           view: '.view'
+        },
+        events: {
+          'click @ui.view': viewEventSpy,
         },
         onRender: renderSpy,
         behaviors: {
@@ -626,16 +635,22 @@ describe('Behaviors', function() {
       expect(entityEventSpy).toHaveBeenCalledOn(childBehavior);
     });
 
-    it('should proxy view UI events to child behavior', function() {
-      v.render();
-      v.$('.view').trigger('click');
-      expect(viewEventSpy).toHaveBeenCalledOn(childBehavior);
-    });
-
     it('should proxy child behavior UI events to child behavior', function() {
       v.render();
       v.$('.child').trigger('click');
-      expect(viewEventSpy).toHaveBeenCalledOn(childBehavior);
+      expect(childEventSpy).toHaveBeenCalledOn(childBehavior);
+    });
+
+    it('should proxy parent behavior UI events to parent behavior', function() {
+      v.render();
+      v.$('.parent').trigger('click');
+      expect(parentEventSpy).toHaveBeenCalledOn(parentBehavior);
+    });
+
+    it('should proxy view UI events to view', function() {
+      v.render();
+      v.$('.view').trigger('click');
+      expect(viewEventSpy).toHaveBeenCalledOn(v);
     });
   });
 });

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -25,12 +25,6 @@ Marionette.Behaviors = (function(Marionette, _) {
       'behaviorEvents', 'triggerMethod',
       'setElement', 'destroy'
     ]);
-
-    _.each(behaviors, function(b) {
-      if (!_.isUndefined(_.result(b, 'behaviors'))) {
-        new Behaviors(view, _.result(b, 'behaviors'));
-      }
-    });
   }
 
   var methods = {
@@ -188,14 +182,17 @@ Marionette.Behaviors = (function(Marionette, _) {
       return _.isFunction(Behaviors.behaviorsLookup) ? Behaviors.behaviorsLookup.apply(this, arguments)[key] : Behaviors.behaviorsLookup[key];
     },
 
-    // Maps over a view's behaviors. Performing
-    // a lookup on each behavior and the instantiating
-    // said behavior passing its options and view.
+    // Iterate over the behaviors object, for each behavior
+    // instanciate it and get its nested behaviors.
     parseBehaviors: function(view, behaviors) {
-      return _.map(behaviors, function(options, key) {
+      return _.chain(behaviors).map(function(options, key) {
         var BehaviorClass = Behaviors.getBehaviorClass(options, key);
-        return new BehaviorClass(options, view);
-      });
+
+        var behavior = new BehaviorClass(options, view);
+        var nestedBehaviors = Behaviors.parseBehaviors(view, _.result(behavior, 'behaviors'));
+
+        return [behavior].concat(nestedBehaviors);
+      }).flatten().value();
     },
 
     // wrap view internal methods so that they delegate to behaviors. For example,


### PR DESCRIPTION
This does a couple things mentioned in #1265
1. it dramatically simplifies behavior setup by not "re-wrapping" view methods
2. it fixes the problem where the "parent" behavior's events were not being bound
3. it cleans up some of the behavior tests. More should be done here in the future...

This commit should be squashed down into the initial child behavior commit.
