### PR TITLE
Improve semver ranges in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "underscore": "1.4.4 - 1.6.0",
     "backbone.babysitter": "^0.1.0",
     "backbone.wreqr": "^1.0.0",
-    "jquery": "1.8.0 - 2.1.0"
+    "jquery": "^1.8.0 || ^2.0.0"
   },
   "devDependencies": {
     "sinonjs": "1.7.3",


### PR DESCRIPTION
Some of the previous ranges didn't really make sense and seemed unintentionally restrictive. (e.g. Allowing jQuery 2.1.0 but no other 2.1.x releases.)

If there was a method behind the previous ranges, feel free to disregard. :)

<!---
@huboard:{"order":1524.0,"milestone_order":1671,"custom_state":""}
-->
