### PR TITLE
Add a test for compositeView behaviors

### DIFF
--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -234,6 +234,10 @@ describe('Behaviors', function() {
         this.view.$el.find('.bar').click();
       });
 
+      it('should not clobber the event prototype', function() {
+        expect(this.behaviors.foo.prototype.events).to.have.property('click @ui.bar', 'onBarClick');
+      });
+
       it('should set the behavior UI element', function() {
         expect(this.onRenderStub).to.have.been.calledOnce;
       });

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -94,7 +94,7 @@ Marionette.Behaviors = (function(Marionette, _) {
 
       _.each(behaviors, function(b, i) {
         var _events = {};
-        var behaviorEvents = _.result(b, 'events') || {};
+        var behaviorEvents = _.clone(_.result(b, 'events')) || {};
         var behaviorUI = _.result(b, 'ui');
 
         // Construct an internal UI hash first using


### PR DESCRIPTION
Fixes #1389 
~~Shows the error in #1389~~

~~This seems to be a problem with the event not getting set in the childView.~~

~~as @MasterLambaster said~~

~~>  i guess it's caused by fd74e60. CollectionView uses buffering and does not use regions, therefore onShow is not triggered for Behavior. It works just fine on 1.8.5~~

~~Well i just stripped down the tests and they are no longer failing... need to think about why~~
