### PR TITLE
Add application.jsdoc

### DIFF
--- a/api/application.jsdoc
+++ b/api/application.jsdoc
@@ -1,0 +1,353 @@
+name: Appliction
+
+class: Marionette.Application
+
+description: |
+  Applications are the entry point into most Marionette Applications. 
+  For all but the simplest of webapps you'll want to instantiate a new Application to act as the hub for the rest of your code.
+
+  Applications let you accomplish three things. 
+  Firstly, they provide a place to put start up code for your app through its Initializers. 
+  Secondly, they allow you to group your code into logical sections with the Module system. 
+  Lastly, they give you a way to connect Views to the document through its Regions.
+  
+  ```js
+  var MyApp = new Backbone.Marionette.Application();
+  ```
+
+constructor: 
+  description: |
+    Creates a new Application.
+    
+    The constructor function calls initialize if it exists, and sets the properties of the Application. 
+    Note that Applications are unique in that their options are automatically attached to the Application instead of a separate options object. 
+    
+    The `options` parameter can take any key/value pair and set it on the application instance.
+    Two special properties that are used in the application are:
+      + regions - regions are set on the app
+      + channelName - channel name for the app
+      
+    @param {...*} options - Options to be available on the Application instance directly.
+    
+  examples: 
+    -
+      name: Add regions 
+      example: |
+        You can also specify regions per `Application` instance.
+        
+        ```js
+        new Marionette.Application({
+          regions: {
+            fooRegion: '#foo-region'
+          }
+        });
+
+properties:
+  vent: |
+    The eventAggregator from the global Channel to be used for Application-level events.
+    
+    @type {Backbone.Wreqr.EventAggregator}
+    
+  commands: |
+    The commands instance from the global Channel to be used for Application-level commands.
+    
+    @type {Backbone.Wreqr.Commands}
+    
+  reqres: |
+    The RequestResponse instance from the global Channel to be used for Application-level requests.
+    
+    @type {Backbone.Wreqr.RequestResponse}
+    
+  submodules: |
+    The container for the Application's modules. 
+    Modules are stored with their name as the key, and the module itself as the value.
+    
+    @type {Object}
+    
+  regions:
+    description: |
+      Region Options
+      
+    examples: 
+      -
+        name: Add regions as prototype property
+        example: |
+          You can also specify regions as a prototype property.
+          
+          ```js
+          Marionette.Application.extend({
+            regions: {
+              fooRegion: '#foo-region'
+            }
+          });
+          ```
+          
+      -
+        name: Add regions as prototype function 
+        example: |
+          You can also specify regions as a prototype function.
+          
+          The `options` parameter is same as the constructor `options` parameter.
+          
+          ```js
+          Marionette.Application.extend({
+            regions: function(options) {
+              return {
+                fooRegion: '#foo-region'
+              }
+            }
+          });
+          ```
+      
+functions:
+  execute: |
+    A convenience method to access the execute method
+    on the instance of Backbone.Wreqr.Commands attached to
+    every instance of Marionette.Application.
+    
+    This method is alternatively available as app.commands.execute,
+    where app is the instance name of the Application.
+    
+    @param {String} commandName - The command to be executed.
+    @param {...*} args - Additional arguments to pass to the command callback.
+    @api public
+    
+  request: |  
+    A convenience method to access the request method on the instance of 
+    Backbone.Wreqr.RequestResponse attached to every instance of Marionette.Application.
+    
+    This method is alternatively available as app.reqres.request,
+    where app is the instance name of the Application.
+    
+    @param {String} requestName - The name of the request.
+    @param {...*} args - Additional arguments to pass to the response callback.
+    @api public
+    
+  addInitializer: 
+    description: |
+      Adds an initializer that runs once the Application has started,
+      or immediately if the app has already been started.
+    
+      Initializer callbacks will be executed when you start your application,
+      and are bound to the application object as the context for
+      the callback. In other words, `this` is the `MyApp` object inside
+      of the initializer function.
+      
+      The callback `options` argument is passed from the `start` method (see below).
+      
+      Initializer callbacks are guaranteed to run, no matter when you
+      add them to the app object. If you add them before the app is
+      started, they will run when the `start` method is called. If you
+      add them after the app is started, they will run immediately.
+      
+      @api public
+      @param {} initializer
+    
+    examples:
+      -
+        name: Adding initializers
+        example: |
+          Your application needs to do useful things, like displaying content in your
+          regions, starting up your routers, and more. To accomplish these tasks and
+          ensure that your `Application` is fully configured, you can add initializer
+          callbacks to the application.
+          
+          ```js
+          MyApp.addInitializer(function(options){
+            // do useful stuff here
+            var myView = new MyView({
+              model: options.someModel
+            });
+            MyApp.mainRegion.show(myView);
+          });
+          
+          MyApp.addInitializer(function(options){
+            new MyAppRouter();
+            Backbone.history.start();
+          });
+          ```
+        
+  start:
+    description: |
+      Start the Application, triggering the Initializers array of callbacks.
+      
+      @param {...*} options - Options to pass to the `start` triggerMethods and the Initializers functions.
+      @api public
+      
+    examples:
+      -
+        name: Starting an Application
+        example: |
+          Once you have your application configured, you can kick everything off by
+          calling: `MyApp.start(options)`.
+          
+          This function takes a single optional parameter. This parameter will be passed
+          to each of your initializer functions, as well as the initialize events. This
+          allows you to provide extra configuration for various parts of your app throughout the
+          initialization sequence.
+          
+          ```js
+          var options = {
+            something: "some value",
+            another: "#some-selector"
+          };
+          
+          MyApp.start(options);
+          ```
+    
+  addRegions: 
+    description: |
+      You can create Regions through the `addRegions` method by passing in an object
+      literal or a function that returns an object literal.
+      
+      For more information on regions, see [the region documentation](./marionette.region.md) 
+      Also, the API that Applications use to manage regions comes from the RegionManager Class, 
+      which is documented [over here](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.regionmanager.md).
+      
+      @api public
+      @param {Object|Function} regions
+    
+    examples:
+      - 
+        name: jQuery Selector
+        example: |
+          The first is to specify a jQuery selector as the value of the region
+          definition. This will create an instance of a Marionette.Region directly,
+          and assign it to the selector:
+          
+          ```js
+          MyApp.addRegions({
+            someRegion: "#some-div",
+            anotherRegion: "#another-div"
+          });
+          ```
+      - 
+        name: Custom Region Class
+        example: |
+          The second is to specify a custom region class, where the region class has
+          already specified a selector:
+          
+          ```js
+          var MyCustomRegion = Marionette.Region.extend({
+            el: "#foo"
+          });
+          
+          MyApp.addRegions(function() {
+            return {
+              someRegion: MyCustomRegion
+            };
+          });
+          ```
+          
+      - 
+        name: Custom Region Class And Selector
+        example: |
+          The third method is to specify a custom region class, and a jQuery selector
+          for this region instance, using an object literal:
+            
+          ```js
+          var MyCustomRegion = Marionette.Region.extend({});
+          
+          MyApp.addRegions({
+          
+            someRegion: {
+              selector: "#foo",
+              regionClass: MyCustomRegion
+            },
+            
+            anotherRegion: {
+              selector: "#bar",
+              regionClass: MyCustomRegion
+            }
+            
+          });
+          ```
+          
+  emptyRegions: |
+    Empties all of the Application's Regions by destroying the View within each Region.
+  
+    @api public
+    
+  removeRegion: 
+    description: |
+      Removes the specified Region from the Application. 
+      Removing a region will properly empty it before removing it from the application object.
+      
+      @param {String} regionName - The name of the Region to be removed.
+      @api public
+      
+    examples: 
+        -
+          name: Remove a region
+          example: |
+            Regions can also be removed with the `removeRegion` method, passing in
+            the name of the region to remove as a string value:
+            
+            ```js
+            MyApp.removeRegion('someRegion');
+            ```
+      
+  getRegion: 
+    description: |
+      Returns a Region by name.
+      
+      @param {String} regionName - The name of the Region to receive.
+      @api public
+
+    examples: 
+      -
+        name: Get Region By Name
+        example: |
+          A region can be retrieved by name, using the `getRegion` method:
+          
+          ```js
+          var app = new Marionette.Application();
+          app.addRegions({ r1: "#region1" });
+          
+          // r1 === r1Again; true
+          var r1 = app.getRegion("r1");
+          var r1Again = app.r1;
+          ```
+          
+          Accessing a region by named attribute is equivalent to accessing
+          it from the `getRegion` method.
+
+    
+  getRegions: |
+    Returns an array of every Region from the RegionManager
+    
+    @api public
+    
+  module: |
+    Create a module, attached to the application
+    
+    @api public
+    @param {} moduleNames
+    @param {} moduleDefinition
+    
+  getRegionManager: |
+    Returns a new instance of a region manager.
+    
+    Enables easy overriding of the default `RegionManager` for customized region interactions 
+    and business-specific view logic for better control over single regions.
+    
+    @api public
+    
+  _initializeRegions: |
+    Internal method to initialize the regions that have been defined in a
+    `regions` attribute on the application instance
+  
+    @param {} options
+    @api private
+    
+  _initRegionManager: |
+    Instantiates the RegionManager for the Application object, and forwards
+    the events from the RegionManager to the Application itself.
+    
+    @api private
+    
+  _initChannel: |
+    Internal method to setup the Wreqr.radio channel
+    
+    @api private
+    


### PR DESCRIPTION
This is coming from three sources, james' great application docs pr from earlier, the application.md, and application.js (true source of knowledge)

A couple note-worthy things:
1. The new jsdoc has a lot more information about parameters and the extent that they're overloaded. I'm trying to document all the possible params options hashes take. Also, give examples for each permutation
2. The examples are an example for a explaining how things work. A lot of the reason why the markdown docs were a mess was that it was confusing, how thing were related. The examples in the new jsdoc make that much more clear

Updates to jsdoc:
- class properties. This was always going to be a thing, but this is the first time they were really used. properties look like functions in that they can just be a description, or description + examples
- constructor. This was also always in the works, but first time it was used. Like functions and properties it can also be description or description + properties.
