### PR TITLE
return view on region.show(view) to enable chaining call

### DIFF
--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -144,6 +144,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     Marionette.triggerMethod.call(this, "show", view);
     Marionette.triggerMethod.call(view, "show");
+
+    return view;
   },
 
   ensureEl: function(){


### PR DESCRIPTION
Return the view instance would permit this kind of code:

```
region.show(view)
  .on('an:event', function () {})
  .on('another:event', function () {});
```

It's like returning `this` in view.render() implementation.
