### PR TITLE
Adds Region events documentation.

### DIFF
--- a/api/region.jsdoc
+++ b/api/region.jsdoc
@@ -290,3 +290,57 @@ functions:
     
     @api private
 
+events:
+  -
+    name: before:show
+
+    description: |
+      Triggered after the view has been rendered, but before it has been placed inside of the Region. At this
+      time the view will still be detached from the `document`.
+
+  -
+    name: show
+
+    description: |
+      Triggered after the view has been both rendered and placed inside of the Region. With the exception
+      of deeply nested view trees, the View will be attached to the `document` at the time of this event.
+
+  -
+    name: before:swapOut
+
+    description: |
+      Triggered before the new view has replaced the old view within the Region. The old view is passed as the
+      first argument.
+
+  -
+    name: swapOut
+
+    description: |
+      Triggered when the new view has replaced the old view within the Region. The old view is passed as the
+      first argument.
+
+  -
+    name: before:swap
+
+    description: |
+      Triggered before the new view has replaced the old view within the Region. The new view is passed as the
+      first argument.
+
+  -
+    name: swapOut
+
+    description: |
+      Triggered when the new view has replaced the old view within the Region. The new view is passed as the
+      first argument.
+
+  -
+    name: before:empty
+
+    description: |
+      Triggered before the Region empties the contents of it element by destroying its current view.
+
+  -
+    name: empty
+
+    description: |
+      Triggered right after Region empties the contents of it element by destroying its current view.


### PR DESCRIPTION
Resolves #1771.

These event docs are not so good right now, but it's the best we can do at the moment, I think.

Presently, we give an example **for every single event**, which is just kind of unnecessary, I think. Rendering a view 6 times and registering a different callback tells the user nothing, other than the fact that, hey, you can register a callback for an event. I think we communicate that same information by simply including the events in this list.

Instead of examples, I think what we need are:
1. A clear, simple way to communicate to people that each of these points describe a _pair_ of things: an event and its callback. Perhaps a little paragraph at the start of each `events` section will effectively accomplish this.
2. The list of arguments that are passed to the callbacks.
3. A concise definition telling people when it is triggered. We can use foresight to add additional information into this description to handle the most-likely use cases. An example of that is how I included whether or not the view is attached to the `document` at the time of the show events.

Extending the API format to support that is beyond the scope of this PR, though, so that shtuff can come later.
