### PR TITLE
Fix 1406

### DIFF
--- a/src/build/marionette.core.js
+++ b/src/build/marionette.core.js
@@ -28,9 +28,6 @@
     return this;
   };
 
-  // Get the DOM manipulator for later use
-  Marionette.$ = Backbone.$;
-
   // Get the Deferred creator for later use
   Marionette.Deferred = Backbone.$.Deferred;
 


### PR DESCRIPTION
Remove last vestige of Marionette.$ to fix #1406.

Confirmed that there aren't any other usages by running `grep -rn 'Marionette\.\$' .` in the project root. Also did a search through src/ and spec/ for $, just to make sure there weren't any strange usages.

I'm not sure if these tiny pull requests are actually more work for you guys, but I thought I'd open it just in case it helps.
