### PR TITLE
Remove bundled (w/wreqr+babysitter) version from bower.json (fixes #1499)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,9 +2,7 @@
   "name": "backbone.marionette",
   "description": "Make your Backbone.js apps dance with a composite application architecture!",
   "homepage": "http://marionettejs.org",
-  "main": [
-    "./lib/core/backbone.marionette.js"
-  ],
+  "main": "./lib/core/backbone.marionette.js",
   "version": "2.0.1",
   "keywords": [
     "backbone",


### PR DESCRIPTION
Having both files in the main section was causing some build tools to
automatically include both in pages. Since wreqr and babysitter are
listed as dependencies, we'll only specify the core version, since many
build tools will automatically pull in the dependencies.
