### PR TITLE
Alter Marionette.normalizeUIKeys to return a new/non-mutated hash

### DIFF
--- a/spec/javascripts/helpers.spec.js
+++ b/spec/javascripts/helpers.spec.js
@@ -1,0 +1,35 @@
+describe("helpers", function () {
+  'use strict';
+
+  var _sut = Marionette;
+
+  describe("when calling normalizeUIKeys", function () {
+    it("given that the ui hash argument is a function, a parsed events hash should be returned", function () {
+      var uiHash = function () {return {anyUiElement: ".any-ui-element"};};
+      var eventsHash = {"focus @ui.anyUiElement": "onAnyUiElementFocus"};
+      var resultEventsHash = _sut.normalizeUIKeys(eventsHash, uiHash);
+      expect(resultEventsHash).to.eql({"focus .any-ui-element": "onAnyUiElementFocus"});
+    });
+
+    it("given that the events hash argument is a function, a parsed events hash should be returned", function () {
+      var uiHash = {anyUiElement: ".any-ui-element"};
+      var eventsHash = function () {return {"focus @ui.anyUiElement": "onAnyUiElementFocus"};};
+      var resultEventsHash = _sut.normalizeUIKeys(eventsHash, uiHash);
+      expect(resultEventsHash).to.eql({"focus .any-ui-element": "onAnyUiElementFocus"});
+    });
+
+    it("given that the events hash argument contains '@ui.', a parsed events hash should be returned", function () {
+      var uiHash = {anyUiElement: ".any-ui-element"};
+      var eventsHash = {"focus @ui.anyUiElement": "onAnyUiElementFocus"};
+      var resultEventsHash = _sut.normalizeUIKeys(eventsHash, uiHash);
+      expect(resultEventsHash).to.eql({"focus .any-ui-element": "onAnyUiElementFocus"});
+    });
+
+    it("a new parsed events hash, not a mutated one, should be returned", function () {
+      var uiHash = {anyUiElement: ".any-ui-element"};
+      var eventsHash = {"focus @ui.anyUiElement": "onAnyUiElementFocus"};
+      var resultEventsHash = _sut.normalizeUIKeys(eventsHash, uiHash);
+      expect(resultEventsHash).not.to.equal(eventsHash);
+    });
+  });
+});

--- a/src/marionette.helpers.js
+++ b/src/marionette.helpers.js
@@ -63,12 +63,22 @@ Marionette.normalizeMethods = function(hash) {
 
 // allows for the use of the @ui. syntax within
 // a given key for triggers and events
-// swaps the @ui with the associated selector
+// swaps the @ui with the associated selector.
+// Returns a new, non-mutated, parsed events hash.
 Marionette.normalizeUIKeys = function(hash, ui) {
   if (typeof(hash) === 'undefined') {
     return;
   }
 
+  if (_.isFunction(hash)) {
+    hash = hash.call(this);
+  }
+
+  if (_.isFunction(ui)) {
+    ui = ui.call(this);
+  }
+
+  hash = _.clone(hash);
   _.each(_.keys(hash), function(v) {
     var pattern = /@ui\.[a-zA-Z_$0-9]*/g;
     if (v.match(pattern)) {

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -120,11 +120,13 @@ Marionette.View = Backbone.View.extend({
 
   // internal method to delegate DOM events and triggers
   _delegateDOMEvents: function(events) {
-    events = events || this.events;
-    if (_.isFunction(events)) { events = events.call(this); }
-
-    // normalize ui keys
-    events = this.normalizeUIKeys(events);
+    if (events) {
+      events = this.normalizeUIKeys(events);
+    }
+    else {
+      this.events = this.normalizeUIKeys(this.events);
+      events = this.events;
+    }
 
     var combinedEvents = {};
 


### PR DESCRIPTION
Instead of mutating the original argument hash, create and return a new cloned hash
