### PR TITLE
pass view instance when calling Marionette.Renderer.render

### DIFF
--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -193,6 +193,10 @@ themselves under the following conditions:
 * When the collection has a model added to it (the "add" event is fired), it will render that one child into the list
 * When the collection has a model removed (the "remove" event is fired), it will remove that one child from the rendered list
 
+As with item view instances, the composite view instance is passed as the
+third argument to the `Renderer` object's `render` method, which is
+useful in custom `Renderer` implementations.
+
 ## Events And Callbacks
 
 During the course of rendering a composite, several events will

--- a/docs/marionette.itemview.md
+++ b/docs/marionette.itemview.md
@@ -30,6 +30,10 @@ will provide features such as `onShow` callbacks, etc. Please see
 An item view has a `render` method built in to it, and uses the
 `Renderer` object to do the actual rendering.
 
+The item view instance is passed as the third argument to the
+`Renderer` object's `render` method, which is useful in custom
+`Renderer` implementations.
+
 You should provide a `template` attribute on the item view, which
 will be either a jQuery selector:
 

--- a/spec/javascripts/compositeView.spec.js
+++ b/spec/javascripts/compositeView.spec.js
@@ -128,6 +128,8 @@ describe('composite view', function() {
         collection: this.collection
       });
 
+      this.sinon.spy(Marionette.Renderer, 'render');
+
       this.compositeView.render();
     });
 
@@ -137,6 +139,10 @@ describe('composite view', function() {
 
     it('should render the collections items', function() {
       expect(this.compositeView.$el).to.contain.$text('baz');
+    });
+
+    it("should pass the view instance to `Marionette.Renderer.Render`", function(){
+      expect(Marionette.Renderer.render).to.have.been.calledWith(this.templateFn, { foo: 'bar' }, this.compositeView);
     });
   });
 

--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -29,6 +29,7 @@ describe('item view', function() {
         template        : this.templateStub,
         attachElContent : this.attachElContentStub
       });
+      this.sinon.spy(Marionette.Renderer, 'render');
 
       this.itemView = new this.ItemView();
       this.itemView.render();
@@ -36,6 +37,10 @@ describe('item view', function() {
 
     it('should render according to the custom attachElContent logic', function() {
       expect(this.attachElContentStub).to.have.been.calledOnce.and.calledWith(this.template);
+    });
+
+    it("should pass the view instance to `Marionette.Renderer.Render`", function(){
+      expect(Marionette.Renderer.render).to.have.been.calledWith(this.templateStub, {}, this.itemView);
     });
   });
 

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -98,7 +98,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     this.triggerMethod('before:render:template');
 
     var template = this.getTemplate();
-    var html = Marionette.Renderer.render(template, data);
+    var html = Marionette.Renderer.render(template, data, this);
     this.attachElContent(html);
 
     // the ui bindings is done here and not at the end of render since they

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -45,7 +45,7 @@ Marionette.ItemView = Marionette.View.extend({
     data = this.mixinTemplateHelpers(data);
 
     var template = this.getTemplate();
-    var html = Marionette.Renderer.render(template, data);
+    var html = Marionette.Renderer.render(template, data, this);
     this.attachElContent(html);
     this.bindUIElements();
 


### PR DESCRIPTION
After speaking with folks on gitter, #1473 should have been PRed against master.  This PR is in favor of #1473, and has been reworked to follow master.  See #1473 for full description.  
