### PR TITLE
Allow use of `el` in RegionManager.addRegion definition.

### DIFF
--- a/spec/javascripts/regionManager.spec.js
+++ b/spec/javascripts/regionManager.spec.js
@@ -35,6 +35,22 @@ describe('regionManager', function() {
       });
     });
 
+    describe('and with a name and el', function() {
+      beforeEach(function() {
+        this.buildSpy = sinon.spy(Marionette.Region, 'buildRegion');
+        this.$el = $('<div>');
+
+        this.regionManager = new Marionette.RegionManager();
+        this.region = this.regionManager.addRegion('foo', {
+          el: this.$el
+        });
+      });
+
+      it('should call Region.buildRegion', function() {
+        expect(this.buildSpy).to.have.been.calledOnce;
+      });
+    });
+
     describe('and a region instance', function() {
       beforeEach(function() {
         this.addHandler = this.sinon.spy();
@@ -104,6 +120,22 @@ describe('regionManager', function() {
         expect(this.region.$el.parent()[0]).to.equal(this.context[0]);
       });
     });
+
+    describe('and with an improper object literal', function() {
+      beforeEach(function() {
+        var regionManager = new Marionette.RegionManager();
+        this.addRegion = function () {
+          regionManager.addRegion('foo', {});
+        };
+      });
+
+      it('throws an error', function() {
+        expect(this.addRegion).
+          to.throw('Improper region configuration type. Please refer ' +
+            'to http://marionettejs.com/docs/marionette.region.html#region-configuration-types');
+      });
+    });
+
   });
 
   describe('.addRegions', function() {

--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -42,16 +42,10 @@ Marionette.RegionManager = (function(Marionette) {
     addRegion: function(name, definition) {
       var region;
 
-      var isObject = _.isObject(definition);
-      var isString = _.isString(definition);
-      var hasSelector = !!definition.selector;
-
-      if (isString || (isObject && hasSelector)) {
-        region = Marionette.Region.buildRegion(definition, Marionette.Region);
-      } else if (_.isFunction(definition)) {
-        region = Marionette.Region.buildRegion(definition, Marionette.Region);
-      } else {
+      if (definition instanceof Marionette.Region) {
         region = definition;
+      } else {
+        region = Marionette.Region.buildRegion(definition, Marionette.Region);
       }
 
       this.triggerMethod('before:add:region', name, region);


### PR DESCRIPTION
RegionManager does not currently support region definitions that use `el`. As LayoutView uses RegionManager behind the scenes, it also will not be able to use `el` when defining region definitions.
