### PR TITLE
Moved Backbone and Underscore to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
   "github": "https://github.com/marionettejs/backbone.marionette",
   "dependencies": {
     "backbone.babysitter": "^0.1.0",
-    "backbone.wreqr": "^1.0.0",
+    "backbone.wreqr": "^1.0.0"
+  },
+  "peerDependencies": {
     "backbone": "1.0.0 - 1.1.2",
     "underscore": "1.4.4 - 1.6.0"
   },
@@ -60,6 +62,8 @@
     "bower": "1.2.8",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-preprocess": "~4.0.0"
+    "grunt-preprocess": "~4.0.0",
+    "backbone": "1.0.0 - 1.1.2",
+    "underscore": "1.4.4 - 1.6.0"
   }
 }


### PR DESCRIPTION
Resolves #1294 in [a less gross way](https://github.com/marionettejs/backbone.marionette/pull/1295).

How does this work?

Putting something as a `dependency` pulls in a new version of that library. This creates a clone of it in your built CommonJS file. When you set something as a `peerDependency` it won't nest it, and you won't make clones of it.

This is important when you need the same instance of the library, as you do with `Backbone.history`

Is this the solution?

It works, but I'm not sure if shimming is the real answer. Backbone sets Underscore as a dep so you'll already get a duplicate of that whether you want it or not. Maybe shimming is just the way to go w. CommonJS.

Will do more research.
