### PR TITLE
Append to set

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -47,7 +47,7 @@ will provide features such as `onShow` callbacks, etc. Please see
 * [CollectionView render](#collectionview-render)
 * [CollectionView: Automatic Rendering](#collectionview-automatic-rendering)
 * [CollectionView: Re-render Collection](#collectionview-re-render-collection)
-* [CollectionView's appendHtml](#collectionviews-appendhtml)
+* [CollectionView's attachHtml](#collectionviews-attachhtml)
 * [CollectionView's children](#collectionviews-children)
 * [CollectionView destroy](#collectionview-destroy)
 
@@ -651,13 +651,13 @@ If you need to re-render the entire collection, you can call the
 `view.render` method. This method takes care of destroying all of
 the child views that may have previously been opened.
 
-## CollectionView's appendHtml
+## CollectionView's attachHtml
 
 By default the collection view will append the HTML of each ChildView
 into the element buffer, and then call jQuery's `.append` once at the
 end to move the HTML into the collection view's `el`.
 
-You can override this by specifying an `appendHtml` method in your
+You can override this by specifying an `attachHtml` method in your
 view definition. This method takes three parameters and has no return
 value.
 
@@ -665,7 +665,7 @@ value.
 Backbone.Marionette.CollectionView.extend({
 
 	// The default implementation:
-  appendHtml: function(collectionView, childView, index){
+  attachHtml: function(collectionView, childView, index){
     if (collectionView.isBuffering) {
       // buffering happens on reset events and initial renders
       // in order to reduce the number of inserts into the
@@ -680,11 +680,11 @@ Backbone.Marionette.CollectionView.extend({
   },
 
   // Called after all children have been appended into the elBuffer
-  appendBuffer: function(collectionView, buffer) {
+  appendHtml: function(collectionView, buffer) {
     collectionView.$el.append(buffer);
   },
 
-  // called on initialize and after appendBuffer is called
+  // called on initialize and after appendHtml is called
   initRenderBuffer: function() {
     this.elBuffer = document.createDocumentFragment();
   }
@@ -701,7 +701,7 @@ model that this `childView` instance represents, in the collection
 that the model came from. This is useful for sorting a collection
 and displaying the sorted list in the correct order on the screen.
 
-Overrides of `appendHtml` that don't take into account the element
+Overrides of `attachHtml` that don't take into account the element
 buffer will work fine, but won't take advantage of the 60x performance
 increase the buffer provides.
 

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -42,7 +42,7 @@ For more examples, see my blog post on
 
 * [Composite Model `template`](#composite-model-template)
 * [CompositeView's `childViewContainer`](#compositeviews-childviewcontainer)
-* [CompositeView's `appendHtml`](#compositeviews-appendhtml)
+* [CompositeView's `attachHtml`](#compositeviews-attachhtml)
 * [Recursive By Default](#recursive-by-default)
 * [Model And Collection Rendering](#model-and-collection-rendering)
 * [Events And Callbacks](#events-and-callbacks)
@@ -63,7 +63,7 @@ new MyComp({
 
 ## CompositeView's `childViewContainer`
 
-By default the composite view uses the same `appendHtml` method that the
+By default the composite view uses the same `attachHtml` method that the
 collection view provides. This means the view will call jQuery's `.append`
 to move the HTML contents from the child view instance in to the collection
 view's `el`.
@@ -158,12 +158,12 @@ var myComp = new Marionette.CompositeView({
 });
 ```
 
-## CompositeView's `appendHtml`
+## CompositeView's `attachHtml`
 
 
 Sometimes the `childViewContainer` configuration is insuficient for
 specifying where the `childView` instance should be placed. If this is the
-case, you can override the `appendHtml` method with your own implementation.
+case, you can override the `attachHtml` method with your own implementation.
 
 For more information on this method, see the [CollectionView's documentation](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.collectionview.md).
 

--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -62,7 +62,7 @@ describe('collection view', function() {
       spyOn(collectionView, 'onAddChild').andCallThrough();
       spyOn(collectionView, 'onBeforeRender').andCallThrough();
       spyOn(collectionView, 'trigger').andCallThrough();
-      spyOn(collectionView, 'appendHtml').andCallThrough();
+      spyOn(collectionView, 'attachHtml').andCallThrough();
       spyOn(collectionView.$el, 'append').andCallThrough();
       spyOn(collectionView, 'startBuffering').andCallThrough();
       spyOn(collectionView, 'endBuffering').andCallThrough();
@@ -79,7 +79,7 @@ describe('collection view', function() {
     });
 
     it('should add to render buffer once for each child', function() {
-      expect(collectionView.appendHtml.callCount).toEqual(2);
+      expect(collectionView.attachHtml.callCount).toEqual(2);
     });
 
     it('should append the html for each childView', function() {
@@ -87,7 +87,7 @@ describe('collection view', function() {
     });
 
     it('should provide the index for each childView, when appending', function() {
-      expect(collectionView.appendHtml.calls[0].args[2]).toBe(0);
+      expect(collectionView.attachHtml.calls[0].args[2]).toBe(0);
     });
 
     it('should reference each of the rendered view children', function() {
@@ -181,7 +181,7 @@ describe('collection view', function() {
       childViewRender = jasmine.createSpy('childview:render');
       collectionView.on('childview:render', childViewRender);
 
-      spyOn(collectionView, 'appendHtml').andCallThrough();
+      spyOn(collectionView, 'attachHtml').andCallThrough();
 
       model = new Backbone.Model({foo: 'bar'});
       collection.add(model);
@@ -196,7 +196,7 @@ describe('collection view', function() {
     });
 
     it('should provide the index for each childView, when appending', function() {
-      expect(collectionView.appendHtml.calls[0].args[2]).toBe(0);
+      expect(collectionView.attachHtml.calls[0].args[2]).toBe(0);
     });
 
     it('should trigger the childview:render event from the collectionView', function() {
@@ -219,7 +219,7 @@ describe('collection view', function() {
       childViewRender = jasmine.createSpy('childview:render');
       collectionView.on('childview:render', childViewRender);
 
-      spyOn(collectionView, 'appendHtml').andCallThrough();
+      spyOn(collectionView, 'attachHtml').andCallThrough();
 
       model = new Backbone.Model({foo: 'baz'});
       collection.add(model);
@@ -234,7 +234,7 @@ describe('collection view', function() {
     });
 
     it('should provide the index for each child view, when appending', function() {
-      expect(collectionView.appendHtml.calls[0].args[2]).toBe(1);
+      expect(collectionView.attachHtml.calls[0].args[2]).toBe(1);
     });
 
     it('should trigger the childview:render event from the collectionView', function() {
@@ -492,11 +492,11 @@ describe('collection view', function() {
 
   });
 
-  describe('when override appendHtml', function() {
+  describe('when override attachHtml', function() {
     var PrependHtmlView = Backbone.Marionette.CollectionView.extend({
       childView: ChildView,
 
-      appendHtml: function(collectionView, childView) {
+      attachHtml: function(collectionView, childView) {
         collectionView.$el.prepend(childView.el);
       }
     });
@@ -737,7 +737,7 @@ describe('collection view', function() {
       collectionView.onShow();
       collectionView.trigger('show');
 
-      sinon.spy(collectionView, 'appendBuffer');
+      sinon.spy(collectionView, 'attachBuffer');
 
       collection.add(model2);
       view = collectionView.children.findByIndex(1);
@@ -749,7 +749,7 @@ describe('collection view', function() {
     });
 
     it('should not use the render buffer', function() {
-      expect(collectionView.appendBuffer).not.toHaveBeenCalled();
+      expect(collectionView.attachBuffer).not.toHaveBeenCalled();
     });
 
     it('should call the "onShow" method of the child view', function() {

--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -600,7 +600,7 @@ describe('composite view', function() {
       template: '#grid-template',
       childView: GridRow,
 
-      appendHtml: function(collectionView, itemView) {
+      attachHtml: function(collectionView, itemView) {
         collectionView.$('tbody').append(itemView.el);
       }
     });
@@ -661,7 +661,7 @@ describe('composite view', function() {
       template: '#grid-template',
       childView: GridRow,
 
-      appendHtml: function(collectionView, itemView) {
+      attachHtml: function(collectionView, itemView) {
         collectionView.$('tbody').append(itemView.el);
       }
     });

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -41,7 +41,7 @@ Marionette.CollectionView = Marionette.View.extend({
   endBuffering: function() {
     this.isBuffering = false;
     this._triggerBeforeShowBufferedChildren();
-    this.appendBuffer(this, this.elBuffer);
+    this.attachBuffer(this, this.elBuffer);
     this._triggerShowBufferedChildren();
     this.initRenderBuffer();
   },
@@ -299,7 +299,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // render the child view
   renderChildView: function(view, index) {
     view.render();
-    this.appendHtml(this, view, index);
+    this.attachHtml(this, view, index);
   },
 
   // Build a `childView` for a model in the collection.
@@ -342,15 +342,15 @@ Marionette.CollectionView = Marionette.View.extend({
     }
   },
 
-  // You might need to override this if you've overridden appendHtml
-  appendBuffer: function(collectionView, buffer) {
+  // You might need to override this if you've overridden attachHtml
+  attachBuffer: function(collectionView, buffer) {
     collectionView.$el.append(buffer);
   },
 
   // Append the HTML to the collection's `el`.
   // Override this method to do something other
   // than `.append`.
-  appendHtml: function(collectionView, childView, index) {
+  attachHtml: function(collectionView, childView, index) {
     if (collectionView.isBuffering) {
       // buffering happens on reset events and initial renders
       // in order to reduce the number of inserts into the

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -108,8 +108,8 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     this.triggerMethod('render:template');
   },
 
-  // You might need to override this if you've overridden appendHtml
-  appendBuffer: function(compositeView, buffer) {
+  // You might need to override this if you've overridden attachHtml
+  attachBuffer: function(compositeView, buffer) {
     var $container = this.getChildViewContainer(compositeView);
     $container.append(buffer);
   },
@@ -123,7 +123,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   },
 
   // Internal method to ensure an `$childViewContainer` exists, for the
-  // `appendHtml` method to use.
+  // `attachHtml` method to use.
   getChildViewContainer: function(containerView) {
     if ('$childViewContainer' in containerView) {
       return containerView.$childViewContainer;


### PR DESCRIPTION
#1327 needs an associated PR to bring collection/composite views in sync with it.

This one uses the verb `attach`, which I actually prefer over `set`. The reason why is because of the buffer methods. Because of this I think we should rewrite history for #1327 to be `attachHtml` instead of `setHtml`. @samccone I think this should be fine for Bower as we're only modifying history **after** the latest tag.
