### PR TITLE
Fix #1355 Return `this` from View and Region-based methods

### DIFF
--- a/spec/javascripts/application.appRegions.spec.js
+++ b/spec/javascripts/application.appRegions.spec.js
@@ -106,16 +106,22 @@ describe('application regions', function() {
         fooRegion: '#foo-region',
         barRegion: '#bar-region'
       });
+      this.regions = this.app.getRegions();
 
       this.sinon.spy(this.app.fooRegion, 'empty');
       this.sinon.spy(this.app.barRegion, 'empty');
 
+      this.sinon.spy(this.app, 'emptyRegions');
       this.app.emptyRegions();
     });
 
     it('should empty the regions', function() {
       expect(this.app.fooRegion.empty).to.have.been.called;
       expect(this.app.barRegion.empty).to.have.been.called;
+    });
+
+    it('should return the regions', function() {
+      expect(this.app.emptyRegions).to.have.returned(this.regions);
     });
   });
 
@@ -143,6 +149,7 @@ describe('application regions', function() {
         fooRegion: '#foo-region',
         barRegion: '#bar-region'
       });
+      this.fooRegion = this.app.fooRegion;
 
       this.beforeRemoveRegionStub = this.sinon.stub();
       this.removeRegionStub = this.sinon.stub();
@@ -150,6 +157,8 @@ describe('application regions', function() {
       this.app.on('remove:region', this.removeRegionStub);
 
       this.app.start();
+
+      this.sinon.spy(this.app, 'removeRegion');
       this.app.removeRegion('fooRegion');
     });
 
@@ -163,6 +172,10 @@ describe('application regions', function() {
 
     it('should trigger a remove:region event', function() {
       expect(this.removeRegionStub).to.have.been.calledWith('fooRegion');
+    });
+
+    it('should return the region', function() {
+      expect(this.app.removeRegion).to.have.returned(this.fooRegion);
     });
   });
 });

--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -641,4 +641,52 @@ describe('Behaviors', function() {
       expect(this.bazClickStub).to.have.been.calledOnce.and.calledOn(this.view);
     });
   });
+
+  describe('return values of wrapped methods', function() {
+    beforeEach(function() {
+      this.behaviors = { foo: Marionette.Behavior };
+      Marionette.Behaviors.behaviorsLookup = this.behaviors;
+
+      this.View = Marionette.View.extend({
+        behaviors: { foo: {} }
+      });
+
+      this.view = new this.View();
+    });
+
+    it('destroy should return the view', function() {
+      this.sinon.spy(this.view, 'destroy');
+      this.view.destroy();
+      expect(this.view.destroy).to.have.returned(this.view);
+    });
+
+    it('setElement should return the view', function() {
+      this.sinon.spy(this.view, 'setElement');
+      this.view.setElement(this.view.$el);
+      expect(this.view.setElement).to.have.returned(this.view);
+    });
+
+    it('delegateEvents should return the view', function() {
+      this.sinon.spy(this.view, 'delegateEvents');
+      this.view.delegateEvents();
+      expect(this.view.delegateEvents).to.have.returned(this.view);
+    });
+
+    it('undelegateEvents should return the view', function() {
+      this.sinon.spy(this.view, 'undelegateEvents');
+      this.view.undelegateEvents({});
+      expect(this.view.undelegateEvents).to.have.returned(this.view);
+    });
+  });
+
+  describe('.destroy', function() {
+    beforeEach(function() {
+      this.behavior = new Marionette.Behavior();
+      this.sinon.spy(this.behavior, 'destroy');
+      this.behavior.destroy();
+    });
+
+    it('should return the behavior', function() {
+    });
+  });
 });

--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -163,6 +163,32 @@ describe('collection view', function() {
     });
   });
 
+  describe('when rendering a childView', function() {
+    beforeEach(function() {
+      this.collection = new Backbone.Collection([{foo: 'bar'}]);
+      this.collectionView = new Marionette.CollectionView({
+        childView: this.ChildView,
+        collection: this.collection
+      });
+
+      this.collectionView.render();
+
+      this.childView = this.collectionView.children.first();
+      this.sinon.spy(this.childView, 'render');
+
+      this.sinon.spy(this.collectionView, 'renderChildView');
+      this.collectionView.renderChildView(this.childView);
+    });
+
+    it('should call "render" on the childView', function() {
+      expect(this.childView.render).to.have.been.calledOnce;
+    });
+
+    it('should return the childView', function() {
+      expect(this.collectionView.renderChildView).to.have.returned(this.childView);
+    });
+  });
+
   describe('when a model is added to the collection', function() {
     beforeEach(function() {
       this.collection = new Backbone.Collection();
@@ -437,9 +463,13 @@ describe('collection view', function() {
     it('should throw an error saying the views been destroyed if render is attempted again', function() {
       expect(this.collectionView.render).to.throw('Cannot use a view thats already been destroyed.');
     });
+
+    it('should return the collection view', function() {
+      expect(this.collectionView.destroy).to.have.returned(this.collectionView);
+    });
   });
 
-  describe('when destroying an childView that does not have a "destroy" method', function() {
+  describe('when removing a childView that does not have a "destroy" method', function() {
     beforeEach(function() {
       this.collectionView = new Marionette.CollectionView({
         childView: Backbone.View,
@@ -451,11 +481,47 @@ describe('collection view', function() {
       this.childView = this.collectionView.children.findByIndex(0);
       this.sinon.spy(this.childView, 'remove');
 
-      this.collectionView.destroyChildren();
+      this.sinon.spy(this.collectionView, 'removeChildView');
+      this.collectionView.removeChildView(this.childView);
     });
 
     it('should call the "remove" method', function() {
       expect(this.childView.remove).to.have.been.called;
+    });
+
+    it('should return the childView', function() {
+      expect(this.collectionView.removeChildView).to.have.returned(this.childView);
+    });
+  });
+
+  describe('when destroying all children', function() {
+    beforeEach(function() {
+      this.collectionView = new Marionette.CollectionView({
+        childView: Backbone.View,
+        collection: new Backbone.Collection([{id: 1}, {id: 2}])
+      });
+
+      this.collectionView.render();
+
+      this.childView0 = this.collectionView.children.findByIndex(0);
+      this.sinon.spy(this.childView0, 'remove');
+
+      this.childView1 = this.collectionView.children.findByIndex(1);
+      this.sinon.spy(this.childView1, 'remove');
+
+      this.childrenViews = this.collectionView.children.map(_.identity);
+
+      this.sinon.spy(this.collectionView, 'destroyChildren');
+      this.collectionView.destroyChildren();
+    });
+
+    it('should call the "remove" method on each child', function() {
+      expect(this.childView0.remove).to.have.been.called;
+      expect(this.childView1.remove).to.have.been.called;
+    });
+
+    it('should return the child views', function() {
+      expect(this.collectionView.destroyChildren).to.have.returned(this.childrenViews);
     });
   });
 

--- a/spec/javascripts/controller.spec.js
+++ b/spec/javascripts/controller.spec.js
@@ -74,6 +74,7 @@ describe('marionette controller', function() {
       this.controller.on('before:destroy', this.beforeDestroyHandlerStub);
       this.controller.listenTo(this.controller, 'destroy', this.listenToHandlerStub);
 
+      this.sinon.spy(this.controller, 'destroy');
       this.controller.destroy(this.argumentOne, this.argumentTwo);
     });
 
@@ -103,6 +104,10 @@ describe('marionette controller', function() {
 
     it('should call an onDestroy method with any arguments passed to destroy', function() {
       expect(this.controller.onDestroy).to.have.been.calledOnce.and.calledWith(this.argumentOne, this.argumentTwo);
+    });
+
+    it('should return the controller', function() {
+      expect(this.controller.destroy).to.have.returned(this.controller);
     });
   });
 });

--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -151,6 +151,7 @@ describe('item view', function() {
       this.stopListeningSpy = this.sinon.spy(this.view, 'stopListening');
       this.triggerSpy       = this.sinon.spy(this.view, 'trigger');
 
+      this.sinon.spy(this.view, 'destroy');
       this.view.destroy();
     });
 
@@ -176,6 +177,10 @@ describe('item view', function() {
 
     it('should call "onDestroy" if provided', function() {
       expect(this.onDestroyStub).to.have.been.called;
+    });
+
+    it('should return the view', function() {
+      expect(this.view.destroy).to.have.returned(this.view);
     });
   });
 

--- a/spec/javascripts/layoutView.spec.js
+++ b/spec/javascripts/layoutView.spec.js
@@ -163,17 +163,23 @@ describe('layoutView', function() {
       this.sinon.spy(this.regionOne, 'empty');
       this.sinon.spy(this.regionTwo, 'empty');
 
+      this.sinon.spy(this.layoutViewManager, 'destroy');
+      this.layoutViewManager.destroy();
       this.layoutViewManager.destroy();
     });
 
     it('should empty the region managers', function() {
-      expect(this.regionOne.empty).to.have.been.called;
-      expect(this.regionTwo.empty).to.have.been.called;
+      expect(this.regionOne.empty).to.have.been.calledOnce;
+      expect(this.regionTwo.empty).to.have.been.calledOnce;
     });
 
     it('should delete the region managers', function() {
       expect(this.layoutViewManager.regionOne).to.be.undefined;
       expect(this.layoutViewManager.regionTwo).to.be.undefined;
+    });
+
+    it('should return the view', function() {
+      expect(this.layoutViewManager.destroy).to.have.always.returned(this.layoutViewManager);
     });
   });
 

--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -116,6 +116,7 @@ describe('region', function() {
       this.view.on('before:show', this.viewBeforeShowSpy);
       this.view.on('show', this.viewShowSpy);
 
+      this.sinon.spy(this.myRegion, 'show');
       this.myRegion.show(this.view);
     });
 
@@ -181,6 +182,10 @@ describe('region', function() {
 
     it('should not call the `onSwap` function on the region', function() {
       expect(this.swapSpy.callCount).to.equal(0);
+    });
+
+    it('should return the region', function() {
+      expect(this.myRegion.show).to.have.returned(this.myRegion);
     });
 
     describe('and then showing a different view', function() {
@@ -524,6 +529,7 @@ describe('region', function() {
       this.myRegion.on('empty', this.emptySpy);
       this.myRegion.show(this.view);
 
+      this.sinon.spy(this.myRegion, 'empty');
       this.myRegion.empty();
     });
 
@@ -557,6 +563,10 @@ describe('region', function() {
 
     it('should delete the current view reference', function() {
       expect(this.myRegion.currentView).to.be.undefined;
+    });
+
+    it('should return the region', function() {
+      expect(this.myRegion.empty).to.have.returned(this.myRegion);
     });
   });
 
@@ -641,6 +651,7 @@ describe('region', function() {
         el: '#foo'
       });
 
+      this.sinon.spy(this.region, 'attachView');
       this.region.attachView(this.view);
     });
 
@@ -654,6 +665,10 @@ describe('region', function() {
 
     it('should not replace the existing html', function() {
       expect($(this.region.el).text()).to.equal('bar');
+    });
+
+    it('should return the region', function() {
+      expect(this.region.attachView).to.have.returned(this.region);
     });
   });
 
@@ -728,6 +743,7 @@ describe('region', function() {
 
       this.region._ensureElement();
 
+      this.sinon.spy(this.region, 'reset');
       this.region.reset();
     });
 
@@ -737,6 +753,10 @@ describe('region', function() {
 
     it('should empty any existing view', function() {
       expect(this.region.empty).to.have.been.called;
+    });
+
+    it('should return the region', function() {
+      expect(this.region.reset).to.have.returned(this.region);
     });
   });
 });

--- a/spec/javascripts/regionManager.spec.js
+++ b/spec/javascripts/regionManager.spec.js
@@ -203,6 +203,7 @@ describe('regionManager', function() {
       this.regionManager.on('remove:region', this.removeHandler);
       this.sinon.spy(this.region, 'stopListening');
 
+      this.sinon.spy(this.regionManager, 'removeRegion');
       this.regionManager.removeRegion('foo');
     });
 
@@ -229,6 +230,10 @@ describe('regionManager', function() {
     it('should adjust the length of the region manager by -1', function() {
       expect(this.regionManager.length).to.equal(0);
     });
+
+    it('should return the region', function() {
+      expect(this.regionManager.removeRegion).to.have.returned(this.region);
+    });
   });
 
   describe('.removeRegions', function() {
@@ -242,6 +247,7 @@ describe('regionManager', function() {
       this.regionManager = new Marionette.RegionManager();
       this.region = this.regionManager.addRegion('foo', '#foo');
       this.r2 = this.regionManager.addRegion('bar', '#bar');
+      this.regions = this.regionManager.getRegions();
 
       this.region.show(new Backbone.View());
       this.r2.show(new Backbone.View());
@@ -254,6 +260,7 @@ describe('regionManager', function() {
       this.sinon.spy(this.region, 'stopListening');
       this.sinon.spy(this.r2, 'stopListening');
 
+      this.sinon.spy(this.regionManager, 'removeRegions');
       this.regionManager.removeRegions();
     });
 
@@ -276,6 +283,10 @@ describe('regionManager', function() {
       expect(this.removeHandler).to.have.been.calledWith('foo', this.region);
       expect(this.removeHandler).to.have.been.calledWith('bar', this.r2);
     });
+
+    it('should return the regions', function() {
+      expect(this.regionManager.removeRegions).to.have.returned(this.regions);
+    });
   });
 
   describe('.emptyRegions', function() {
@@ -287,10 +298,12 @@ describe('regionManager', function() {
 
       this.regionManager = new Marionette.RegionManager();
       this.region = this.regionManager.addRegion('foo', '#foo');
+      this.regions = this.regionManager.getRegions();
       this.region.show(new Backbone.View());
 
       this.region.on('empty', this.emptyHandler);
 
+      this.sinon.spy(this.regionManager, 'emptyRegions');
       this.regionManager.emptyRegions();
     });
 
@@ -300,6 +313,10 @@ describe('regionManager', function() {
 
     it('should not remove all regions', function() {
       expect(this.regionManager.get('foo')).to.equal(this.region);
+    });
+
+    it('should return the regions', function() {
+      expect(this.regionManager.emptyRegions).to.have.returned(this.regions);
     });
   });
 
@@ -318,6 +335,7 @@ describe('regionManager', function() {
 
       this.sinon.spy(this.region, 'stopListening');
 
+      this.sinon.spy(this.regionManager, 'destroy');
       this.regionManager.destroy();
     });
 
@@ -335,6 +353,10 @@ describe('regionManager', function() {
 
     it('should trigger a "destroy" event/method', function() {
       expect(this.destroyManagerHandler).to.have.been.called;
+    });
+
+    it('should return the region manager', function() {
+      expect(this.regionManager.destroy).to.have.returned(this.regionManager);
     });
   });
 

--- a/spec/javascripts/view.entityEvents.spec.js
+++ b/spec/javascripts/view.entityEvents.spec.js
@@ -128,6 +128,7 @@ describe('view entity events', function() {
         collection : this.collection
       });
 
+      this.sinon.spy(this.view, 'undelegateEvents');
       this.view.undelegateEvents();
 
       this.model.trigger('foo');
@@ -140,6 +141,10 @@ describe('view entity events', function() {
 
     it('should undelegate the collection events', function() {
       expect(this.barStub).not.to.have.been.calledOnce;
+    });
+
+    it('should return the view', function() {
+      expect(this.view.undelegateEvents).to.have.returned(this.view);
     });
   });
 
@@ -158,6 +163,7 @@ describe('view entity events', function() {
       });
 
       this.view.undelegateEvents();
+      this.sinon.spy(this.view, 'delegateEvents');
       this.view.delegateEvents();
     });
 
@@ -169,6 +175,10 @@ describe('view entity events', function() {
     it('should fire the collection event once', function() {
       this.collection.trigger('bar');
       expect(this.barStub).to.have.been.calledOnce;
+    });
+
+    it('should return the view from delegateEvents', function() {
+      expect(this.view.delegateEvents).to.have.returned(this.view);
     });
   });
 

--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -106,14 +106,14 @@ describe('base view', function() {
       this.view = new Marionette.View();
 
       this.removeSpy = this.sinon.spy(this.view, 'remove');
-      this.destroySpy = this.sinon.spy(this.view, 'destroy');
 
       this.destroyStub = this.sinon.stub();
       this.view.on('destroy', this.destroyStub);
 
       this.onBeforeDestroyStub = this.sinon.stub().returns(false);
       this.view.onBeforeDestroy = this.onBeforeDestroyStub;
-
+      this.sinon.spy(this.view, 'destroy');
+      
       this.view.destroy(this.argumentOne, this.argumentTwo);
     });
 
@@ -126,7 +126,11 @@ describe('base view', function() {
     });
 
     it('should set the view isDestroyed to true', function() {
-      expect(this.view).to.be.have.property('isDestroyed', true);
+      expect(this.view).to.have.property('isDestroyed', true);
+    });
+
+    it('should return the view', function() {
+      expect(this.view.destroy).to.have.returned(this.view);
     });
   });
 

--- a/src/marionette.application.js
+++ b/src/marionette.application.js
@@ -53,14 +53,14 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
 
   // Empty all regions in the app, without removing them
   emptyRegions: function() {
-    this._regionManager.emptyRegions();
+    return this._regionManager.emptyRegions();
   },
 
   // Removes a region from your app, by name
   // Accepts the regions name
   // removeRegion('myRegion')
   removeRegion: function(region) {
-    this._regionManager.removeRegion(region);
+    return this._regionManager.removeRegion(region);
   },
 
   // Provides alternative access to regions

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -36,6 +36,8 @@ Marionette.Behaviors = (function(Marionette, _) {
       _.each(behaviors, function(b) {
         b.$el = this.$el;
       }, this);
+
+      return this;
     },
 
     destroy: function(destroy, behaviors) {
@@ -47,6 +49,7 @@ Marionette.Behaviors = (function(Marionette, _) {
       // This unbinds event listeners
       // that behaviors have registerd for.
       _.invoke(behaviors, 'destroy', args);
+      return this;
     },
 
     bindUIElements: function(bindUIElements, behaviors) {
@@ -76,6 +79,8 @@ Marionette.Behaviors = (function(Marionette, _) {
         Marionette.bindEntityEvents(b, this.model, Marionette.getOption(b, 'modelEvents'));
         Marionette.bindEntityEvents(b, this.collection, Marionette.getOption(b, 'collectionEvents'));
       }, this);
+
+      return this;
     },
 
     undelegateEvents: function(undelegateEvents, behaviors) {
@@ -86,6 +91,8 @@ Marionette.Behaviors = (function(Marionette, _) {
         Marionette.unbindEntityEvents(b, this.model, Marionette.getOption(b, 'modelEvents'));
         Marionette.unbindEntityEvents(b, this.collection, Marionette.getOption(b, 'collectionEvents'));
       }, this);
+
+      return this;
     },
 
     behaviorEvents: function(behaviorEvents, behaviors) {

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -318,6 +318,7 @@ Marionette.CollectionView = Marionette.View.extend({
   renderChildView: function(view, index) {
     view.render();
     this.attachHtml(this, view, index);
+    return view;
   },
 
   // Build a `childView` for a model in the collection.
@@ -346,6 +347,7 @@ Marionette.CollectionView = Marionette.View.extend({
       this._updateIndices(view, false);
     }
 
+    return view;
   },
 
   // check if the collection is empty
@@ -425,14 +427,16 @@ Marionette.CollectionView = Marionette.View.extend({
     this.destroyChildren();
     this.triggerMethod('destroy:collection');
 
-    Marionette.View.prototype.destroy.apply(this, arguments);
+    return Marionette.View.prototype.destroy.apply(this, arguments);
   },
 
   // Destroy the child views that this collection view
   // is holding on to, if any
   destroyChildren: function() {
+    var childViews = this.children.map(_.identity);
     this.children.each(this.removeChildView, this);
     this.checkEmpty();
+    return childViews;
   },
 
   // Set up the child view event forwarding. Uses a "childview:"

--- a/src/marionette.controller.js
+++ b/src/marionette.controller.js
@@ -27,6 +27,7 @@ _.extend(Marionette.Controller.prototype, Backbone.Events, {
 
     this.stopListening();
     this.off();
+    return this;
   },
 
   // import the `triggerMethod` to trigger events with corresponding

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -77,6 +77,6 @@ Marionette.ItemView = Marionette.View.extend({
   destroy: function() {
     if (this.isDestroyed) { return; }
 
-    Marionette.View.prototype.destroy.apply(this, arguments);
+    return Marionette.View.prototype.destroy.apply(this, arguments);
   }
 });

--- a/src/marionette.layoutview.js
+++ b/src/marionette.layoutview.js
@@ -43,10 +43,10 @@ Marionette.LayoutView = Marionette.ItemView.extend({
 
   // Handle destroying regions, and then destroy the view itself.
   destroy: function() {
-    if (this.isDestroyed) { return; }
+    if (this.isDestroyed) { return this; }
 
     this.regionManager.destroy();
-    Marionette.ItemView.prototype.destroy.apply(this, arguments);
+    return Marionette.ItemView.prototype.destroy.apply(this, arguments);
   },
 
   // Add a single region, by name, to the layoutView

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -224,6 +224,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     this.triggerMethod('empty', view);
 
     delete this.currentView;
+    return this;
   },
 
   // Attach an existing view to the region. This
@@ -232,6 +233,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   // of the region.
   attachView: function(view) {
     this.currentView = view;
+    return this;
   },
 
   // Reset the region by destroying any existing view and
@@ -246,6 +248,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     }
 
     delete this.$el;
+    return this;
   },
 
   // Proxy `getOption` to enable getting options from this or this.options by name.

--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -72,29 +72,37 @@ Marionette.RegionManager = (function(Marionette) {
     removeRegion: function(name) {
       var region = this._regions[name];
       this._remove(name, region);
+
+      return region;
     },
 
     // Empty all regions in the region manager, and
     // remove them
     removeRegions: function() {
+      var regions = this.getRegions();
       _.each(this._regions, function(region, name) {
         this._remove(name, region);
       }, this);
+
+      return regions;
     },
 
     // Empty all regions in the region manager, but
     // leave them attached
     emptyRegions: function() {
-      _.each(this._regions, function(region) {
+      var regions = this.getRegions();
+      _.each(regions, function(region) {
         region.empty();
       }, this);
+
+      return regions;
     },
 
     // Destroy all regions and shut down the region
     // manager entirely
     destroy: function() {
       this.removeRegions();
-      Marionette.Controller.prototype.destroy.apply(this, arguments);
+      return Marionette.Controller.prototype.destroy.apply(this, arguments);
     },
 
     // internal method to store regions

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -109,6 +109,7 @@ Marionette.View = Backbone.View.extend({
     this._delegateDOMEvents(events);
     this.bindEntityEvents(this.model, this.getOption('modelEvents'));
     this.bindEntityEvents(this.collection, this.getOption('collectionEvents'));
+    return this;
   },
 
   // internal method to delegate DOM events and triggers
@@ -138,6 +139,7 @@ Marionette.View = Backbone.View.extend({
     Backbone.View.prototype.undelegateEvents.apply(this, args);
     this.unbindEntityEvents(this.model, this.getOption('modelEvents'));
     this.unbindEntityEvents(this.collection, this.getOption('collectionEvents'));
+    return this;
   },
 
   // Internal method, handles the `show` event.
@@ -174,6 +176,7 @@ Marionette.View = Backbone.View.extend({
 
     // remove the view from the DOM
     this.remove();
+    return this;
   },
 
   // This method binds the elements specified in the "ui" hash inside the view's code with


### PR DESCRIPTION
Fix #1355 and concerns raised in #1436

This tries to draw similarities between the return value behavior of Views
and Regions, and their equivalent methods in Backbone.View.

Conflicts:
    spec/javascripts/view.spec.js
