### PR TITLE
Abstract html insertion into a private helper.

### DIFF
--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -82,6 +82,24 @@ describe('composite view', function() {
     });
   });
 
+  describe('when rendering with a overridden attachHTML', function() {
+    beforeEach(function() {
+      this.attachHTMLStub = this.sinon.stub();
+      this.CompositeView = Marionette.CompositeView.extend({
+        template: function(){},
+        attachHTML: this.attachHTMLStub
+      });
+
+      this.compositeView = new this.CompositeView();
+
+      this.compositeView.render();
+    });
+
+    it('should render according to the custom attachHTML logic', function() {
+      expect(this.attachHTMLStub).to.have.been.calledOnce.and.calledWith(undefined);
+    });
+  });
+
   describe('when a composite view has a model and a template', function() {
     beforeEach(function() {
       this.ChildView = Backbone.Marionette.ItemView.extend({

--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -24,6 +24,24 @@ describe('item view', function() {
     });
   });
 
+  describe('when rendering with a overridden attachHTML', function() {
+    beforeEach(function() {
+      this.attachHTMLStub = this.sinon.stub();
+      this.ItemView = Marionette.ItemView.extend({
+        template: function(){},
+        attachHTML: this.attachHTMLStub
+      });
+
+      this.itemView = new this.ItemView();
+
+      this.itemView.render();
+    });
+
+    it('should render according to the custom attachHTML logic', function() {
+      expect(this.attachHTMLStub).to.have.been.calledOnce.and.calledWith(undefined);
+    });
+  });
+
   describe('when rendering', function() {
     beforeEach(function() {
       this.OnRenderView = Backbone.Marionette.ItemView.extend({

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -99,13 +99,31 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
 
     var template = this.getTemplate();
     var html = Marionette.Renderer.render(template, data);
-    this.$el.html(html);
+    this.attachHTML(html);
 
     // the ui bindings is done here and not at the end of render since they
     // will not be available until after the model is rendered, but should be
     // available before the collection is rendered.
     this.bindUIElements();
     this.triggerMethod('render:template');
+  },
+
+  // Attaches the `HTML` content of the root.
+  // This method can be overriden to optimize rendering,
+  // or to render in a non standard way.
+  //
+  // For example, using `innerHTML` instead of `$el.html`
+  //
+  // ```js
+  // attachHTML: function(html) {
+  //   this.el.innerHTML = html;
+  //   return this;
+  // }
+  // ```
+  attachHTML: function(html) {
+    this.$el.html(html);
+
+    return this;
   },
 
   // You might need to override this if you've overridden attachHtml

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -46,11 +46,28 @@ Marionette.ItemView = Marionette.View.extend({
 
     var template = this.getTemplate();
     var html = Marionette.Renderer.render(template, data);
-
-    this.$el.html(html);
+    this.attachHTML(html);
     this.bindUIElements();
 
     this.triggerMethod('render', this);
+
+    return this;
+  },
+
+  // Attaches the `HTML` content of a given view.
+  // This method can be overriden to optimize rendering,
+  // or to render in a non standard way.
+  //
+  // For example, using `innerHTML` instead of `$el.html`
+  //
+  // ```js
+  // attachHTML: function(html) {
+  //   this.el.innerHTML = html;
+  //   return this;
+  // }
+  // ```
+  attachHTML: function(html) {
+    this.$el.html(html);
 
     return this;
   },


### PR DESCRIPTION
This brings the implementation of `ItemView` and `CompositeView`
more inline with the methods that are present in `CollectionView`,
such as `_insertAfter`, `_insertBefore`, and `attachBuffer`.

This also has the added benifit of allowing people to render
things in non standard ways, or to use a different rendering engine
without having to really "hack" into the render cycle.

Your might wonder why there are no docs for this method tho, and that
is a fair question. The rational behind it is that by leaving it private
it is implied that this is something you should not override (unless you 
have a specific need).

Fixes #1374 
Fixes https://github.com/marionettejs/backbone.marionette/issues/842
