### PR TITLE
Enforce `@ui.stuff` ui key syntax.

### DIFF
--- a/spec/javascripts/view.uiBindings.spec.js
+++ b/spec/javascripts/view.uiBindings.spec.js
@@ -96,7 +96,10 @@ describe('view ui elements', function() {
   describe("when calling delegateEvents", function () {
     beforeEach(function () {
       this.uiHash = {'foo': '#foo'};
-      this.eventsHash = {'click @ui.foo': 'bar'};
+      this.eventsHash = {
+        'click @ui.foo': 'bar',
+        'mouseout @ui#foo': 'baz'
+      };
 
       this.View = Marionette.ItemView.extend({
         ui     : this.uiHash,
@@ -110,8 +113,11 @@ describe('view ui elements', function() {
       this.view.delegateEvents();
     });
 
-    it("the events should be re-normalised", function() {
-      expect(this.view.events).to.deep.equal({'click #foo': 'bar'});
+    it("the events should be re-normalised valid ui references", function() {
+      expect(this.view.events).to.deep.equal({
+        'click #foo': 'bar',
+        'mouseout @ui#foo': 'baz'
+      });
     });
   });
 });

--- a/src/marionette.helpers.js
+++ b/src/marionette.helpers.js
@@ -71,7 +71,7 @@ Marionette.normalizeUIKeys = function(hash, ui) {
   }
 
   _.each(_.keys(hash), function(v) {
-    var pattern = /@ui.[a-zA-Z_$0-9]*/g;
+    var pattern = /@ui\.[a-zA-Z_$0-9]*/g;
     if (v.match(pattern)) {
       hash[v.replace(pattern, function(r) {
         return ui[r.slice(4)];


### PR DESCRIPTION
Previously, any character was allowed instead of the '.'

Opening against 2.1 since it seems like a bugfix.
