### PR TITLE
Updates reference to normalizeMethods

### DIFF
--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -11,7 +11,7 @@ a way to get the same behaviors and conventions from your own code.
 * [Marionette.getOption](#marionettegetoption)
 * [Marionette.triggerMethod](#marionettetriggermethod)
 * [Marionette.bindEntityEvent](#marionettebindentityevents)
-* [Marionette.normalizeEvents](#marionettenormalizeevents)
+* [Marionette.normalizeMethods](#marionettenormalizemethods)
 * [Marionette.normalizeUIKeys](#marionettenormalizeuikeys)
 * [Marionette.actAsCollection](#marionetteactascollection)
 
@@ -147,7 +147,7 @@ The third parameter is a hash of { "event:name": "eventHandler" }
 configuration. Multiple handlers can be separated by a space. A
 function can be supplied instead of a string handler name.
 
-## Marionette.normalizeEvents
+## Marionette.normalizeMethods
 
 Receives a hash of event names and functions and/or function names, and returns the
 same hash with the function names replaced with the function references themselves.


### PR DESCRIPTION
`normalizeEvents` doesn't, and never has, existed. I typo'd in [the original PR.](https://github.com/jmeas/backbone.marionette/commit/04e1c0e20b309e9f99903671ed6d6d3cb90efcc3)
