### PR TITLE
Unwrap view triggerMethod

### DIFF
--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -541,6 +541,33 @@ describe('Behaviors', function() {
     });
   });
 
+  describe('behavior triggerMethod calls', function() {
+    beforeEach(function() {
+      this.behaviors = {
+        foo: Marionette.Behavior.extend({
+          onFoo: function() {
+            return "behavior foo";
+          }
+        })
+      };
+      Marionette.Behaviors.behaviorsLookup = this.behaviors;
+
+      this.View = Marionette.View.extend({
+        behaviors: { foo: {} },
+
+        onFoo: function() {
+          return "view foo";
+        }
+      });
+
+      this.view = new this.View();
+    });
+
+    it('onFoo should return "foo"', function() {
+      expect(this.view.triggerMethod('foo')).to.equal('view foo');
+    });
+  });
+
   describe('behavior is evented', function() {
     beforeEach(function() {
       this.listenToStub = this.sinon.stub();

--- a/src/marionette.behaviors.js
+++ b/src/marionette.behaviors.js
@@ -54,15 +54,6 @@ Marionette.Behaviors = (function(Marionette, _) {
       return this;
     },
 
-    triggerMethod: function(triggerMethod, behaviors) {
-      var args = _.tail(arguments, 2);
-      triggerMethod.apply(this, args);
-
-      _.each(behaviors, function(b) {
-        triggerMethod.apply(b, args);
-      });
-    },
-
     delegateEvents: function(delegateEvents, behaviors) {
       var args = _.tail(arguments, 2);
       delegateEvents.apply(this, args);

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -245,7 +245,17 @@ Marionette.View = Backbone.View.extend({
 
   // import the `triggerMethod` to trigger events with corresponding
   // methods if the method exists
-  triggerMethod: Marionette.triggerMethod,
+  triggerMethod: function() {
+    var args = arguments;
+    var triggerMethod = Marionette.triggerMethod;
+
+    var ret = triggerMethod.apply(this, args);
+    _.each(this._behaviors, function(b) {
+      triggerMethod.apply(b, args);
+    });
+
+    return ret;
+  },
 
   // Imports the "normalizeMethods" to transform hashes of
   // events=>function references/names to a hash of events=>function references


### PR DESCRIPTION
This is part two of the unwrap view behavior functionality story.

In this part, we uncover a subtle bug where when a view had behaviors, triggerMethod wasn't returning the view's triggerMethod response. 

Also, it becomes apparent that behaviors' `triggerMethod` doesn't have a return value. Lets talk about it...
