### PR TITLE
Add View _behaviors reference to the associated behaviors

### DIFF
--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -121,6 +121,10 @@ describe('Behaviors', function() {
     it('should call initialize when a behavior is created', function() {
       expect(this.initializeStub).to.have.been.calledOnce.and.calledWith(this.behaviorOptions, this.view);
     });
+
+    it('should set _behaviors', function() {
+      expect(this.view._behaviors.length).to.be.equal(1);
+    });
   });
 
   describe('behavior events', function() {
@@ -588,6 +592,10 @@ describe('Behaviors', function() {
 
     it('should call initialize on grouped behaviors', function() {
       expect(this.initializeStub).to.have.been.calledOnce;
+    });
+
+    it('should set _behaviors', function() {
+      expect(this.view._behaviors.length).to.be.equal(2);
     });
 
     it('should call onRender on grouped behaviors', function() {

--- a/spec/javascripts/view.spec.js
+++ b/spec/javascripts/view.spec.js
@@ -20,6 +20,10 @@ describe('base view', function() {
     it('should call initialize', function() {
       expect(this.initializeStub).to.have.been.calledOnce;
     });
+
+    it('should set _behaviors', function() {
+      expect(this.view._behaviors).to.be.eql({});
+    });
   });
 
   describe('when using listenTo for the "destroy" event on itself, and destroying the view', function() {
@@ -113,7 +117,7 @@ describe('base view', function() {
       this.onBeforeDestroyStub = this.sinon.stub().returns(false);
       this.view.onBeforeDestroy = this.onBeforeDestroyStub;
       this.sinon.spy(this.view, 'destroy');
-      
+
       this.view.destroy(this.argumentOne, this.argumentTwo);
     });
 

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -11,6 +11,11 @@
 Marionette.Behaviors = (function(Marionette, _) {
 
   function Behaviors(view, behaviors) {
+
+    if (!_.isObject(view.behaviors)) {
+      return {};
+    }
+
     // Behaviors defined on a view can be a flat object literal
     // or it can be a function that returns an object.
     behaviors = Behaviors.parseBehaviors(view, behaviors || _.result(view, 'behaviors'));
@@ -19,6 +24,7 @@ Marionette.Behaviors = (function(Marionette, _) {
     // calling the methods first on each behavior
     // and then eventually calling the method on the view.
     Behaviors.wrap(view, behaviors, _.keys(methods));
+    return behaviors;
   }
 
   var methods = {

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -16,9 +16,7 @@ Marionette.View = Backbone.View.extend({
     // parses out the @ui DSL for events
     this.events = this.normalizeUIKeys(_.result(this, 'events'));
 
-    if (_.isObject(this.behaviors)) {
-      new Marionette.Behaviors(this);
-    }
+    this._behaviors = new Marionette.Behaviors(this);
 
     Backbone.View.apply(this, arguments);
 


### PR DESCRIPTION
Views should have a private reference to their associated behaviors. We initially avoided keeping this reference because accessing it in production code is an anti-pattern, but there are a couple reasons why we should have it.
1. internal properties like _events, _ui are super common. 
2. clean up our `behaviors` wrapping logic which we do in Behaviors now, but could do in view methods
3. debugging 
4. testing
5. dev tools 
