### PR TITLE
Add Wreqr and Babysitter to Core AMD definition

### DIFF
--- a/src/build/marionette.core.js
+++ b/src/build/marionette.core.js
@@ -1,7 +1,7 @@
 (function(root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['backbone', 'underscore'], function(Backbone, _) {
+    define(['backbone', 'underscore', 'backbone.wreqr', 'backbone.babysitter'], function(Backbone, _) {
       return (root.Marionette = factory(root, Backbone, _));
     });
   } else if (typeof exports !== 'undefined') {


### PR DESCRIPTION
Fixes #1498

**Changes:**
- Added Wreqr and Babysitter to `marionette.core.js` AMD definition
