### PR TITLE
DO NOT MERGE: proof of concept multiple event handlers

### DIFF
--- a/spec/javascripts/view.uiEventAndTriggers.spec.js
+++ b/spec/javascripts/view.uiEventAndTriggers.spec.js
@@ -2,7 +2,7 @@ describe('view ui event trigger configuration', function() {
   'use strict';
 
   describe('@ui syntax within events and triggers', function() {
-    var view, view2, view3, fooHandler, attackHandler, tapHandler, defendHandler;
+    var view, view2, view3, fooHandler, attackHandler, tapHandler, defendHandler, yieldHandler;
 
     var View = Backbone.Marionette.ItemView.extend({
       ui: {
@@ -16,9 +16,13 @@ describe('view ui event trigger configuration', function() {
       },
 
       events: {
-        'click @ui.bar': 'attack',
+        'click @ui.bar': ['attack', 'yield'],
         'click div:not(@ui.bar)': 'tapper',
         'click @ui.bar, @ui.foo, @ui.bat': 'defend'
+      },
+
+      yield: function() {
+        yieldHandler();
       },
 
       tapper: function() {
@@ -87,6 +91,7 @@ describe('view ui event trigger configuration', function() {
       attackHandler = jasmine.createSpy('attack handler');
       defendHandler = jasmine.createSpy('defend handler');
       tapHandler = jasmine.createSpy('tap handler');
+      yieldHandler = jasmine.createSpy('yield handler');
       spyOn(view, 'attack').andCallThrough();
       view.on('do:foo', fooHandler);
       view2.on('do:foo', fooHandler);
@@ -105,6 +110,7 @@ describe('view ui event trigger configuration', function() {
     it('should correctly call an event', function() {
       view.$('#tap').trigger('click');
       expect(attackHandler).toHaveBeenCalled();
+      expect(yieldHandler).toHaveBeenCalled();
     });
 
     it('should correctly call an event with a functional events hash', function() {

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -16,6 +16,9 @@ Marionette.View = Backbone.View.extend({
     // parses out the @ui DSL for events
     this.events = this.normalizeUIKeys(_.result(this, 'events'));
 
+    // normalize array formated multiple event methods
+    this.events = this.normalizeHandlers(this.events);
+
     if (_.isObject(this.behaviors)) {
       new Marionette.Behaviors(this);
     }
@@ -48,6 +51,22 @@ Marionette.View = Backbone.View.extend({
     return _.extend(target, templateHelpers);
   },
 
+  normalizeHandlers: function(hash) {
+    return _.chain(hash)
+            .pairs()
+            .reduce(function(events, pair){
+              if (_.isArray(pair[1])) {
+                _.each(pair[1], function(action, i) {
+                  events.push([pair[0] + (new Array(i + 1)).join(' '), action]);
+                });
+              } else {
+                events.push(pair);
+              }
+              return events;
+            }, [])
+            .object()
+            .value();
+  },
 
   normalizeUIKeys: function(hash) {
     var ui = _.result(this, 'ui');


### PR DESCRIPTION
Ok this is a proof of concept for #1034 

Ended up with this syntax for defining multiple event handlers 

``` js
      events: {
        'click @ui.bar': ['attack', 'yield']
      }
```

Which I think is much better than defining another space delimitated DSL.
This also has the added advantage of not being breaking!

---

Let me know what you guys think and I will extend this functionality to the other events: 
- `collectionEvents`
- `modelEvents`

^ I think that is all right?
