### PR TITLE
Adds helper methods to AppRouter.

### DIFF
--- a/src/marionette.approuter.js
+++ b/src/marionette.approuter.js
@@ -76,5 +76,11 @@ Marionette.AppRouter = Backbone.Router.extend({
   },
 
   // Proxy `getOption` to enable getting options from this or this.options by name.
-  getOption: Marionette.proxyGetOption
+  getOption: Marionette.proxyGetOption,
+
+  triggerMethod: Marionette.triggerMethod,
+
+  bindEntityEvents: Marionette.proxyBindEntityEvents,
+
+  unbindEntityEvents: Marionette.proxyUnbindEntityEvents
 });


### PR DESCRIPTION
Resolves #1835.

You might be thinking: tests? Well, we tend to not test these things, as indicated by [our fairly weak Marionette.Object tests](https://github.com/marionettejs/backbone.marionette/blob/master/spec/javascripts/object.spec.js). If you have suggestions on how to test them just let me know and we can add them. Also go ahead and make an issue about adding those same tests to most other Marionette Classes.

My suggestion for tests, if we wanted to, would just be to do:

``` js
expect(Marionette.Object.prototype.triggerMethod).to.equal(Marionette.triggerMethod);
```
