### PR TITLE
Fix ui bindings for Collection and Composite Views

### DIFF
--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -726,10 +726,8 @@ describe('composite view', function() {
       });
 
       describe('accessing a ui element that belongs to the collection', function() {
-        // This test makes it clear that not allowing access to the collection elements is a design decision
-        // and not a bug.
-        it('should return an empty jQuery object', function() {
-          expect(this.gridView.ui.itemRows.length).to.equal(0);
+        it('should return a jQuery object', function() {
+          expect(this.gridView.ui.itemRows.length).to.equal(2);
         });
       });
     });

--- a/spec/javascripts/view.uiBindings.spec.js
+++ b/spec/javascripts/view.uiBindings.spec.js
@@ -34,7 +34,7 @@ describe('view ui elements', function() {
     });
   });
 
-  describe('when re-rendering a view with a UI element configuration', function() {
+  describe('when re-rendering an ItemView with a UI element configuration', function() {
     beforeEach(function() {
       this.itemWithCheckboxTemplateFn = _.template('<input type="checkbox" id="chk" <% if (done) { %>checked<% } %>></input>');
 
@@ -65,6 +65,72 @@ describe('view ui elements', function() {
 
     it('should return an up-to-date selector on subsequent renders', function() {
       expect(this.view.ui.checkbox.attr('checked')).to.exist;
+    });
+
+  });
+
+  describe('when re-rendering a CollectionView with a UI element configuration', function() {
+    beforeEach(function() {
+      this.itemWithCheckboxTemplateFn = _.template('<input type="checkbox" class="chk"></input>');
+
+      this.ItemView = Backbone.Marionette.ItemView.extend({
+        template: this.itemWithCheckboxTemplateFn,
+      });
+
+      this.CollectionView = Backbone.Marionette.CollectionView.extend({
+
+        childView: this.ItemView,
+
+        ui: {
+          checkbox: '.chk',
+        }
+      });
+
+      this.collection = new Backbone.Collection([{}, {}]);
+
+      this.view = new this.CollectionView({
+        collection: this.collection
+      });
+
+      this.view.render();
+    });
+
+    it('should return an up-to-date selector on subsequent renders', function() {
+      expect(this.view.ui.checkbox.length).to.equal(2);
+    });
+
+  });
+
+  describe('when re-rendering a CompositeView with a UI element configuration', function() {
+    beforeEach(function() {
+      this.itemWithCheckboxTemplateFn = _.template('<input type="checkbox" class="chk"></input>');
+
+      this.ItemView = Backbone.Marionette.ItemView.extend({
+        template: this.itemWithCheckboxTemplateFn,
+      });
+
+      this.CompositeView = Backbone.Marionette.CompositeView.extend({
+
+        template: _.template(''),
+
+        childView: this.ItemView,
+
+        ui: {
+          checkbox: '.chk',
+        }
+      });
+
+      this.collection = new Backbone.Collection([{}, {}]);
+
+      this.view = new this.CompositeView({
+        collection: this.collection
+      });
+
+      this.view.render();
+    });
+
+    it('should return an up-to-date selector on subsequent renders', function() {
+      expect(this.view.ui.checkbox.length).to.equal(2);
     });
 
   });

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -114,6 +114,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this._ensureViewIsIntact();
     this.triggerMethod('before:render', this);
     this._renderChildren();
+    this.bindUIElements();
     this.triggerMethod('render', this);
     return this;
   },

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -77,6 +77,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
 
     this._renderRoot();
     this._renderChildren();
+    this.bindUIElements();
 
     this.triggerMethod('render', this);
     return this;


### PR DESCRIPTION
Fixes #1502.

Not going to lie, this was a bigger / more invasive change than I expected when I went in here.

This fixes a couple things that broke:
1. collectionView now invokes bindUIelements after rendering its children
2. compositeView now invokes bindUIelements after rendering its children

Interesting to note:
- compositeView also invokes bindUIelements before rendering its children because childViewContainer could have ui interpolation
