### PR TITLE
Use throwError helper in Marionette.View

### DIFF
--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -161,9 +161,7 @@ Marionette.View = Backbone.View.extend({
   // Internal helper method to verify whether the view hasn't been destroyed
   _ensureViewIsIntact: function() {
     if (this.isDestroyed) {
-      var err = new Error('Cannot use a view thats already been destroyed.');
-      err.name = 'ViewDestroyedError';
-      throw err;
+      throwError('Cannot use a view thats already been destroyed.', 'ViewDestroyedError');
     }
   },
 


### PR DESCRIPTION
Small cleanup in `Marionette.View._ensureViewIsIntact`. Use the `throwError` helper instead of creating the error object directly. Similar to #1748.
