### PR TITLE
Allow use of `el` in RegionManager.addRegion definition.

### DIFF
--- a/spec/javascripts/regionManager.spec.js
+++ b/spec/javascripts/regionManager.spec.js
@@ -35,7 +35,7 @@ describe('regionManager', function() {
       });
     });
 
-    describe('with a name and el', function() {
+    describe('and with a name and el', function() {
       beforeEach(function() {
         this.buildSpy = sinon.spy(Marionette.Region, 'buildRegion');
         this.$el = $('<div>');
@@ -120,6 +120,22 @@ describe('regionManager', function() {
         expect(this.region.$el.parent()[0]).to.equal(this.context[0]);
       });
     });
+
+    describe('and with an improper object literal', function() {
+      beforeEach(function() {
+        var regionManager = new Marionette.RegionManager();
+        this.addRegion = function () {
+          regionManager.addRegion('foo', {});
+        };
+      });
+
+      it('throws an error', function() {
+        expect(this.addRegion).
+          to.throw('Improper region configuration type. Please refer ' +
+            'to http://marionettejs.com/docs/marionette.region.html#region-configuration-types');
+      });
+    });
+
   });
 
   describe('.addRegions', function() {

--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -42,15 +42,9 @@ Marionette.RegionManager = (function(Marionette) {
     addRegion: function(name, definition) {
       var region;
 
-      var isObject = _.isObject(definition);
-      var isString = _.isString(definition);
-      var isRegion = definition instanceof Marionette.Region;
-
-      if (isRegion) {
+      if (definition instanceof Marionette.Region) {
         region = definition;
-      } else if (isString || (isObject && (!!definition.selector || !!definition.el))) {
-        region = Marionette.Region.buildRegion(definition, Marionette.Region);
-      } else if (_.isFunction(definition)) {
+      } else {
         region = Marionette.Region.buildRegion(definition, Marionette.Region);
       }
 


### PR DESCRIPTION
From the [Docs](http://marionettejs.com/docs/marionette.region.html):

> Finally, you can define regions with an object literal. Object literal definitions normally expect a selector or el property. The selector property is a selector string, and the el property can be a selector string, a jQuery object, or an HTML node.

RegionManager does not currently support region definitions that use `el`. As LayoutView uses RegionManager behind the scenes, it also will not be able to use `el` when defining region definitions.
