### PR TITLE
Refactor buildRegion to simplify building from different regionConfig types

### DIFF
--- a/spec/javascripts/application.appRegions.spec.js
+++ b/spec/javascripts/application.appRegions.spec.js
@@ -10,6 +10,9 @@ describe('application regions', function() {
       this.app.on('before:add:region', this.beforeAddRegionStub);
       this.app.on('add:region', this.addRegionStub);
 
+      this.fooRegion = new Marionette.Region({ el: '#foo-region' });
+      this.barRegion = new Marionette.Region({ el: '#bar-region' });
+
       this.app.addRegions({
         fooRegion: '#foo-region',
         barRegion: '#bar-region'
@@ -18,8 +21,8 @@ describe('application regions', function() {
     });
 
     it('should initialize the regions', function() {
-      expect(this.app.fooRegion).to.exist;
-      expect(this.app.barRegion).to.exist;
+      expect(this.app.fooRegion).to.deep.equal(this.fooRegion);
+      expect(this.app.barRegion).to.deep.equal(this.barRegion);
     });
 
     it('should trigger a before:add:region event', function() {
@@ -56,6 +59,11 @@ describe('application regions', function() {
       this.app = new Marionette.Application();
       this.FooRegion = Marionette.Region.extend();
 
+      this.fooRegion = new this.FooRegion({
+        el: this.fooSelector,
+        fooOption: this.fooOption
+      });
+
       this.app.addRegions({
         fooRegion: {
           selector: this.fooSelector,
@@ -66,7 +74,7 @@ describe('application regions', function() {
     });
 
     it('should initialize the regions, immediately', function() {
-      expect(this.app.fooRegion).to.exist;
+      expect(this.app.fooRegion).to.deep.equal(this.fooRegion);
     });
 
     it('should create an instance of the specified region class', function() {
@@ -82,16 +90,43 @@ describe('application regions', function() {
     });
   });
 
+  describe('when adding custom region classes to an app', function() {
+    beforeEach(function() {
+      this.fooSelector = '#foo-region';
+      this.app = new Marionette.Application();
+      this.FooRegion = Marionette.Region.extend({ el: this.fooSelector });
+
+      this.fooRegion = new this.FooRegion();
+
+      this.app.addRegions({
+        fooRegion: this.FooRegion
+      });
+    });
+
+    it('should initialize the regions, immediately', function() {
+      expect(this.app.fooRegion).to.deep.equal(this.fooRegion);
+    });
+
+    it('should create an instance of the specified region class', function() {
+      expect(this.app.fooRegion).to.be.instanceof(this.FooRegion);
+    });
+
+    it('should set the specified selector', function() {
+      expect(this.app.fooRegion.$el.selector).to.equal('#foo-region');
+    });
+  });
+
   describe('when an app has a region', function() {
     beforeEach(function() {
       this.app = new Marionette.Application();
+      this.fooRegion = new Marionette.Region({ el: '#foo-region' });
       this.app.addRegions({
         fooRegion: '#foo-region'
       });
     });
 
     it('should make the region available as a named attribute', function() {
-      expect(this.app.fooRegion).to.exist;
+      expect(this.app.fooRegion).to.deep.equal(this.fooRegion);
     });
 
     it('should be able to retrieve the region', function() {

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -45,53 +45,41 @@ _.extend(Marionette.Region, {
   // }
   // ```
   //
-  buildRegion: function(regionConfig, defaultRegionClass) {
-    var regionIsString = _.isString(regionConfig);
-    var regionSelectorIsString = _.isString(regionConfig.selector);
-    var regionClassIsUndefined = _.isUndefined(regionConfig.regionClass);
-    var regionIsClass = _.isFunction(regionConfig);
-
-    if (!regionIsClass && !regionIsString && !regionSelectorIsString) {
-      throwError('Region must be specified as a Region class,' +
-        'a selector string or an object with selector property');
+  buildRegion: function(regionConfig, DefaultRegionClass) {
+    if (_.isString(regionConfig)) {
+      return this._buildRegionFromSelector(regionConfig, DefaultRegionClass);
     }
 
-    var selector, RegionClass;
-
-    // get the selector for the region
-
-    if (regionIsString) {
-      selector = regionConfig;
+    if (regionConfig.selector || regionConfig.regionClass) {
+      return this._buildRegionFromObject(regionConfig, DefaultRegionClass);
     }
+
+    if (_.isFunction(regionConfig)) {
+      return this._buildRegionFromRegionClass(regionConfig);
+    }
+
+    throwError('Region must be specified as a Region class,' +
+      'a selector string, or an object with a selector property');
+  },
+
+  // Build the region from a string selector like '#foo-region'
+  _buildRegionFromSelector: function(selector, DefaultRegionClass) {
+    return new DefaultRegionClass({ el: selector });
+  },
+
+  // Build the region from a configuration object
+  // ```js
+  // { selector: '#foo', regionClass: FooRegion }
+  // ```
+  _buildRegionFromObject: function(regionConfig, DefaultRegionClass) {
+    var RegionClass = regionConfig.regionClass || DefaultRegionClass;
+    var options = _.omit(regionConfig, 'selector', 'regionClass');
 
     if (regionConfig.selector) {
-      selector = regionConfig.selector;
-      delete regionConfig.selector;
+      options.el = regionConfig.selector;
     }
 
-    // get the class for the region
-
-    if (regionIsClass) {
-      RegionClass = regionConfig;
-    }
-
-    if (!regionIsClass && regionClassIsUndefined) {
-      RegionClass = defaultRegionClass;
-    }
-
-    if (regionConfig.regionClass) {
-      RegionClass = regionConfig.regionClass;
-      delete regionConfig.regionClass;
-    }
-
-    if (regionIsString || regionIsClass) {
-      regionConfig = {};
-    }
-
-    regionConfig.el = selector;
-
-    // build the region instance
-    var region = new RegionClass(regionConfig);
+    var region = new RegionClass(options);
 
     // override the `getEl` function if we have a parentEl
     // this must be overridden to ensure the selector is found
@@ -113,6 +101,11 @@ _.extend(Marionette.Region, {
     }
 
     return region;
+  },
+
+  // Build the region directly from a given `RegionClass`
+  _buildRegionFromRegionClass: function(RegionClass) {
+    return new RegionClass();
   }
 
 });


### PR DESCRIPTION
Per my findings in bug #1562, this would be a possible refactored solution to `Region.buildRegion`.  I've changed the specs that use `exist` to `deep.equal` and added a test to show the case that would break under the current implementation of `Region.buildRegion`.  Let me know what you guys think about this solution.  If it's too much, then the simpler proposed solution in #1562 should work fine.  It will just require bumping maxcomplexity by one.
