### PR TITLE
Make CollectionView#appendHtml preserve model index

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -206,6 +206,44 @@ describe("collection view", function(){
     });
   });
 
+  describe("when a model is added to a non-empty collection at specific index", function(){
+    var collectionView, collection, model, itemViewRender;
+
+    beforeEach(function(){
+      collection = new Backbone.Collection({foo: 'bar'});
+
+      collectionView = new CollectionView({
+        itemView: ItemView,
+        collection: collection
+      });
+      collectionView.render();
+
+      itemViewRender = jasmine.createSpy("itemview:render");
+      collectionView.on("itemview:render", itemViewRender);
+
+      spyOn(collectionView, "appendHtml").andCallThrough();
+
+      model = new Backbone.Model({foo: "baz"});
+      collection.add(model, {at: 0});
+    });
+
+    it("should add the model to the list", function(){
+      expect(_.size(collectionView.children)).toBe(2);
+    });
+
+    it("should render the model in to the DOM with right order", function(){
+      expect($(collectionView.$el)).toHaveText("bazbar");
+    });
+
+    it("should provide the index for each itemView, when appending", function(){
+      expect(collectionView.appendHtml.calls[0].args[2]).toBe(0);
+    });
+
+    it("should trigger the itemview:render event from the collectionView", function(){
+      expect(itemViewRender).toHaveBeenCalled();
+    });
+  });
+
   describe("when a model is added to a non-empty collection", function(){
     var collectionView, collection, model, itemViewRender;
 

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -304,8 +304,16 @@ Marionette.CollectionView = Marionette.View.extend({
     }
     else {
       // If we've already rendered the main collection, just
-      // append the new items directly into the element.
-      collectionView.$el.append(itemView.el);
+      // append the new items directly into the element preserving
+      // the given index.
+
+      if(index === undefined) {
+        collectionView.$el.append(itemView.el);
+      } else if(index === 0) {
+        collectionView.$el.prepend(itemView.el);
+      } else {
+        $(collectionView.$el.find(itemView.$el.prop('tagName'))[index - 1]).after(itemView.el);
+      }
     }
   },
 


### PR DESCRIPTION
A lot of times I needed to override CollectionView#appendHtml to make it preserve the model collection index. 

I think this should be a default behavior. Also I think this just make sense when not buffering, since buffering happens only on first "loading" and index is naturally preserved.
