### PR TITLE
moved this.endBuffering() before this.triggerMethod() (issue 1503)

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -136,20 +136,18 @@ Marionette.CollectionView = Marionette.View.extend({
   // more control over events being triggered, around the rendering
   // process
   _renderChildren: function() {
-    this.startBuffering();
-
     this.destroyEmptyView();
     this.destroyChildren();
 
     if (!this.isEmpty(this.collection)) {
+      this.startBuffering();
       this.triggerMethod('before:render:collection', this);
       this.showCollection();
+      this.endBuffering();
       this.triggerMethod('render:collection', this);
     } else {
       this.showEmptyView();
     }
-
-    this.endBuffering();
   },
 
   // Internal method to loop through collection and show each child view.


### PR DESCRIPTION
fixes this bug:
https://github.com/marionettejs/backbone.marionette/issues/1503

P.s. I'm not sure, but buffering for `this.showEmptyView()` not so important. Otherwise need to add `this.endBuffering()` in both conditions and leave the `this.startBuffering()` in the same place

Please comment, thanks.
