### PR TITLE
Removed now-redundant line from view constructor

### DIFF
--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -13,8 +13,6 @@ Marionette.View = Backbone.View.extend({
     // of this.options
     // at some point however this may be removed
     this.options = _.extend({}, _.result(this, 'options'), _.isFunction(options) ? options.call(this) : options);
-    // parses out the @ui DSL for events
-    this.events = this.normalizeUIKeys(_.result(this, 'events'));
 
     if (_.isObject(this.behaviors)) {
       new Marionette.Behaviors(this);


### PR DESCRIPTION
A recent change added the line 

``` js
    this.events = this.normalizeUIKeys(_.result(this, 'events'));
```

to the `_delegateDOMEvents` method, which is called on every render, so the original line in the constructor was no longer necessary. Removed.
