### PR TITLE
Itemevent argz

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -804,7 +804,7 @@ describe('collection view', function() {
     });
 
     it('should provide the child view that triggered the event, including other relevant parameters', function() {
-      expect(someEventSpy).toHaveBeenCalledWith('childview:some:event', childView, 'test', model);
+      expect(someEventSpy).toHaveBeenCalledWith(childView, 'test', model);
     });
   });
 
@@ -836,7 +836,7 @@ describe('collection view', function() {
     });
 
     it('should provide the child view that triggered the event, including other relevant parameters', function() {
-      expect(onSomeEventSpy).toHaveBeenCalledWith('childview:some:event', childView, 'test', model);
+      expect(onSomeEventSpy).toHaveBeenCalledWith(childView, 'test', model);
     });
   });
 
@@ -869,7 +869,7 @@ describe('collection view', function() {
     });
 
     it('should provide the child view that triggered the event, including other relevant parameters', function() {
-      expect(someEventSpy).toHaveBeenCalledWith('childview:some:event', childView, 'test', model);
+      expect(someEventSpy).toHaveBeenCalledWith(childView, 'test', model);
     });
   });
 

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -417,7 +417,7 @@ Marionette.CollectionView = Marionette.View.extend({
 
       // call collectionView childEvent if defined
       if (typeof childEvents !== 'undefined' && _.isFunction(childEvents[rootEvent])) {
-        childEvents[rootEvent].apply(this, args);
+        childEvents[rootEvent].apply(this, args.slice(1));
       }
 
       this.triggerMethod.apply(this, args);


### PR DESCRIPTION
This change adds consistency to our callbacks for children events.

As every1 knows when you call `trigger` from a Backbone Event'ed object, you pass in the name of the event, then any additional arguments.

`myObj.trigger('some:event', argOne, argTwo);`

You prob. also know that registered callbacks for `some:event` do not get the name of the event as the first argument; they only get `argOne` and `argTwo`.

Our collection view code set up a `listen`-like system where we listened to events on the children and triggered callbacks. These callbacks were getting **all** of the arguments – even the name of the event. This was inconsistent & is gone now.

This fixes #1154
