### PR TITLE
For for Behavior [un]bindUIElements()

### DIFF
--- a/src/marionette.behavior.js
+++ b/src/marionette.behavior.js
@@ -30,6 +30,8 @@ Marionette.Behavior = (function(_, Backbone) {
 
   _.extend(Behavior.prototype, Backbone.Events, {
     initialize: function() {},
+    bindUIElements: function() {},
+    unbindUIElements: function() {},
 
     // stopListening to behavior `onListen` events.
     destroy: function() {

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -15,9 +15,9 @@ Marionette.Behaviors = (function(Marionette, _) {
     // or it can be a function that returns an object.
     behaviors = Behaviors.parseBehaviors(view, behaviors || _.result(view, 'behaviors'));
 
-    // Wraps several of the view's methods
-    // calling the methods first on each behavior
-    // and then eventually calling the method on the view.
+    // Wraps several of the view's methods calling the
+    // method first on the view and then calling the method
+    // on each behavior.
     Behaviors.wrap(view, behaviors, _.keys(methods));
   }
 
@@ -50,12 +50,12 @@ Marionette.Behaviors = (function(Marionette, _) {
 
     bindUIElements: function(bindUIElements, behaviors) {
       bindUIElements.apply(this);
-      _.invoke(behaviors, bindUIElements);
+      _.invoke(behaviors, 'bindUIElements');
     },
 
     unbindUIElements: function(unbindUIElements, behaviors) {
       unbindUIElements.apply(this);
-      _.invoke(behaviors, unbindUIElements);
+      _.invoke(behaviors, 'unbindUIElements');
     },
 
     triggerMethod: function(triggerMethod, behaviors) {


### PR DESCRIPTION
I don't believe the implementation was correct if the intent was for the wrapped version of [un]bindUIElements() to eventually call a method of the same name on the Behavior itself.
