### PR TITLE
add hasView property to region

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -12,6 +12,7 @@ Using the `LayoutView` class you can create nested regions.
 * [Initialize A Region With An `el`](#initialize-a-region-with-an-el)
 * [Basic Use](#basic-use)
 * [Showing a view](#showing-a-view)
+* [Checking whether a region is showing a view](#checking-whether-a-region-is-showing-a-view)
 * [`reset` A Region](#reset-a-region)
 * [Set How View's `el` Is Attached](#set-how-views-el-is-attached)
 * [Attach Existing View](#attach-existing-view)
@@ -145,6 +146,12 @@ MyApp.mainRegion.show(myView);
 // the second show call will re-show the view
 MyApp.mainRegion.show(myView, {forceShow: true});
 ```
+
+### Checking whether a region is showing a view
+
+If you wish to check whether a region has a view, you can use the `hasView`
+function. This will return a boolean value depending whether or not the region
+is showing a view.
 
 ### `reset` A Region
 

--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -36,6 +36,11 @@ describe('region', function() {
       expect(this.customRegion.$el[0]).to.equal(this.el);
     });
 
+    it('should not have a view', function() {
+      expect(this.customRegion.hasView()).to.equal(false);
+      expect(this.optionRegion.hasView()).to.equal(false);
+    });
+
     it('should complain if the el passed in as an option is invalid', function() {
       expect(function() {
         Backbone.Marionette.Region({el: $("the-ghost-of-lechuck")[0]});
@@ -70,6 +75,10 @@ describe('region', function() {
         expect(function(){
           this.myRegion.show(new this.MyView());
         }.bind(this)).to.throw('An "el" #not-existed-region must exist in DOM');
+      });
+
+      it('should not have a view', function() {
+        expect(this.myRegion.hasView()).to.equal(false);
       });
     });
   });
@@ -122,6 +131,10 @@ describe('region', function() {
 
     it('should render the view', function() {
       expect(this.view.render).to.have.been.called;
+    });
+
+    it('should have a view', function() {
+      expect(this.myRegion.hasView()).to.equal(true);
     });
 
     it('should set $el and el', function() {
@@ -212,6 +225,10 @@ describe('region', function() {
 
       it('should set "this" to the manager, from the swap event', function() {
         expect(this.swapSpy).to.have.been.calledOn(this.myRegion);
+      });
+
+      it('should stil have a view', function() {
+        expect(this.myRegion.hasView()).to.equal(true);
       });
     });
 
@@ -567,6 +584,10 @@ describe('region', function() {
 
     it('should return the region', function() {
       expect(this.myRegion.empty).to.have.returned(this.myRegion);
+    });
+
+    it('should not have a view', function() {
+      expect(this.myRegion.hasView()).to.equal(false);
     });
   });
 

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -236,6 +236,13 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     return this;
   },
 
+  // Checks whether a view is currently present within
+  // the region. Returns `true` if there is and `false` if
+  // no view is present.
+  hasView: function() {
+    return !!this.currentView;
+  },
+
   // Reset the region by destroying any existing view and
   // clearing out the cached `$el`. The next time a view
   // is shown via this region, the region will re-query the


### PR DESCRIPTION
Fixes #1632

An alternative solution would be to declare `hasView` as a function and return a boolean based on whether `currentView` is set.

thoughts @marionettejs/marionette-core?
