### PR TITLE
Region#show return currentView

### DIFF
--- a/docs/marionette.layout.md
+++ b/docs/marionette.layout.md
@@ -165,6 +165,31 @@ layout.show(new MenuView());
 You can nest layouts into region managers as deeply as you want.
 This provides for a well organized, nested view structure.
 
+For example, to nest 3 layouts (all of these are equivalent):
+
+```js
+var layout1 = new Layout1();
+var layout2 = new Layout2();
+var layout3 = new Layout3();
+MyApp.mainRegion.show(layout1);
+layout1.region1.show(layout2);
+layout2.region2.show(layout3);
+```
+
+```js
+MyApp.mainRegion.show(new Layout1());
+MyApp.mainRegion.currentView.myRegion1.show(new Layout2());
+MyApp.mainRegion.currentView.myRegion1.currentView.myRegion2.show(new Layout3());
+```
+
+Or if you like chaining:
+
+```js
+MyApp.mainRegion.show(new Layout1())
+  .currentView.myRegion1.show(new Layout2())
+  .currentView.myRegion2.show(new Layout3());
+```
+
 ## Closing A Layout
 
 When you are finished with a layout, you can call the

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -144,6 +144,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     Marionette.triggerMethod.call(this, "show", view);
     Marionette.triggerMethod.call(view, "show");
+
+    return this;
   },
 
   ensureEl: function(){


### PR DESCRIPTION
Adds the capability to write

```
myRegion1.show(new MyLayout1());
myRegion1.currentView.myRegion2.show(new MyLayout2());
myRegion1.currentView.myRegion2.currentView.myRegion3.show(new MyLayout3());
... etc
```

as 

```
myRegion1.show(new MyLayout1()).myRegion2
         .show(new MyLayout2()).myRegion3
         .show(new MyLayout3()) ... etc
```
