### PR TITLE
Convert raw collection array into Collections

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -1086,4 +1086,22 @@ describe('collection view', function() {
       expect(this.childView.$el).to.contain.$text('bar');
     });
   });
+
+  describe('when passing a raw array into a collectionView', function() {
+    beforeEach(function() {
+      this.CollectionView = Marionette.CollectionView.extend({
+        childView: this.ChildView
+      });
+
+      this.Collection = [{},{},{}];
+
+      this.collectionView = new this.CollectionView({
+        collection: this.Collection
+      });
+    });
+
+    it('should coerce the array into a generic Backbone Collection', function() {
+      expect(this.collectionView.collection).to.be.instanceof(Backbone.Collection);
+    });
+  });
 });

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -17,6 +17,11 @@ Marionette.CollectionView = Marionette.View.extend({
   // This will fallback onto appending childView's to the end.
   constructor: function(options){
     var initOptions = options || {};
+
+    if (_.isArray(initOptions.collection)) {
+      initOptions.collection = new Backbone.Collection(initOptions.collection);
+    }
+
     this.sort = _.isUndefined(initOptions.sort) ? true : initOptions.sort;
 
     this._initChildViewStorage();


### PR DESCRIPTION
The default error that happens here is super strange and scary to new people.

My rational is that if someone is passing in a raw array under the collection key we can assume they want a collection. Thus why not take care of this work for them.

This will help to clean up many peoples code and remove an unneeded ivar when you just need a "dumb" collection.

:tada: 

thanks for the idea @jenius
