### PR TITLE
Change the Marionette.extend reference to be Backbone.View.extend

### DIFF
--- a/src/marionette.helpers.js
+++ b/src/marionette.helpers.js
@@ -16,7 +16,7 @@ function throwError(message, name) {
 // -----------------
 
 // Borrow the Backbone `extend` method so we can use it as needed
-Marionette.extend = Backbone.Model.extend;
+Marionette.extend = Backbone.View.extend;
 
 // Marionette.getOption
 // --------------------


### PR DESCRIPTION
Since Marionette is essentially a bunch of extensions to Backbone.View, it makes sense that `Marionette.extend` would be a reference to `Backbone.View.extend` (and not `Backbone.Model.extend`).

Note that `Backbone.Model.extend` and `Backbone.View.extend` are simply references to the same internal `extend` helper function in Backbone, so this PR has absolutely no effects. But it looks a bit strange to see `Backbone.Model` in Marionette's codebase. This change brings a little more coherence.
