### PR TITLE
Controller before destroy

### DIFF
--- a/docs/marionette.controller.md
+++ b/docs/marionette.controller.md
@@ -58,13 +58,17 @@ unbinding all of the events that are directly attached to the controller
 instance, as well as those that are bound using the EventBinder from
 the controller.
 
-Invoking the `destroy` method will trigger a "destroy" event and corresponding
-`onDestroy` method call. These calls will be passed any arguments `destroy`
+Invoking the `destroy` method will trigger the "before:destroy" and "destroy" events and the
+corresponding `onBeforeDestory` and `onDestroy` method calls. These calls will be passed any arguments `destroy`
 was invoked with.
 
 ```js
 // define a controller with an onDestroy method
 var MyController = Marionette.Controller.extend({
+
+  onBeforeDestroy: function(arg1, arg2){
+    // put custom code here, before destroying this controller
+  }
 
   onDestroy: function(arg1, arg2){
     // put custom code here, to destroy this controller
@@ -76,6 +80,7 @@ var MyController = Marionette.Controller.extend({
 var contr = new MyController();
 
 // add some event handlers
+contr.on("before:destroy", function(arg1, arg2){ ... });
 contr.on("destroy", function(arg1, arg2){ ... });
 contr.listenTo(something, "bar", function(){...});
 

--- a/spec/javascripts/controller.spec.js
+++ b/spec/javascripts/controller.spec.js
@@ -61,10 +61,11 @@ describe('marionette controller', function() {
   });
 
   describe('when destroying a controller', function() {
-    var controller, destroyHandler, listenToHandler;
+    var controller, destroyHandler, listenToHandler, beforeDestroyHandler;
 
     var Controller = Marionette.Controller.extend({
-      onDestroy: jasmine.createSpy('onDestroy')
+      onDestroy: jasmine.createSpy('onDestroy'),
+      onBeforeDestroy: jasmine.createSpy('onBeforeDestroy')
     });
 
     beforeEach(function() {
@@ -73,8 +74,11 @@ describe('marionette controller', function() {
       destroyHandler = jasmine.createSpy('destroy');
       controller.on('destroy', destroyHandler);
 
-      listenToHandler = jasmine.createSpy('destroy');
-      controller.listenTo(controller, 'destroy', listenToHandler);
+      beforeDestroyHandler = jasmine.createSpy('beforeDestroy');
+      controller.on('before:destroy', beforeDestroyHandler);
+
+      listenToHandler = jasmine.createSpy('beforeDestroy');
+      controller.listenTo(controller, 'before:destroy', listenToHandler);
 
       spyOn(controller, 'stopListening').andCallThrough();
       spyOn(controller, 'off').andCallThrough();
@@ -90,8 +94,16 @@ describe('marionette controller', function() {
       expect(controller.off).toHaveBeenCalled();
     });
 
-    it('should stopListening after calling destroy', function() {
+    it('should stopListening after calling before:destroy', function() {
       expect(listenToHandler).toHaveBeenCalled();
+    });
+
+    it('should trigger a before:destroy event with any arguments passed to destroy', function() {
+      expect(beforeDestroyHandler).toHaveBeenCalledWith(123, 'second param');
+    });
+
+    it('should call an onBeforeDestroy method with any arguments passed to destroy', function() {
+      expect(controller.onBeforeDestroy).toHaveBeenCalledWith(123, 'second param');
     });
 
     it('should trigger a destroy event with any arguments passed to destroy', function() {

--- a/src/marionette.controller.js
+++ b/src/marionette.controller.js
@@ -22,7 +22,9 @@ Marionette.Controller.extend = Marionette.extend;
 _.extend(Marionette.Controller.prototype, Backbone.Events, {
   destroy: function() {
     var args = Array.prototype.slice.call(arguments);
+    this.triggerMethod.apply(this, ['before:destroy'].concat(args));
     this.triggerMethod.apply(this, ['destroy'].concat(args));
+
     this.stopListening();
     this.off();
   },


### PR DESCRIPTION
Fixes #1316

NOTE: This reverts this change - https://github.com/marionettejs/backbone.marionette/commit/466609af4e662de3d787e007f56533fbfed46b00

The event to be used now for this use case will be `before:destroy` or the `onBeforeDestroy` function
