### PR TITLE
pass view instance in calls to Marionette.Renderer.render

### DIFF
--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -196,6 +196,10 @@ You can also manually re-render either or both of them:
 * If you want to re-render everything, call the `.render()` method
 * If you want to re-render the model's view, you can call `.renderModel()`
 
+As with item view instances, the composite view instance is passed as the
+third argument to the `Renderer` object's `render` method, which is
+useful in custom `Renderer` implementations.
+
 ## Events And Callbacks
 
 During the course of rendering a composite, several events will

--- a/docs/marionette.itemview.md
+++ b/docs/marionette.itemview.md
@@ -30,6 +30,10 @@ will provide features such as `onShow` callbacks, etc. Please see
 An item view has a `render` method built in to it, and uses the
 `Renderer` object to do the actual rendering.
 
+The item view instance is passed as the third argument to the
+`Renderer` object's `render` method, which is useful in custom
+`Renderer` implementations.
+
 You should provide a `template` attribute on the item view, which
 will be either a jQuery selector:
 

--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -70,6 +70,8 @@ describe("composite view", function(){
         collection: collection
       });
 
+      spyOn(Marionette.Renderer, 'render').andCallThrough();
+
       compositeView.render();
     });
 
@@ -80,6 +82,10 @@ describe("composite view", function(){
     it("should render the collection's items", function(){
       expect(compositeView.$el).toHaveText(/baz/);
     });
+
+    it("should pass the view instance to `Marionette.Renderer.Render`", function(){
+      expect(Marionette.Renderer.render).toHaveBeenCalledWith('#composite-template', { foo: 'bar' }, compositeView)
+    })
   });
 
   describe("when a composite view triggers render in initialize", function(){

--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -45,6 +45,8 @@ describe("item view", function(){
       spyOn(view, "onRender").andCallThrough();
       spyOn(view, "trigger").andCallThrough();
 
+      spyOn(Marionette.Renderer, 'render').andCallThrough();
+
       view.render();
     });
 
@@ -63,6 +65,10 @@ describe("item view", function(){
     it("should trigger a rendered event", function(){
       expect(view.trigger).toHaveBeenCalledWith("item:rendered", view);
     });
+
+    it("should pass the view instance to `Marionette.Renderer.Render`", function(){
+      expect(Marionette.Renderer.render).toHaveBeenCalledWith('#emptyTemplate', {}, view)
+    })
   });
 
   describe("when an item view has a model and is rendered", function(){

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -97,7 +97,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     data = this.mixinTemplateHelpers(data);
 
     var template = this.getTemplate();
-    return Marionette.Renderer.render(template, data);
+    return Marionette.Renderer.render(template, data, this);
   },
 
 

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -46,7 +46,7 @@ Marionette.ItemView = Marionette.View.extend({
     data = this.mixinTemplateHelpers(data);
 
     var template = this.getTemplate();
-    var html = Marionette.Renderer.render(template, data);
+    var html = Marionette.Renderer.render(template, data, this);
 
     this.$el.html(html);
     this.bindUIElements();


### PR DESCRIPTION
Enable custom `Marionette.Renderer` implementations access to the view instance in which `render` was called.  This is useful in such scenarios as defining Mustache partials for a view, or even defining per-view templating engines.

Replaces calls:

```
Marionette.Renderer.render(template, data)
```

with:

```
Marionette.Renderer.render(template, data, this)
```

_this_ being the view instance.
