### PR TITLE
Fix 1355

### DIFF
--- a/spec/javascripts/application.appRegions.spec.js
+++ b/spec/javascripts/application.appRegions.spec.js
@@ -110,12 +110,17 @@ describe('application regions', function() {
       this.sinon.spy(this.app.fooRegion, 'empty');
       this.sinon.spy(this.app.barRegion, 'empty');
 
+      this.sinon.spy(this.app, 'emptyRegions');
       this.app.emptyRegions();
     });
 
     it('should empty the regions', function() {
       expect(this.app.fooRegion.empty).to.have.been.called;
       expect(this.app.barRegion.empty).to.have.been.called;
+    });
+
+    it('should return the app', function() {
+      expect(this.app.emptyRegions).to.have.returned(this.app);
     });
   });
 
@@ -150,6 +155,8 @@ describe('application regions', function() {
       this.app.on('remove:region', this.removeRegionStub);
 
       this.app.start();
+
+      this.sinon.spy(this.app, 'removeRegion');
       this.app.removeRegion('fooRegion');
     });
 
@@ -163,6 +170,10 @@ describe('application regions', function() {
 
     it('should trigger a remove:region event', function() {
       expect(this.removeRegionStub).to.have.been.calledWith('fooRegion');
+    });
+
+    it('should return the app', function() {
+      expect(this.app.removeRegion).to.have.returned(this.app);
     });
   });
 });

--- a/spec/javascripts/application.spec.js
+++ b/spec/javascripts/application.spec.js
@@ -66,7 +66,7 @@ describe('marionette application', function() {
 
       this.startStub = this.sinon.stub();
       this.app.on('start', this.startStub);
-
+      this.sinon.spy(this.app, 'start');
       this.app.start(this.fooOptions);
     });
 
@@ -76,6 +76,10 @@ describe('marionette application', function() {
 
     it('should pass the startup option to the callback', function() {
       expect(this.startStub).to.have.been.calledOnce.and.calledWith(this.fooOptions);
+    });
+
+    it('should return the app', function() {
+      expect(this.app.start).to.have.returned(this.app);
     });
   });
 });

--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -114,6 +114,7 @@ describe('region', function() {
 
       this.view.on('before:show', this.viewBeforeShowSpy);
 
+      this.sinon.spy(this.myRegion, 'show');
       this.myRegion.show(this.view);
     });
 
@@ -175,6 +176,10 @@ describe('region', function() {
 
     it('should not call the `onSwap` function on the region', function() {
       expect(this.swapSpy.callCount).to.equal(0);
+    });
+
+    it('should return the region', function() {
+      expect(this.myRegion.show).to.have.returned(this.myRegion);
     });
 
     describe('and then showing a different view', function() {
@@ -518,6 +523,7 @@ describe('region', function() {
       this.myRegion.on('empty', this.emptySpy);
       this.myRegion.show(this.view);
 
+      this.sinon.spy(this.myRegion, 'empty');
       this.myRegion.empty();
     });
 
@@ -551,6 +557,10 @@ describe('region', function() {
 
     it('should delete the current view reference', function() {
       expect(this.myRegion.currentView).to.be.undefined;
+    });
+
+    it('should return the region', function() {
+      expect(this.myRegion.empty).to.have.returned(this.myRegion);
     });
   });
 
@@ -635,6 +645,7 @@ describe('region', function() {
         el: '#foo'
       });
 
+      this.sinon.spy(this.region, 'attachView');
       this.region.attachView(this.view);
     });
 
@@ -648,6 +659,10 @@ describe('region', function() {
 
     it('should not replace the existing html', function() {
       expect($(this.region.el).text()).to.equal('bar');
+    });
+
+    it('should return the region', function() {
+      expect(this.region.attachView).to.have.returned(this.region);
     });
   });
 
@@ -722,6 +737,7 @@ describe('region', function() {
 
       this.region._ensureElement();
 
+      this.sinon.spy(this.region, 'reset');
       this.region.reset();
     });
 
@@ -731,6 +747,10 @@ describe('region', function() {
 
     it('should empty any existing view', function() {
       expect(this.region.empty).to.have.been.called;
+    });
+
+    it('should return the region', function() {
+      expect(this.region.reset).to.have.returned(this.region);
     });
   });
 });

--- a/spec/javascripts/regionManager.spec.js
+++ b/spec/javascripts/regionManager.spec.js
@@ -203,6 +203,7 @@ describe('regionManager', function() {
       this.regionManager.on('remove:region', this.removeHandler);
       this.sinon.spy(this.region, 'stopListening');
 
+      this.sinon.spy(this.regionManager, 'removeRegion');
       this.regionManager.removeRegion('foo');
     });
 
@@ -229,6 +230,10 @@ describe('regionManager', function() {
     it('should adjust the length of the region manager by -1', function() {
       expect(this.regionManager.length).to.equal(0);
     });
+
+    it('should return the region manager', function() {
+      expect(this.regionManager.removeRegion).to.have.returned(this.regionManager);
+    });
   });
 
   describe('.removeRegions', function() {
@@ -254,6 +259,7 @@ describe('regionManager', function() {
       this.sinon.spy(this.region, 'stopListening');
       this.sinon.spy(this.r2, 'stopListening');
 
+      this.sinon.spy(this.regionManager, 'removeRegions');
       this.regionManager.removeRegions();
     });
 
@@ -276,6 +282,10 @@ describe('regionManager', function() {
       expect(this.removeHandler).to.have.been.calledWith('foo', this.region);
       expect(this.removeHandler).to.have.been.calledWith('bar', this.r2);
     });
+
+    it('should return the region manager', function() {
+      expect(this.regionManager.removeRegions).to.have.returned(this.regionManager);
+    });
   });
 
   describe('.emptyRegions', function() {
@@ -291,6 +301,7 @@ describe('regionManager', function() {
 
       this.region.on('empty', this.emptyHandler);
 
+      this.sinon.spy(this.regionManager, 'emptyRegions');
       this.regionManager.emptyRegions();
     });
 
@@ -300,6 +311,10 @@ describe('regionManager', function() {
 
     it('should not remove all regions', function() {
       expect(this.regionManager.get('foo')).to.equal(this.region);
+    });
+
+    it('should return the region manager', function() {
+      expect(this.regionManager.emptyRegions).to.have.returned(this.regionManager);
     });
   });
 
@@ -318,6 +333,7 @@ describe('regionManager', function() {
 
       this.sinon.spy(this.region, 'stopListening');
 
+      this.sinon.spy(this.regionManager, 'destroy');
       this.regionManager.destroy();
     });
 
@@ -335,6 +351,10 @@ describe('regionManager', function() {
 
     it('should trigger a "destroy" event/method', function() {
       expect(this.destroyManagerHandler).to.have.been.called;
+    });
+
+    it('should return the region manager', function() {
+      expect(this.regionManager.destroy).to.have.returned(this.regionManager);
     });
   });
 

--- a/spec/javascripts/view.entityEvents.spec.js
+++ b/spec/javascripts/view.entityEvents.spec.js
@@ -134,6 +134,7 @@ describe('view entity events', function() {
         collection: this.collection
       });
 
+      this.sinon.spy(this.view, 'undelegateEvents');
       this.view.undelegateEvents();
 
       this.model.trigger('model-event');
@@ -146,6 +147,10 @@ describe('view entity events', function() {
 
     it('should undelegate the collection events', function() {
       expect(this.collectionHandler).not.to.have.been.called;
+    });
+
+    it('should return the view', function() {
+      expect(this.view.undelegateEvents).to.have.returned(this.view);
     });
   });
 
@@ -176,6 +181,7 @@ describe('view entity events', function() {
       });
 
       this.view.undelegateEvents();
+      this.sinon.spy(this.view, 'delegateEvents');
       this.view.delegateEvents();
 
       this.model.trigger('model-event');
@@ -188,6 +194,10 @@ describe('view entity events', function() {
 
     it('should fire the collection event once', function() {
       expect(this.collectionHandler.callCount).to.equal(1);
+    });
+
+    it('should return the view from delegateEvents', function() {
+      expect(this.view.delegateEvents).to.have.returned(this.view);
     });
   });
 

--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -111,6 +111,7 @@ describe('base view', function() {
         return undefined;
       };
 
+      this.sinon.spy(this.view, 'destroy');
       this.view.destroy(123, 'second param');
     });
 
@@ -124,6 +125,10 @@ describe('base view', function() {
 
     it('should set the view isDestroyed to true', function() {
       expect(this.view.isDestroyed).to.be.true;
+    });
+
+    it('should return the view', function() {
+      expect(this.view.destroy).to.have.returned(this.view);
     });
   });
 

--- a/src/marionette.application.js
+++ b/src/marionette.application.js
@@ -41,6 +41,8 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
     this.triggerMethod('before:start', options);
     this._initCallbacks.run(options, this);
     this.triggerMethod('start', options);
+
+    return this;
   },
 
   // Add regions to your app.
@@ -54,6 +56,7 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
   // Empty all regions in the app, without removing them
   emptyRegions: function() {
     this._regionManager.emptyRegions();
+    return this;
   },
 
   // Removes a region from your app, by name
@@ -61,6 +64,7 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
   // removeRegion('myRegion')
   removeRegion: function(region) {
     this._regionManager.removeRegion(region);
+    return this;
   },
 
   // Provides alternative access to regions

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -225,6 +225,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     this.triggerMethod('empty', view);
 
     delete this.currentView;
+    return this;
   },
 
   // Attach an existing view to the region. This
@@ -233,6 +234,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   // of the region.
   attachView: function(view) {
     this.currentView = view;
+    return this;
   },
 
   // Reset the region by destroying any existing view and
@@ -247,6 +249,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     }
 
     delete this.$el;
+    return this;
   },
 
   // Proxy `getOption` to enable getting options from this or this.options by name.

--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -72,6 +72,8 @@ Marionette.RegionManager = (function(Marionette) {
     removeRegion: function(name) {
       var region = this._regions[name];
       this._remove(name, region);
+
+      return this;
     },
 
     // Empty all regions in the region manager, and
@@ -80,6 +82,8 @@ Marionette.RegionManager = (function(Marionette) {
       _.each(this._regions, function(region, name) {
         this._remove(name, region);
       }, this);
+
+      return this;
     },
 
     // Empty all regions in the region manager, but
@@ -88,6 +92,8 @@ Marionette.RegionManager = (function(Marionette) {
       _.each(this._regions, function(region) {
         region.empty();
       }, this);
+
+      return this;
     },
 
     // Destroy all regions and shut down the region
@@ -95,6 +101,7 @@ Marionette.RegionManager = (function(Marionette) {
     destroy: function() {
       this.removeRegions();
       Marionette.Controller.prototype.destroy.apply(this, arguments);
+      return this;
     },
 
     // internal method to store regions

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -108,6 +108,7 @@ Marionette.View = Backbone.View.extend({
     this._delegateDOMEvents(events);
     this.bindEntityEvents(this.model, this.getOption('modelEvents'));
     this.bindEntityEvents(this.collection, this.getOption('collectionEvents'));
+    return this;
   },
 
   // internal method to delegate DOM events and triggers
@@ -134,6 +135,7 @@ Marionette.View = Backbone.View.extend({
     Backbone.View.prototype.undelegateEvents.apply(this, args);
     this.unbindEntityEvents(this.model, this.getOption('modelEvents'));
     this.unbindEntityEvents(this.collection, this.getOption('collectionEvents'));
+    return this;
   },
 
   // Internal method, handles the `show` event.
@@ -170,6 +172,7 @@ Marionette.View = Backbone.View.extend({
 
     // remove the view from the DOM
     this.remove();
+    return this;
   },
 
   // This method binds the elements specified in the "ui" hash inside the view's code with


### PR DESCRIPTION
As discussed in #1355, it would be nice if Regions and Views returned `this` from many of their methods, in an attempt to be more self-consistent and also to more closely resemble Backbone.View. This also extends that similarity to RegionManager and Application.
