### PR TITLE
Fix link to addChild in CollectionView docs

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -22,7 +22,7 @@ will provide features such as `onShow` callbacks, etc. Please see
   * [CollectionView's `childViewEventPrefix`](#collectionviews-childvieweventprefix)
   * [CollectionView's `childEvents`](#collectionviews-childevents)
   * [CollectionView's `buildChildView`](#collectionviews-buildchildview)
-  * [CollectionView's `addChild`](#collectionviews-addchildview)
+  * [CollectionView's `addChild`](#collectionviews-addchild)
 * [CollectionView's `emptyView`](#collectionviews-emptyview)
   * [CollectionView's `getEmptyView`](#collectionviews-getemptyview)
   * [CollectionView's `emptyViewOptions`](#collectionviews-emptyviewoptions)


### PR DESCRIPTION
The table-of-contents link to addChild was broken in the CollectionView docs. It linked to a non-existent element ID, `#collectionview-addchildview`, instead of the actual element's ID, `#collectionview-addchild`.
