### PR TITLE
False template option for ItemView

### DIFF
--- a/spec/javascripts/itemView.spec.js
+++ b/spec/javascripts/itemView.spec.js
@@ -17,7 +17,63 @@ describe('item view', function() {
     });
 
     it('should throw an exception because there was no valid template', function() {
-      expect(this.view.render).to.throw('Cannot render the template since its false, null or undefined.');
+      expect(this.view.render).to.throw('Cannot render the template since it is null or undefined.');
+    });
+  });
+
+  describe('when rendering with a false template', function() {
+    beforeEach(function() {
+      this.onBeforeRenderStub = this.sinon.stub();
+      this.onRenderStub       = this.sinon.stub();
+
+      this.View = Marionette.ItemView.extend({
+        template: false,
+        onBeforeRender: this.onBeforeRenderStub,
+        onRender: this.onRenderStub
+      });
+
+      this.view = new this.View();
+
+      this.marionetteRendererSpy   = this.sinon.spy(Marionette.Renderer, 'render');
+      this.triggerSpy              = this.sinon.spy(this.view, 'trigger');
+      this.serializeDataSpy        = this.sinon.spy(this.view, 'serializeData');
+      this.mixinTemplateHelpersSpy = this.sinon.spy(this.view, 'mixinTemplateHelpers');
+      this.attachElContentSpy      = this.sinon.spy(this.view, 'attachElContent');
+
+      this.view.render();
+    });
+
+    it('should not throw an exception for a false template', function() {
+      expect(this.view.render).to.not.throw('Cannot render the template since it is null or undefined.');
+    });
+
+    it('should call an "onBeforeRender" method on the view', function() {
+      expect(this.onBeforeRenderStub).to.have.been.calledOnce;
+    });
+
+    it('should call an "onRender" method on the view', function() {
+      expect(this.onRenderStub).to.have.been.calledOnce;
+    });
+
+    it('should trigger a before:render event', function() {
+      expect(this.triggerSpy).to.have.been.calledWith('before:render', this.view);
+    });
+
+    it('should trigger a rendered event', function() {
+      expect(this.triggerSpy).to.have.been.calledWith('render', this.view);
+    });
+
+    it('should not add in data or template helpers', function() {
+      expect(this.serializeDataSpy).to.not.have.been.called;
+      expect(this.mixinTemplateHelpersSpy).to.not.have.been.called;
+    });
+
+    it('should not render a template', function() {
+      expect(this.marionetteRendererSpy).to.not.have.been.called;
+    });
+
+    it('should not attach any html content', function() {
+      expect(this.attachElContentSpy).to.not.have.been.called;
     });
   });
 

--- a/spec/javascripts/renderer.spec.js
+++ b/spec/javascripts/renderer.spec.js
@@ -51,7 +51,11 @@ describe('renderer', function() {
   describe('when overriding the `render` method', function() {
     beforeEach(function() {
       this.renderStub = this.sinon.stub(Marionette.Renderer, 'render');
-      this.view = new Marionette.ItemView();
+
+      this.view = new Marionette.ItemView({
+        template: 'foobar'
+      });
+
       this.view.render();
     });
 

--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -41,15 +41,38 @@ Marionette.ItemView = Marionette.View.extend({
 
     this.triggerMethod('before:render', this);
 
-    var data = this.serializeData();
-    data = this.mixinTemplateHelpers(data);
-
-    var template = this.getTemplate();
-    var html = Marionette.Renderer.render(template, data, this);
-    this.attachElContent(html);
+    this._renderTemplate();
     this.bindUIElements();
 
     this.triggerMethod('render', this);
+
+    return this;
+  },
+
+  // Internal method to render the template with the serialized data
+  // and template helpers via the `Marionette.Renderer` object.
+  // Throws an `UndefinedTemplateError` error if the template is
+  // any falsely value but literal `false`.
+  _renderTemplate: function() {
+    var template = this.getTemplate();
+
+    // Allow template-less item views
+    if (template === false) {
+      return;
+    }
+
+    if (!template) {
+      throwError('Cannot render the template since it is null or undefined.',
+        'UndefinedTemplateError');
+    }
+
+    // Add in entity data and template helpers
+    var data = this.serializeData();
+    data = this.mixinTemplateHelpers(data);
+
+    // Render and add to el
+    var html = Marionette.Renderer.render(template, data, this);
+    this.attachElContent(html);
 
     return this;
   },


### PR DESCRIPTION
This is the general idea after reviewing #1042, abstracting template rendering logic to renderTemplate and stopping its execution if the template is false. This may need more tests, but it currently mimics the base rendering spec as well as verifying no error is thrown in render.

One concern is that the error thrown in Renderer when the template is falsely mentions false as an incorrect value. This is not the case for ItemView with this PR, so this will be a misleading error. I've added an error to ItemView#renderTemplate at the moment with an appropriate message and updated specs accordingly.

I had to change one test in the Renderer spec, but I'm not sure if this will be intended behavior when overriding Renderer.render.
