### PR TITLE
Fix SpecRunner tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -243,9 +243,9 @@ module.exports = function(grunt) {
 
   grunt.registerTask('lint', 'Lints our sources', ['lintspaces', 'jshint']);
 
-  grunt.registerTask('test', 'Run the unit tests.', ['lint', 'unwrap', 'preprocess:bundle', 'template:bundle', 'jasmine:marionette', 'clean:tmp']);
+  grunt.registerTask('test', 'Run the unit tests.', ['lint', 'unwrap', 'preprocess:bundle', 'template:bundle', 'jasmine:marionette']);
 
   grunt.registerTask('dev', 'Auto-lints while writing code.', ['test', 'watch:marionette']);
 
-  grunt.registerTask('build', 'Build all three versions of the library.', ['clean:lib', 'bower:install', 'lint', 'unwrap', 'preprocess', 'template', 'jasmine:marionette', 'concat', 'uglify', 'clean:tmp']);
+  grunt.registerTask('build', 'Build all three versions of the library.', ['clean:lib', 'bower:install', 'lint', 'unwrap', 'preprocess', 'template', 'jasmine:marionette', 'concat', 'uglify']);
 };


### PR DESCRIPTION
We've talked about getting the SpecRunner to see built marionette src in the browser before, but it's still a problem. The best way that I know to fix this is to not remove the tmp code when we run the tests. I'd be happy if there's a better solution, but ultimately I don't see this being too bad because `tmp` is gitignored. 
