### PR TITLE
Fix `Functions` example on `Marionette.getOption`

### DIFF
--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -55,7 +55,8 @@ the object's `this.options`, with `this.options` taking precedence.
 var M = Backbone.Model.extend({
   foo: "bar",
 
-  initialize: function(){
+  initialize: function(attributes, options){
+    this.options = options;
     var f = Marionette.getOption(this, "foo");
     console.log(f);
   }


### PR DESCRIPTION
`this.options` is not automatically assigned when initializing a Backbone.Model with options.
