### PR TITLE
Fix UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-preprocess": "~4.0.0",
     "grunt-bower-task": "~0.3.4",
-    "grunt-template": "^0.2.3"
+    "grunt-template": "^0.2.3",
+    "unwrap": "^0.1.0"
   }
 }

--- a/src/build/marionette.bundled.js
+++ b/src/build/marionette.bundled.js
@@ -1,21 +1,26 @@
 (function(root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['exports', 'backbone', 'underscore'], function(exports, Backbone, _) {
-      root.Marionette = factory(root, exports, Backbone, _);
+    define(['backbone', 'underscore'], function(Backbone, _) {
+      return (root.Marionette = factory(root, Backbone, _));
     });
   } else if (typeof exports !== 'undefined') {
     var Backbone = require('backbone');
     var _ = require('underscore');
-    factory(root, exports, Backbone, _);
+    module.exports = factory(root, Backbone, _);
   } else {
-    root.Marionette = factory(root, {}, root.Backbone, root._);
+    root.Marionette = factory(root, root.Backbone, root._);
   }
 
-}(this, function(root, Marionette, Backbone, _) {
+}(this, function(root, Backbone, _) {
   'use strict';
 
+  // @include ../../tmp/backbone.babysitter.bare.js
+  // @include ../../tmp/backbone.wreqr.bare.js
+
   var previousMarionette = root.Marionette;
+
+  var Marionette = Backbone.Marionette = {};
 
   Marionette.VERSION = '<%= version %>';
 
@@ -23,8 +28,6 @@
     root.Marionette = previousMarionette;
     return this;
   };
-
-  Backbone.Marionette = Marionette;
 
   // Get the DOM manipulator for later use
   Marionette.$ = Backbone.$;

--- a/src/build/marionette.core.js
+++ b/src/build/marionette.core.js
@@ -1,23 +1,25 @@
 (function(root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['exports', 'backbone', 'underscore'], function(exports, Backbone, _) {
-      root.Marionette = factory(root, exports, Backbone, _);
+    define(['backbone', 'underscore'], function(Backbone, _) {
+      return (root.Marionette = factory(root, Backbone, _));
     });
   } else if (typeof exports !== 'undefined') {
     var Backbone = require('backbone');
     var _ = require('underscore');
-    require('backbone.wreqr');
-    require('backbone.babysitter');
-    factory(root, exports, Backbone, _);
+    var Wreqr = require('backbone.wreqr');
+    var BabySitter = require('backbone.babysitter');
+    module.exports = factory(root, Backbone, _);
   } else {
-    root.Marionette = factory(root, {}, root.Backbone, root._);
+    root.Marionette = factory(root, root.Backbone, root._);
   }
 
-}(this, function(root, Marionette, Backbone, _) {
+}(this, function(root, Backbone, _) {
   'use strict';
 
   var previousMarionette = root.Marionette;
+
+  var Marionette = Backbone.Marionette = {};
 
   Marionette.VERSION = '<%= version %>';
 
@@ -25,8 +27,6 @@
     root.Marionette = previousMarionette;
     return this;
   };
-
-  Backbone.Marionette = Marionette;
 
   // Get the DOM manipulator for later use
   Marionette.$ = Backbone.$;


### PR DESCRIPTION
~~**_DO NOT MERGE UNTIL BABYSITTER AND WREQR UMDS ARE OUT, TESTS WILL NOT PASS UNTIL THEN**_~~

---
#### 1/3 PRs resolving https://github.com/marionettejs/backbone.marionette/issues/1264

---

**Changes:**
- AMD: Return value instead of passing in exports object
- Common.js: Use `module.exports` instead of passing in exports object
- Globals: Don't pass in empty object
- Switch from concatenated build to import bare builds of wreqr and babysitter

---

[See built lib files here](https://gist.github.com/thejameskyle/ecde48a3cce63c2e1aa4)
