### PR TITLE
Add regions jsdoc file

### DIFF
--- a/api/region.jsdoc
+++ b/api/region.jsdoc
@@ -1,0 +1,293 @@
+name: Region
+
+class: Marionette.Region
+
+extends:
+  - Backbone.Events
+  - Backbone.extend
+
+description: |
+  Regions provide consistent methods to manage, show and destroy views in your applications and layouts. 
+  They use a jQuery selector to show your views in the correct place.
+
+examples:
+  -
+    name: Adding a region to your app
+    example: |
+      You can add regions to your applications by calling the `addRegions` method on
+      your application instance. This method expects a single hash parameter, with
+      named regions and either jQuery selectors or `Region` objects. You may
+      call this method as many times as you like, and it will continue adding regions
+      to the app.
+      
+      ```js
+      MyApp.addRegions({
+        mainRegion: "#main-content",
+        navigationRegion: "#navigation"
+      });
+      ```
+     
+      As soon as you call `addRegions`, your regions are available on your
+      app object. In the above, example `MyApp.mainRegion` and `MyApp.navigationRegion`
+      would be available for use immediately.
+      
+      If you specify the same region name twice, the last one in wins.
+      
+  -
+    name: Adding a region to a layout
+    example: |
+      You can add regions to your layouts by setting a regions property on the class. When 
+      the layout is shown, it should show its subviews in its regions.
+      
+      ```js
+      var AppLayoutView = Backbone.Marionette.LayoutView.extend({
+        template: "#layout-view-template",
+        
+        regions: {
+          menu: "#menu",
+          content: "#content"
+        },
+        
+        onShow: function() {
+          this.menu.show(new MenuView());
+          this.content.show(new MainContentView());
+        }
+      });
+      ```
+
+  - 
+    name: Creating a standalone region
+    example: |
+      You can create a standalone region, by simply instantiating a region and providing a
+      way to find an el on the page. 
+      
+      Once a region is instantiated, it can be used to show a view inside it. 
+      
+      ```js
+      var myRegion = new Region({
+        el: '.my-region'
+      });
+      
+      myRegion.show(new Backbone.View());
+      ```
+
+constructor: |
+  The Region constructor function is responsible for setting up the region and its root element.
+  
+  There are four ways to specify an `el` when instantiating a region
+  1. as a selector as a class property
+  2. as a selector as a constructor option
+  3. as a dom element as a constructor option
+  4. as a jQuery element as a constructor option
+  
+  #### 1. `el` as a class property
+  
+  ```js
+  var SomeRegion = Backbone.Marionette.Region.extend({
+    el: "#some-div",
+  });
+  
+  MyApp.someRegion = new SomeRegion();
+  MyApp.someRegion.show(someView);
+  ```
+  
+  #### 2. `el` as a selector:
+  
+  ```js
+  var mgr = new Backbone.Marionette.Region({
+    el: "#someElement"
+  });
+  ```
+  
+  #### `el` as raw DOM node reference:
+  
+  ```js
+  var mgr = new Backbone.Marionette.Region({
+    el: document.querySelector("body")
+  });
+  ```
+  
+  #### `el` as a `jQuery` wrapped DOM node:
+  
+  ```js
+  var mgr = new Backbone.Marionette.Region({
+    el: $("body")
+  });
+
+  @param {Object} options
+
+properties:
+  el: |
+    The `el` property is the root dom element that holds the view's element.
+    
+    Note that a region must have an element to attach itself to when it is instantiated. 
+    If you do not specify a selector when attaching the region instance to your
+    Application or LayoutView, the region must provide an `el` either in its
+    definition or constructor options.
+  
+  $el: |
+    The `$el` property is the jQuery wrapped version of `el`.
+  
+  currentView: |
+    The `currentView` property references the currently shown view. 
+    If `currentView` is `undefined`, the region is empty.
+
+  initialize: |
+    If `initialize` is set in the Region class, it will be called when new regions are instantiated.
+    
+    The `initialize` function is a good place to put custom, post instantiation class logic. 
+    
+    ```js
+    var SomeRegion = Backbone.Marionette.Region.extend({
+      initialize: function() {
+        // do some stuff
+      }
+    });
+    
+    MyApp.someRegion = new SomeRegion();
+    ```
+    
+    @param {Object} options - The constructor's options
+
+functions:
+  buildRegion: |
+    Returns a new Region from the `regionConfig` object. This is used by the RegionManager to
+    create a new Region instance.
+    
+    @api public
+    @static
+    @param {Object} regionConfig
+    @param {Marionette.Region} DefaultRegionClass
+
+  _buildRegionFromSelector: |
+    Build the region from a string selector like '#foo-region'
+    
+    @api private
+    @static  
+    @param {String} selector  
+    @param {Marionette.Region} DefaultRegionClass  
+
+  _buildRegionFromObject: |
+    Build the region from a configuration object
+    ```js
+    { selector: '#foo', regionClass: FooRegion }
+    ```
+    
+    @api private
+    @static
+    @param {Object} regionConfig
+    @param {Marionette.Region} DefaultRegionClass
+
+  _buildRegionFromRegionClass: |
+    Build the region directly from a given `RegionClass`
+    
+    @api private
+    @static
+    @param {Marionette.Region} RegionClass
+
+  show: |
+    Shows `newView` inside the region if `newView` is not already shown within the region. The previous view, if one exists,
+    will be destroyed in this process. The `show` methods fires the show and swap triggerMethods.
+    
+    You can modify the behavior of `show` by passing in an options object.
+    
+    `preventDestroy`
+    Pass this as `true` to prevent the destruction of the old view. This is not recommended, as Views
+    are intended to be throwaway objects in Marionette. You are encouraged to only use this option
+    if the View you are rendering is a render-heavy view, such as a large chart or graphic.
+    
+    ```js
+    // Show the first view.
+    var myView = new MyView();
+    MyApp.mainRegion.show(myView);
+    
+    // Replace the view with another. The `destroy` method is called for you
+    var anotherView = new AnotherView();
+    MyApp.mainRegion.show(anotherView);
+    
+    // Replace the view with another. Prevent `destroy` from being called
+    var anotherView2 = new AnotherView();
+    MyApp.mainRegion.show(anotherView2, { preventDestroy: true });
+    
+    `forceShow`
+    By default passing the same view to `show` will be a noop; your view will not be rendered, and no
+    events will be fired. Pass `true` for this option to cause the entire show process to happen again,
+    including events and the re-rendering of your view.
+    
+    ```js
+    var myView = new MyView();
+    MyApp.mainRegion.show(myView);
+    
+    // the second show call will re-show the view
+    MyApp.mainRegion.show(myView, {forceShow: true});
+    ```
+    
+    @api public
+    @static
+    @param {Marionette.View} view
+    @param {Object} options
+
+  _ensureElement: |
+    Ensure that `this.el` and `this.$el` is set. If 
+    
+    @api private
+
+  getEl: |
+    Returns the jQuery Object of `el`.
+    Do note that it is not recommended that you override this method because it is ignored in certain circumstances.
+    
+    @api private
+    @param {} el
+
+  attachHtml: |
+    This method determines how the view's html is attached to the Region's element. The default
+    method is using append. You can override this if you would like to, for instance, specify that
+    the view's element fade in to view.
+    
+    You can override `attachHtml` for transition effects and more. 
+    This example will cause a view to slide down from the top of the region, instead of just appearing in place.
+    
+    ```js
+    Marionette.Region.prototype.attachHtml = function(view){
+      this.$el.hide();
+      this.$el.html(view.el);
+      this.$el.slideDown("fast");
+    }
+    ```
+    
+    @api private
+    @param {Marionette.View} view
+
+  empty: |
+    Empty calls `destroy` on the `currentView`. This has the consequence of clearing the contents
+    of the Region.
+    
+    @api public
+  
+  _destroyView: |
+    Call 'destroy' or 'remove', depending on which is found on the view (if showing a raw Backbone view or a Marionette View).
+  
+    @api private
+  
+  attachView: |
+    Associate a new view with the region by setting the region's value of `currentView`. This will not call render,
+    show, or fire any events.
+    
+    @api private
+    @param {Marionette.View} view
+  
+  hasView: |
+    Checks whether a view is currently present within the region. 
+    
+    @api public
+
+  reset: |
+    Reset the region by calling `empty`, which destroys its view and clears its content. It then deletes
+    the cached `$el` property. Finally it sets `this.el` to the value of the selector string of the old
+    element.
+    
+    This prepares the Region to be 're-initialized' with a new element based on the old selector
+    string, and is used by the LayoutView when it re-renders itself.
+    
+    @api private
+


### PR DESCRIPTION
This is a standalone PR for the regions jsdoc file. 

The `jsdoc` file follows a format:
- name
- class
- extends
- description
- examples
- constructor
- properties
- functions

And the output looks something like this [gist](https://gist.github.com/jasonLaster/361cd2167b0c38e8e4d5)
