### PR TITLE
Use jQuery.contains to check if view.el is in DOM

### DIFF
--- a/src/marionette.domRefresh.js
+++ b/src/marionette.domRefresh.js
@@ -29,7 +29,7 @@ Marionette.MonitorDOMRefresh = (function(documentElement) {
   }
 
   function isInDOM(view) {
-    return documentElement.contains(view.el);
+    return Backbone.$.contains(documentElement, view.el);
   }
 
   // Export public API


### PR DESCRIPTION
Instead of [Node.contains](https://developer.mozilla.org/en-US/docs/Web/API/Node.contains). In particular, fixes compatibility with Firefox < 9.
