### PR TITLE
Have region throw ViewDestroyError for error handling

### DIFF
--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -113,6 +113,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
   show: function(view, options){
     this._ensureElement();
+    this._ensureViewIsIntact(view);
 
     var showOptions = options || {};
     var isDifferentView = view !== this.currentView;
@@ -167,7 +168,6 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
       this.triggerMethod('show', view);
       Marionette.triggerMethodOn(view, 'show');
 
-      return this;
     }
 
     return this;
@@ -181,6 +181,15 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     if (!this.$el || this.$el.length === 0) {
       throw new Marionette.Error('An "el" ' + this.$el.selector + ' must exist in DOM');
+    }
+  },
+
+  _ensureViewIsIntact: function(view) {
+    if (view.isDestroyed) {
+      throw new Marionette.Error({
+        name: 'ViewDestroyedError',
+        message: 'View (cid: "' + view.cid + '") has already been destroyed and cannot be used.'
+      });
     }
   },
 
@@ -232,6 +241,10 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
       view.destroy();
     } else if (view.remove) {
       view.remove();
+
+      // appending isDestroyed to raw Backbone View allows regions
+      // to throw a ViewDestroyedError for this view
+      view.isDestroyed = true;
     }
   },
 


### PR DESCRIPTION
Having the region check for `view.isDestroyed` does two things:

1: It allows you to handle the error of a `region.show` without the region killing the `currentView` and breaking without recourse.

``` javascript
var foo_view = new FooView();
someRegion.show(foo_view);

var bar_view = new BarView();
someRegion.show(bar_view);

try{
  someRegion.show(foo_view);
} catch(e){
  // Should log ViewDestroyError 
  console.log(e.name);

   // Without destroying bar_view
  console.log('Is Destroyed? ' + !!bar_view.isDestroyed);
}
```

2: Appending `isDestroyed` to a `Backbone.View` on `region.empty` adds the same safety for not re-showing a removed backbone view.

The extra `return this;` was removed to prevent jslint error for too many statements, and seemed unnecessary
