### PR TITLE
Update jsdoc grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,5 @@
 var path = require('path');
 var unwrap = require('unwrap');
-var dox = require('dox');
-var _ = require('underscore');
-var yaml = require('js-yaml')
 
 module.exports = function(grunt) {
 
@@ -261,6 +258,8 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.loadTasks('tasks');
+
   grunt.registerMultiTask('unwrap', 'Unwrap UMD', function () {
     var done = this.async();
     var timesLeft = 0;
@@ -275,39 +274,6 @@ module.exports = function(grunt) {
           timesLeft--;
           if (timesLeft <= 0) done();
         });
-      });
-    });
-  });
-
-  grunt.registerMultiTask('jsDocFiles', function() {
-    this.files.forEach(function(f) {
-      f.src.filter(function(filepath) {
-        return grunt.file.exists(filepath) && !grunt.file.isDir(filepath);
-      }).map(function(filepath) {
-
-        // read yaml file
-        var file = grunt.file.read(filepath);
-
-        try {
-          var json = yaml.safeLoad(file);
-        } catch (err){ 
-          grunt.fail.fatal(err.name + ":\n"+  err.reason + "\n\n" + err.mark);
-        }
-        
-        // parse jsDoc comment
-        _.each(json.functions, function(docString, name) {
-          var doc = dox.parseComment(docString);
-
-          var tags = doc.tags || [];
-          doc.api = _.findWhere(tags, {type: 'api'});
-          doc.params = _.where(tags, {type: 'param'});
-          
-          json.functions[name] = doc;
-        });
-
-        // write parsed api to file
-        var prettyJSON = JSON.stringify(json, undefined, 2);
-        grunt.file.write(f.dest, prettyJSON);
       });
     });
   });

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,133 @@
+## JS Doc Overview
+
+We on Marionette, believe that documentation is incredibly important. Because of that, we've gone the extra mile to design an api format (jsdoc) that works great for us.
+ 
+### Goals
+1. Documentation should be in its own file
+Good documentation is just as important as good source and tests. 
+
+  Tests takes space to do right and context. 
+Separating the the docs from the source makes it much easier to evaluate the documentation holistically.
+
+2. Documentation should be structured
+
+  There are many different components of documentation that should be structured: function signatures, descriptions, properties, examples.
+Each of these types should be optimized so that it's easy to record the relevant information. 
+
+  Function signatures fit naturally with `@tag` formats, while descriptions and examples fit well as markdown.
+Yaml as overall document format provides the overall structure for the document so that the content is properly organized.
+
+3. Documentation should have great content
+
+  This should go without saying, but too often the documentation fails at being practical.
+
+  The documentation should have complete coverage over all of the ways any class function could be used or property value set.
+
+  The documentation should also have examples for the main use cases and explain the pros and cons of those approaches.
+
+### Structure of the jsdoc document
++ class
++ namespace
++ name
++ examples
++ properties
++ constructor
++ functions
+
+
+### Example Doc
+```yaml
+name: Region
+class: Region
+namespace: Marionette
+description: |
+  # Regions do really cool things
+
+properties:
+  currentView: |
+    current view is important
+
+constructor: |
+  instantiate ya
+  
+functions: 
+  show: 
+    description: |
+      show yea
+      
+      @param woo
+      
+    examples:
+      -
+        name: Showing a simple view
+        example: |
+          markdown example
+
+  empty: |
+    This is just a jsdoc description. 
+    Why, because I'm lazy and don't want to write any examples
+```
+
+### Compile phase
+Jsdoc documents are compiled by running `grunt api`. Under the hood, the docs are compiled with the `jsDocFiles` task.
+
+The `jsdoc` files are compiled via a two-phase process. First, they're parsed through `yaml` to `json`. Then the `jsdoc` sections are parsed with the great `dox` library.
+
+The result is a `json` api document in the `jsdoc` folder. We use the `json` files on the website to present the api, but you can feel free to use it for other purposes as well.
+
+
+### Gotchas
+
+#### jsdoc sections
+It's important to know a little `yaml` and a little `jsdoc` to document a function.
+
+1. all `jsdoc` sections start with a pipe (`|`). This is because when `yaml` sees that it will convert the subsequent content to text.
+2. `jsdoc` always begins with at least one line of description. Multiple line descriptions are cool, but the first line will become a summary.
+3. `jsdoc` loves its tags, you should read all about them, but here are the basics `@param`, `return`, `@api`
+
+```js
+_.extend(Foo.prototype, {
+  foo: function(options) {
+    // does foo
+  }
+})
+```
+```yaml
+functions: 
+  foo: |
+     This is my description
+        
+     @param {Object} options
+     @return this
+     @api private
+``` 
+
+
+#### Whitespace matters
+
+The api is written in `yaml`, so whitespace matters.
+
+  #### > line 18 is bad
+  ![](http://f.cl.ly/items/0O3B0P3G3u1o3i112G16/Image%202014-08-22%20at%209.27.36%20PM.png)
+
+  #### > line 18 is good
+  ![](http://f.cl.ly/items/272h0V442i0c1j1L3V3o/Image%202014-08-22%20at%209.27.42%20PM.png)
+
+#### Lists
+`Yaml`, is a little funny. One of the most common questions is how to list an array of objects.
+This comes up in our `jsdocs` when you're showing a list of examples.
+
+The appropriate way to do that is to separate each item in the list with a dash (`-`)
+
+```yaml
+examples:
+  -
+    name: first example
+    example: |
+       my cool markdown based example
+  -
+    name: second example
+    example: |
+       my cool markdown based example
+```
+

--- a/tasks/jsDocFile.js
+++ b/tasks/jsDocFile.js
@@ -1,0 +1,144 @@
+/*
+ * jsDocFiles is a task for compiling jsdoc api files
+ *
+ */
+
+'use strict';
+
+var dox = require('dox');
+var _ = require('underscore');
+var yaml = require('js-yaml')
+
+
+function JsDocFilesTask(grunt) {
+  this.grunt = grunt;
+};
+
+_.extend(JsDocFilesTask.prototype, {
+  buildFiles: function(files) {
+    files.forEach(function(file) {
+      file.src
+        .filter(function(filepath) {
+          return this.grunt.file.exists(filepath) && !this.grunt.file.isDir(filepath);
+        }.bind(this))
+        .map(function(filepath) {
+          return this.compileJsDoc(file, filepath);
+        }.bind(this));
+    }.bind(this));
+  },
+  
+  compileJsDoc: function(file, filepath) {
+    
+    var doc = this.grunt.file.read(filepath);
+    var json = this.parseYaml(doc);
+
+    json.functions = json.functions || [];
+    json.properties = json.properties || [];
+    json.constructor = json.constructor || "";
+
+    _.each(json.functions, function(value, name) {
+      json.functions[name] = this.parseBody(value, name);
+    }, this);
+
+    _.each(json.properties, function(value, name) {
+      json.properties[name] = this.parseBody(value, name);
+    }, this);
+        
+    json.constructor = this.parseBody(json.constructor, 'constructor');
+
+    this.writeJSON(file, json);
+  },
+  
+  /**
+   * parseBody takes a yaml body, which is either a string or an object. 
+   * if it's just a string, it assumes it's one dox string, if it's an object it
+   * assumes it has a description and examples.
+   *
+   *
+   * e.g 
+   * foo: |
+   *    Foo function is yay
+   *    
+   *     @param wtf
+   *
+   * or...
+   * foo:
+   *   description: |
+   *     Foo function is yay
+   *     
+   *      @param wtf
+   *
+   *   examples:
+   *     -
+   *       name: foo e.g. 1
+   *       example: |
+   *          show the foo in action
+   *          ```js
+   *             foo(1,2,3)
+   *          ```
+   *
+  **/  
+  parseBody: function(value, name) {
+    var result = {};
+    
+    if (_.isEmpty(value)) {
+      return result;
+    }    
+
+    // Function values have both a description and examples
+    // If the function value is a string, only the description was added
+    if (_.isObject(value)) {
+      result = value;
+    } else {
+      result.examples = [];
+      result.description = value;
+    }
+
+    result.description = this.parseDox(result.description, name);
+    return result;
+  },
+  
+  /**
+   * parse the dox comment string.
+   * We also pluck some tags from the tags property to make it easy to access later.
+   * This could probably be moved out into a separate presentation task that www consumes
+   *
+  **/
+  parseDox: function(docString, name) {
+    
+    try {
+      var doc = dox.parseComment(docString);
+    } catch (err) {      
+      this.grunt.fail.fatal('jsDocFile failed to parse dox at ' + name);
+    }
+
+    var tags = doc.tags || [];
+    doc.api = _.findWhere(tags, {type: 'api'});
+    doc.params = _.where(tags, {type: 'param'});
+    
+    return doc;
+  },
+  
+  // write parsed api to file
+  writeJSON: function(file, json) {
+    var prettyJSON = JSON.stringify(json, undefined, 2);
+    this.grunt.file.write(file.dest, prettyJSON);
+  },
+  
+  // read yaml file
+  parseYaml: function(file) {
+    try {
+      return yaml.safeLoad(file);
+    } catch (err){ 
+      this.grunt.fail.fatal(err.name + ":\n"+  err.reason + "\n\n" + err.mark);
+    }
+  }
+  
+});
+
+module.exports = function(grunt) {
+  grunt.registerMultiTask('jsDocFiles', 'Compile jsdoc files to json', function() {
+    var jsDocFiles = new JsDocFilesTask(grunt);
+    jsDocFiles.buildFiles(this.files);
+  });
+}


### PR DESCRIPTION
This update adds three things to the `jsDocFiles` task:
    1. a new task file that's well factored
    2. support for bodies with description and examples (functions, properties, constructor)
    3. body parsing for properties and constructor (it now supports description, or description + examples)

Here's an example from the great `helpers.jsdoc`, where a function has a description and examples.

`````` yaml
  actAsCollection:
    description: |
      Mix in methods from Underscore, for iteration, and other collection related features. Borrowing this code
      from `Backbone.Collection`. See http://backbonejs.org/docs/backbone.html#section-121

      @api public
      @static
      @param {Object} object
      @param {Object} listProperty

    examples:
      -
        name: Object Literal
        example: |
          It works by taking an object and a property field, in this example 'list',
          and appending collection functions to the object so that it can
          delegate collection calls to its list.

          ```js
          var obj = {
            list: [1, 2, 3]
          }

          Marionette.actAsCollection(obj, 'list');

          var double = function(v){ return v*2};
          console.log(obj.map(double)); // [2, 4, 6]
          ```

      -
          name: Function Prototype
          example: |
            ```js
            var Func = function(list) {
              this.list = list;
            };

            Marionette.actAsCollection(Func.prototype, 'list');
            var func = new Func([1,2,3]);

            var double = function(v){ return v*2};
            console.log(func.map(double)); // [2, 4, 6]
            ```
``````
