### PR TITLE
Destroy to empty

### DIFF
--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -159,9 +159,9 @@ first render has happened, though, the render function is modified to
 account for re-rendering with regions in the layoutView.
 
 After the first render, all subsequent renders will force every
-region to destroy by calling the `destroy` method on them. This will
-force every view in the region, and sub-views if any, to be destroyd
-as well. Once the regions have been destroyd, the regions will be
+region to be emptied by calling the `empty` method on them. This will
+force every view in the region, and sub-views if any, to be destroyed
+as well. Once the regions are emptied, the regions will also be
 reset so that they are no longer referencing the element of the previous
 layoutView render.
 
@@ -232,8 +232,8 @@ MyApp.mainRegion.show(new Layout1())
 
 When you are finished with a layoutView, you can call the
 `destroy` method on it. This will ensure that all of the region managers
-within the layoutView are destroyd correctly, which in turn
-ensures all of the views shown within the regions are destroyd correctly.
+within the layoutView are destroyed correctly, which in turn
+ensures all of the views shown within the regions are destroyed correctly.
 
 If you are showing a layoutView within a parent region manager, replacing
 the layoutView with another view or another layoutView will destroy the current

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -94,7 +94,7 @@ var mgr = new Backbone.Marionette.Region({
 ### Showing a View
 
 Once a region is defined, you can call its `show`
-and `destroy` methods to display and shut-down a view:
+and `empty` methods to display and shut-down a view:
 
 ```js
 var myView = new MyView();
@@ -102,8 +102,8 @@ var myView = new MyView();
 // render and display the view
 MyApp.mainRegion.show(myView);
 
-// destroys the current view
-MyApp.mainRegion.destroy();
+// empties the contents of the region
+MyApp.mainRegion.empty();
 ```
 
 #### preventDestroy
@@ -242,8 +242,8 @@ and destroying views:
 * "show" / `onShow` - Called on the region instance when the view has been rendered and displayed.
 * "before:swap" / `onBeforeSwap` - Called on the region instance before a new view is shown. NOTE: this will only be called when a view is being swapped, not when the region is empty.
 * "swap" / `onSwap` - Called on the region instance when a new view is `show`n. NOTE: this will only be called when a view is being swapped, not when the region is empty.
-* "before:destroy" / `onBeforeDestroy` - Called on the region instance before the view has been destroyed.
-* "destroy" / `onDestroy` - Called when the view has been destroyed.
+* "before:empty" / `onBeforeEmpty` - Called on the region instance before it is emptied and its view is destroyed.
+* "empty" / `onEmpty` - Called when the region has been emptied and its view is destroyed.
 
 These events can be used to run code when your region
 opens and destroys views.

--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -18,7 +18,7 @@ objects.
 * [RegionManager.get](#regionmanagerget)
 * [RegionManager.removeRegion](#regionmanagerremoveregion)
 * [RegionManager.removeRegions](#regionmanagerremoveregions)
-* [RegionManager.destroyRegions](#regionmanagerdestroyregions)
+* [RegionManager.emptyRegions](#regionmanagerdestroyregions)
 * [RegionManager.destroy](#regionmanagerdestroy)
 * [RegionManager Events](#regionmanager-events)
   * [before:region:add event](#beforeregionadd-event)
@@ -170,10 +170,11 @@ rm.removeRegions();
 
 This will destroy all regions, and remove them.
 
-## RegionManager.destroyRegions
+## RegionManager.emptyRegions
 
-You can quickly destroy all regions from the RegionManager
-instance by calling the `destroyRegions` method.
+You can empty all regions from the RegionManager
+instance by calling the `emptyRegions` method. This
+destroys the view within each Region.
 
 ```js
 var rm = new Marionette.RegionManager();
@@ -183,11 +184,8 @@ rm.addRegions({
   baz: "#baz"
 });
 
-rm.destroyRegions();
+rm.emptyRegions();
 ```
-
-This will destroy the regions without removing them
-from the RegionManager instance.
 
 ## RegionManager.destroy
 

--- a/spec/javascripts/application.appRegions.spec.js
+++ b/spec/javascripts/application.appRegions.spec.js
@@ -121,7 +121,7 @@ describe('application regions', function() {
     });
   });
 
-  describe('when destroying all regions in the app', function() {
+  describe('when emptying all regions in the app', function() {
     var r1, r2;
 
     beforeEach(function() {
@@ -138,15 +138,15 @@ describe('application regions', function() {
       r1 = app.myRegion;
       r2 = app.r2;
 
-      spyOn(r1, 'destroy').andCallThrough();
-      spyOn(r2, 'destroy').andCallThrough();
+      spyOn(r1, 'empty').andCallThrough();
+      spyOn(r2, 'empty').andCallThrough();
 
-      app.destroyRegions();
+      app.emptyRegions();
     });
 
-    it('should destroy the regions', function() {
-      expect(r1.destroy).toHaveBeenCalled();
-      expect(r2.destroy).toHaveBeenCalled();
+    it('should empty the regions', function() {
+      expect(r1.empty).toHaveBeenCalled();
+      expect(r2.empty).toHaveBeenCalled();
     });
   });
 

--- a/spec/javascripts/layoutView.dynamicRegions.spec.js
+++ b/spec/javascripts/layoutView.dynamicRegions.spec.js
@@ -155,7 +155,7 @@ describe('layoutView - dynamic regions', function() {
 
   describe('when removing a region from a layoutView', function() {
     var LayoutView;
-    var layoutView, region, destroyHandler, removeHandler, beforeRemoveHandler, onBeforeRemoveSpy, onRemoveSpy;
+    var layoutView, region, emptyHandler, removeHandler, beforeRemoveHandler, onBeforeRemoveSpy, onRemoveSpy;
 
     beforeEach(function() {
       LayoutView = Marionette.LayoutView.extend({
@@ -167,7 +167,7 @@ describe('layoutView - dynamic regions', function() {
         onRemoveRegion: function() {}
       });
 
-      destroyHandler = sinon.spy();
+      emptyHandler = sinon.spy();
       beforeRemoveHandler = sinon.spy();
       removeHandler = sinon.spy();
 
@@ -180,15 +180,15 @@ describe('layoutView - dynamic regions', function() {
       layoutView.foo.show(new Backbone.View());
       region = layoutView.foo;
 
-      region.on('destroy', destroyHandler);
+      region.on('empty', emptyHandler);
       layoutView.on('before:remove:region', beforeRemoveHandler);
       layoutView.on('remove:region', removeHandler);
 
       layoutView.removeRegion('foo');
     });
 
-    it('should destroy the region', function() {
-      expect(destroyHandler).toHaveBeenCalled();
+    it('should empty the region', function() {
+      expect(emptyHandler).toHaveBeenCalled();
     });
 
     it('should trigger a before:remove:region event', function() {
@@ -237,10 +237,10 @@ describe('layoutView - dynamic regions', function() {
   });
 
   describe('when adding a region to a layoutView then destroying the layoutView', function() {
-    var layoutView, region, destroyHandler;
+    var layoutView, region, emptyHandler;
 
     beforeEach(function() {
-      destroyHandler = jasmine.createSpy('add handler');
+      emptyHandler = jasmine.createSpy('add handler');
       layoutView = new Marionette.LayoutView({
         template: template
       });
@@ -248,7 +248,7 @@ describe('layoutView - dynamic regions', function() {
       layoutView.render();
 
       region = layoutView.addRegion('foo', '#foo');
-      region.on('destroy', destroyHandler);
+      region.on('empty', emptyHandler);
 
       var view = new Backbone.View();
       layoutView.foo.show(view);
@@ -256,8 +256,8 @@ describe('layoutView - dynamic regions', function() {
       layoutView.destroy();
     });
 
-    it('should destroy the region', function() {
-      expect(destroyHandler).toHaveBeenCalled();
+    it('should empty the region', function() {
+      expect(emptyHandler).toHaveBeenCalled();
     });
   });
 });

--- a/spec/javascripts/layoutView.spec.js
+++ b/spec/javascripts/layoutView.spec.js
@@ -170,18 +170,18 @@ describe('layoutView', function() {
       regionOne = layoutViewManager.regionOne;
       regionTwo = layoutViewManager.regionTwo;
 
-      spyOn(regionOne, 'destroy').andCallThrough();
-      spyOn(regionTwo, 'destroy').andCallThrough();
+      spyOn(regionOne, 'empty').andCallThrough();
+      spyOn(regionTwo, 'empty').andCallThrough();
 
       layoutViewManager.destroy();
     });
 
-    it('should destroy the region managers', function() {
-      expect(regionOne.destroy).toHaveBeenCalled();
-      expect(regionTwo.destroy).toHaveBeenCalled();
+    it('should empty the regions', function() {
+      expect(regionOne.empty).toHaveBeenCalled();
+      expect(regionTwo.empty).toHaveBeenCalled();
     });
 
-    it('should delete the region managers', function() {
+    it('should delete the regions', function() {
       expect(layoutViewManager.regionOne).toBeUndefined();
       expect(layoutViewManager.regionTwo).toBeUndefined();
     });
@@ -221,7 +221,7 @@ describe('layoutView', function() {
   });
 
   describe('when re-rendering an already rendered layoutView', function() {
-    var region, layoutView, view, destroyRegionsSpy;
+    var region, layoutView, view, emptyRegionsSpy;
 
     beforeEach(function() {
       loadFixtures('layoutViewManagerTemplate.html');
@@ -235,15 +235,15 @@ describe('layoutView', function() {
       view.destroy = function() {};
       layoutView.regionOne.show(view);
 
-      destroyRegionsSpy = spyOn(layoutView.regionManager, 'destroyRegions').andCallThrough();
+      emptyRegionsSpy = spyOn(layoutView.regionManager, 'emptyRegions').andCallThrough();
 
       layoutView.render();
       layoutView.regionOne.show(view);
       region = layoutView.regionOne;
     });
 
-    it('should destroy the regions', function() {
-      expect(destroyRegionsSpy.callCount).toBe(1);
+    it('should empty the regions', function() {
+      expect(emptyRegionsSpy.callCount).toBe(1);
     });
 
     it('should re-bind the regions to the newly rendered elements', function() {
@@ -281,7 +281,7 @@ describe('layoutView', function() {
       layoutView.regionOne.show(view);
       layoutView.destroy();
 
-      spyOn(region, 'destroy').andCallThrough();
+      spyOn(region, 'empty').andCallThrough();
       spyOn(view, 'destroy').andCallThrough();
 
       layoutView.onBeforeRender = jasmine.createSpy('before render');

--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -520,12 +520,12 @@ describe('region', function() {
       destroy: function() {}
     });
 
-    var myRegion, view, beforeDestroySpy ,destroyedSpy;
+    var myRegion, view, beforeEmptySpy ,emptySpy;
 
     beforeEach(function() {
       setFixtures('<div id="region"></div>');
-      beforeDestroySpy = sinon.spy();
-      destroyedSpy = sinon.spy();
+      beforeEmptySpy = sinon.spy();
+      emptySpy = sinon.spy();
 
       view = new MyView();
 
@@ -533,31 +533,31 @@ describe('region', function() {
       spyOn(view, 'remove');
 
       myRegion = new MyRegion();
-      myRegion.on('before:destroy', beforeDestroySpy);
-      myRegion.on('destroy', destroyedSpy);
+      myRegion.on('before:empty', beforeEmptySpy);
+      myRegion.on('empty', emptySpy);
       myRegion.show(view);
 
-      myRegion.destroy();
+      myRegion.empty();
     });
 
-    it('should trigger a "before:destroy" event with the view thats being destroyed', function() {
-      expect(beforeDestroySpy).toHaveBeenCalledWith(view);
+    it('should trigger a "before:empty" event with the view thats being destroyed', function() {
+      expect(beforeEmptySpy).toHaveBeenCalledWith(view);
     });
 
-    it('should set "this" to the manager, from the before:destroy event', function() {
-      expect(beforeDestroySpy).toHaveBeenCalledOn(myRegion);
+    it('should set "this" to the manager, from the before:empty event', function() {
+      expect(beforeEmptySpy).toHaveBeenCalledOn(myRegion);
     });
 
     it('should trigger a destroy event', function() {
-      expect(destroyedSpy).toHaveBeenCalled();
+      expect(emptySpy).toHaveBeenCalled();
     });
 
     it('should trigger a destroy event with the view thats being destroyd', function() {
-      expect(destroyedSpy).toHaveBeenCalledWith(view);
+      expect(emptySpy).toHaveBeenCalledWith(view);
     });
 
     it('should set "this" to the manager, from the destroy event', function() {
-      expect(destroyedSpy).toHaveBeenCalledOn(myRegion);
+      expect(emptySpy).toHaveBeenCalledOn(myRegion);
     });
 
     it('should call "destroy" on the already show view', function() {
@@ -591,7 +591,7 @@ describe('region', function() {
       spyOn(view, 'remove');
       myRegion = new MyRegion();
       myRegion.show(view);
-      myRegion.destroy();
+      myRegion.empty();
     });
 
     it('should call "remove" on the view', function() {
@@ -713,7 +713,7 @@ describe('region', function() {
       });
 
       region = MyApp.MyRegion;
-      spyOn(region, 'destroy');
+      spyOn(region, 'empty');
 
       MyApp.removeRegion('MyRegion');
     });
@@ -722,8 +722,8 @@ describe('region', function() {
       expect(MyApp.MyRegion).not.toBeDefined();
     });
 
-    it('should call "destroy" of the region', function() {
-      expect(region.destroy).toHaveBeenCalled();
+    it('should call "empty" of the region', function() {
+      expect(region.empty).toHaveBeenCalled();
     });
   });
 
@@ -753,7 +753,7 @@ describe('region', function() {
         el: '#region'
       });
 
-      spyOn(region, 'destroy');
+      spyOn(region, 'empty');
 
       region._ensureElement();
 
@@ -765,7 +765,7 @@ describe('region', function() {
     });
 
     it('should destroy any existing view', function() {
-      expect(region.destroy).toHaveBeenCalled();
+      expect(region.empty).toHaveBeenCalled();
     });
 
   });

--- a/spec/javascripts/regionManager.spec.js
+++ b/spec/javascripts/regionManager.spec.js
@@ -185,12 +185,12 @@ describe('regionManager', function() {
   });
 
   describe('.removeRegion', function() {
-    var region, regionManager, destroyHandler, removeHandler, beforeRemoveHandler;
+    var region, regionManager, emptyHandler, removeHandler, beforeRemoveHandler;
 
     beforeEach(function() {
       setFixtures('<div id="foo"></div>');
 
-      destroyHandler = sinon.spy();
+      emptyHandler = sinon.spy();
       beforeRemoveHandler = sinon.spy();
       removeHandler = sinon.spy();
 
@@ -198,7 +198,7 @@ describe('regionManager', function() {
       region = regionManager.addRegion('foo', '#foo');
       region.show(new Backbone.View());
 
-      region.on('destroy', destroyHandler);
+      region.on('empty', emptyHandler);
       regionManager.on('before:remove:region', beforeRemoveHandler);
       regionManager.on('remove:region', removeHandler);
 
@@ -207,8 +207,8 @@ describe('regionManager', function() {
       regionManager.removeRegion('foo');
     });
 
-    it('should destroy the region', function() {
-      expect(destroyHandler).toHaveBeenCalled();
+    it('should empty the region', function() {
+      expect(emptyHandler).toHaveBeenCalled();
     });
 
     it('should stopListening on the region', function() {
@@ -233,13 +233,13 @@ describe('regionManager', function() {
   });
 
   describe('.removeRegions', function() {
-    var region, r2, regionManager, destroyHandler, destroyHandler2, removeHandler;
+    var region, r2, regionManager, emptyHandler, emptyHandler2, removeHandler;
 
     beforeEach(function() {
       setFixtures('<div id="foo"></div><div id="bar"></div>');
 
-      destroyHandler = jasmine.createSpy('destroy handler');
-      destroyHandler2 = jasmine.createSpy('destroy handler');
+      emptyHandler = jasmine.createSpy('destroy handler');
+      emptyHandler2 = jasmine.createSpy('destroy handler');
       removeHandler = jasmine.createSpy('remove handler');
 
       regionManager = new Marionette.RegionManager();
@@ -249,8 +249,8 @@ describe('regionManager', function() {
       region.show(new Backbone.View());
       r2.show(new Backbone.View());
 
-      region.on('destroy', destroyHandler);
-      r2.on('destroy', destroyHandler2);
+      region.on('empty', emptyHandler);
+      r2.on('empty', emptyHandler2);
 
       regionManager.on('remove:region', removeHandler);
 
@@ -260,9 +260,9 @@ describe('regionManager', function() {
       regionManager.removeRegions();
     });
 
-    it('should destroy the regions', function() {
-      expect(destroyHandler).toHaveBeenCalled();
-      expect(destroyHandler2).toHaveBeenCalled();
+    it('should empty the regions', function() {
+      expect(emptyHandler).toHaveBeenCalled();
+      expect(emptyHandler2).toHaveBeenCalled();
     });
 
     it('should stopListening on the regions', function() {
@@ -281,26 +281,26 @@ describe('regionManager', function() {
     });
   });
 
-  describe('.destroyRegions', function() {
-    var region, regionManager, destroyHandler, destroyManagerHandler;
+  describe('.emptyRegions', function() {
+    var region, regionManager, emptyHandler, destroyManagerHandler;
 
     beforeEach(function() {
       setFixtures('<div id="foo">');
 
-      destroyHandler = jasmine.createSpy('destroy region handler');
+      emptyHandler = jasmine.createSpy('destroy region handler');
       destroyManagerHandler = jasmine.createSpy('destroy manager handler');
 
       regionManager = new Marionette.RegionManager();
       region = regionManager.addRegion('foo', '#foo');
       region.show(new Backbone.View());
 
-      region.on('destroy', destroyHandler);
+      region.on('empty', emptyHandler);
 
-      regionManager.destroyRegions();
+      regionManager.emptyRegions();
     });
 
     it('should destroy all regions', function() {
-      expect(destroyHandler).toHaveBeenCalled();
+      expect(emptyHandler).toHaveBeenCalled();
     });
 
     it('should not remove all regions', function() {
@@ -309,18 +309,18 @@ describe('regionManager', function() {
   });
 
   describe('.destroy', function() {
-    var region, regionManager, destroyHandler, destroyManagerHandler;
+    var region, regionManager, emptyHandler, destroyManagerHandler;
 
     beforeEach(function() {
       setFixtures('<div id="foo">');
-      destroyHandler = jasmine.createSpy('destroy region handler');
+      emptyHandler = jasmine.createSpy('destroy region handler');
       destroyManagerHandler = jasmine.createSpy('destroy manager handler');
 
       regionManager = new Marionette.RegionManager();
       region = regionManager.addRegion('foo', '#foo');
       region.show(new Backbone.View());
 
-      region.on('destroy', destroyHandler);
+      region.on('empty', emptyHandler);
       regionManager.on('destroy', destroyManagerHandler);
 
       spyOn(region, 'stopListening');
@@ -328,8 +328,8 @@ describe('regionManager', function() {
       regionManager.destroy();
     });
 
-    it('should destroy all regions', function() {
-      expect(destroyHandler).toHaveBeenCalled();
+    it('should empty all regions', function() {
+      expect(emptyHandler).toHaveBeenCalled();
     });
 
     it('should stopListening on all regions', function() {

--- a/src/marionette.application.js
+++ b/src/marionette.application.js
@@ -51,9 +51,9 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
     return this._regionManager.addRegions(regions);
   },
 
-  // Destroy all regions in the app, without removing them
-  destroyRegions: function() {
-    this._regionManager.destroyRegions();
+  // Empty all regions in the app
+  emptyRegions: function() {
+    this._regionManager.emptyRegions();
   },
 
   // Removes a region from your app, by name

--- a/src/marionette.layoutview.js
+++ b/src/marionette.layoutview.js
@@ -117,7 +117,7 @@ Marionette.LayoutView = Marionette.ItemView.extend({
   // Internal method to re-initialize all of the regions by updating the `el` that
   // they point to
   _reInitializeRegions: function() {
-    this.regionManager.destroyRegions();
+    this.regionManager.emptyRegions();
     this.regionManager.each(function(region) {
       region.reset();
     });

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -147,7 +147,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     var _shouldDestroyView = !preventDestroy && isDifferentView;
 
     if (_shouldDestroyView) {
-      this.destroy();
+      this.empty();
     }
 
     // show the view if the view is different or if you want to re-show the view
@@ -204,17 +204,17 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
   // Destroy the current view, if there is one. If there is no
   // current view, it does nothing and returns immediately.
-  destroy: function() {
+  empty: function() {
     var view = this.currentView;
     if (!view || view.isDestroyed) { return; }
 
-    this.triggerMethod('before:destroy', view);
+    this.triggerMethod('before:empty', view);
 
     // call 'destroy' or 'remove', depending on which is found
     if (view.destroy) { view.destroy(); }
     else if (view.remove) { view.remove(); }
 
-    this.triggerMethod('destroy', view);
+    this.triggerMethod('empty', view);
 
     delete this.currentView;
   },
@@ -232,7 +232,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   // is shown via this region, the region will re-query the
   // DOM for the region's `el`.
   reset: function() {
-    this.destroy();
+    this.empty();
 
     if (this.$el) {
       this.el = this.$el.selector;

--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -76,11 +76,11 @@ Marionette.RegionManager = (function(Marionette) {
       }, this);
     },
 
-    // Destroy all regions in the region manager, but
-    // leave them attached
-    destroyRegions: function() {
+    // Destroys the view inside any region,
+    // leaving it empty.
+    emptyRegions: function() {
       _.each(this._regions, function(region) {
-        region.destroy();
+        region.empty();
       }, this);
     },
 
@@ -100,7 +100,7 @@ Marionette.RegionManager = (function(Marionette) {
     // internal method to remove a region
     _remove: function(name, region) {
       this.triggerMethod('before:remove:region', name, region);
-      region.destroy();
+      region.empty();
       region.stopListening();
       delete this._regions[name];
       this._setLength();


### PR DESCRIPTION
Resolves #1320

Regions have two very important functions that are inverses of one another, currently known as `show` and `destroy`. These methods work just fine, but the name of `destroy` can be a source of confusion, I think.

In every other class, `destroy` prepares the class for garbage collection. How surprised would you be to hear that a region's destroy doesn't do that, but instead prepares its _**view**_ for gc by calling `destroy` on that view? This leads to strange language in the documentation like ["This will destroy the regions without removing them from the RegionManager instance."](https://github.com/marionettejs/backbone.marionette/blob/v2.0/docs/marionette.regionmanager.md#regionmanagerdestroyregions) Yikes. Talk about confusing.

Regions have no destroy method right now. They can only be cleaned up when they're being used in conjunction with a RegionManager. While we may want to change this in the future, for now we need to change the current `destroy` method to make more sense. I opted for `empty` in this PR, which makes reference to us, you know, emptying the region by destroying its view.
