### PR TITLE
Add triggers support to behaviors

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -9,6 +9,7 @@ A `Behavior` is an  isolated set of DOM / user interactions that can be mixed in
 * [Using Behaviors](#using)
 * [API](#api)
   * [Event proxy](#the-event-proxy)
+  * [Triggers](#triggers)
   * [Model Events](#model-events)
   * [Collection Events](#model-events)
   * [Grouped Behaviors](#grouped-behaviors)
@@ -146,7 +147,7 @@ Nested behaviors act as if they were direct behaviors of the parent behavior's v
 
 ## API
 
-### the event proxy
+### The Event Proxy
 Behaviors are powered by an event proxy. What this means is that any events that are triggered by the view's `triggerMethod` function are passed to each Behavior on the view as well.
 
 As a real world example, whenever in your `view` you would have `onShow`, your behavior can also have this `onShow` method defined. The same follows for `modelEvents` and `collectionEvents`. Think of your behavior as a receiver for all of the events on your view instance.
@@ -159,6 +160,18 @@ Marionette.Behavior.extend({
 	onSomeEvent: function(data) {
 		console.log("wow such data", data);
 	}
+});
+```
+
+### Triggers
+Any `triggers` you define on the `Behavior` will be triggered in response to the
+appropriate event on the view.
+
+```js
+Marionette.Behavior.extend({
+  triggers: {
+    'click .label': 'click:label'
+  }
 });
 ```
 

--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -174,6 +174,50 @@ describe('Behaviors', function() {
     });
   });
 
+  describe('behavior triggers', function() {
+    beforeEach(function() {
+      this.onClickFooStub = this.sinon.stub();
+
+      this.behaviors = {
+        foo: Marionette.Behavior.extend({
+          triggers: { 'click': 'click:foo' },
+          onClickFoo: this.onClickFooStub
+        })
+      };
+
+      this.model      = new Backbone.Model();
+      this.collection = new Backbone.Collection();
+
+      this.View = Marionette.ItemView.extend({
+        behaviors: { foo: {} }
+      });
+
+      Marionette.Behaviors.behaviorsLookup = this.behaviors;
+
+      this.view = new this.View({
+        model: this.model,
+        collection: this.collection
+      });
+
+      this.triggerMethodSpy = this.sinon.spy(this.view, 'triggerMethod');
+
+      this.view.$el.click();
+    });
+
+    it('calls `triggerMethod` with the triggered event', function() {
+      expect(this.triggerMethodSpy)
+        .to.have.been.calledOnce
+        .and.calledOn(this.view)
+        .and.calledWith('click:foo');
+    });
+
+    it('calls the triggered method', function() {
+      expect(this.onClickFooStub)
+        .to.have.been.calledOnce
+        .and.have.been.calledOn(sinon.match.instanceOf(this.behaviors.foo));
+    });
+  });
+
   describe('behavior $el', function() {
     beforeEach(function() {
       var suite = this;

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -97,6 +97,11 @@ Marionette.Behaviors = (function(Marionette, _) {
       return this;
     },
 
+    behaviorTriggers: function(behaviorTriggers, behaviors) {
+      var triggerBuilder = new BehaviorTriggersBuilder(this, behaviors);
+      return triggerBuilder.buildBehaviorTriggers();
+    },
+
     behaviorEvents: function(behaviorEvents, behaviors) {
       var _behaviorsEvents = {};
       var viewUI = _.result(this, 'ui');
@@ -190,6 +195,44 @@ Marionette.Behaviors = (function(Marionette, _) {
       _.each(methodNames, function(methodName) {
         view[methodName] = _.partial(methods[methodName], view[methodName], behaviors);
       });
+    }
+  });
+
+  // Class to build handlers for `triggers` on behaviors
+  // for views
+  function BehaviorTriggersBuilder(view, behaviors) {
+    this._view      = view;
+    this._viewUI    = _.result(view, 'ui');
+    this._behaviors = behaviors;
+    this._triggers  = {};
+  }
+
+  _.extend(BehaviorTriggersBuilder.prototype, {
+    // Main method to build the triggers hash with event keys and handlers
+    buildBehaviorTriggers: function() {
+      _.each(this._behaviors, this._buildTriggerHandlersForBehavior, this);
+      return this._triggers;
+    },
+
+    // Internal method to build all trigger handlers for a given behavior
+    _buildTriggerHandlersForBehavior: function(behavior, i) {
+      var ui = _.extend({}, this._viewUI, _.result(behavior, 'ui'));
+      var triggersHash = _.clone(_.result(behavior, 'triggers')) || {};
+
+      triggersHash = Marionette.normalizeUIKeys(triggersHash, ui);
+
+      _.each(triggersHash, _.partial(this._setHandlerForBehavior, behavior, i), this);
+    },
+
+    // Internal method to create and assign the trigger handler for a given
+    // behavior
+    _setHandlerForBehavior: function(behavior, i, eventName, trigger) {
+      // Unique identifier for the `this._triggers` hash
+      var triggerKey = trigger.replace(/^\S+/, function(triggerName) {
+        return triggerName + '.' + 'behaviortriggers' + i;
+      });
+
+      this._triggers[triggerKey] = this._view._buildViewTrigger(eventName);
     }
   });
 

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -81,36 +81,7 @@ Marionette.View = Backbone.View.extend({
     // Configure the triggers, prevent default
     // action and stop propagation of DOM events
     _.each(triggers, function(value, key) {
-
-      var hasOptions = _.isObject(value);
-      var eventName = hasOptions ? value.event : value;
-
-      // build the event handler function for the DOM event
-      triggerEvents[key] = function(e) {
-
-        // stop the event in its tracks
-        if (e) {
-          var prevent = e.preventDefault;
-          var stop = e.stopPropagation;
-
-          var shouldPrevent = hasOptions ? value.preventDefault : prevent;
-          var shouldStop = hasOptions ? value.stopPropagation : stop;
-
-          if (shouldPrevent && prevent) { prevent.apply(e); }
-          if (shouldStop && stop) { stop.apply(e); }
-        }
-
-        // build the args for the event
-        var args = {
-          view: this,
-          model: this.model,
-          collection: this.collection
-        };
-
-        // trigger the event
-        this.triggerMethod(eventName, args);
-      };
-
+      triggerEvents[key] = this._buildViewTrigger(value);
     }, this);
 
     return triggerEvents;
@@ -138,9 +109,10 @@ Marionette.View = Backbone.View.extend({
     // look up if this view has behavior events
     var behaviorEvents = _.result(this, 'behaviorEvents') || {};
     var triggers = this.configureTriggers();
+    var behaviorTriggers = _.result(this, 'behaviorTriggers') || {};
 
     // behavior events will be overriden by view events and or triggers
-    _.extend(combinedEvents, behaviorEvents, events, triggers);
+    _.extend(combinedEvents, behaviorEvents, events, triggers, behaviorTriggers);
 
     Backbone.View.prototype.delegateEvents.call(this, combinedEvents);
   },
@@ -228,6 +200,39 @@ Marionette.View = Backbone.View.extend({
     // reset the ui element to the original bindings configuration
     this.ui = this._uiBindings;
     delete this._uiBindings;
+  },
+
+  // Internal method to create an event handler for a given `triggerDef` like
+  // 'click:foo'
+  _buildViewTrigger: function(triggerDef) {
+    var hasOptions = _.isObject(triggerDef);
+
+    var options = _.defaults({}, (hasOptions ? triggerDef : {}), {
+      preventDefault: true,
+      stopPropagation: true
+    });
+
+    var eventName = hasOptions ? options.event : triggerDef;
+
+    return function(e) {
+      if (e) {
+        if (e.preventDefault && options.preventDefault) {
+          e.preventDefault();
+        }
+
+        if (e.stopPropagation && options.stopPropagation) {
+          e.stopPropagation();
+        }
+      }
+
+      var args = {
+        view: this,
+        model: this.model,
+        collection: this.collection
+      };
+
+      this.triggerMethod(eventName, args);
+    };
   },
 
   // import the `triggerMethod` to trigger events with corresponding


### PR DESCRIPTION
I started looking into #1642 because I recently needed the functionality.  This was my initial attempt to implement triggers for behaviors without duplicating too much code.  At first glance, this should be BC.  It still needs more specs and the first `calledWith` needs fixed.  I still need to match the expected `args` parameter, but I'm getting max call size.

Need lots of eyes and feedback on this one because behaviors are still relatively new to me too.  It's semi-modeled after the implementation for `behaviorEvents`.

Note this is also introduces `Marionette.buildViewTrigger` and `Marionette.proxyBuildViewTrigger` to avoid code duplication from `View#configureTriggers`, so I'm not sure how we feel about that.
