### PR TITLE
Revert "Throw a descriptive error for collectionViews"

### DIFF
--- a/spec/javascripts/collectionView.spec.js
+++ b/spec/javascripts/collectionView.spec.js
@@ -1133,19 +1133,4 @@ describe('collection view', function() {
       expect(this.childView.$el).to.contain.$text('bar');
     });
   });
-
-  describe('Creating an invalid collectionView', function() {
-    beforeEach(function() {
-      this.createCollectionView = function() {
-        Backbone.Marionette.CollectionView({
-          collection: []
-        });
-      };
-    });
-
-    it('should warn you of an invalid collectionView', function() {
-      expect(this.createCollectionView).to.throw('The Collection option passed to this view needs to be an instance of a Backbone.Collection');
-    });
-  });
-
 });

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -1,5 +1,4 @@
 /* jshint maxstatements: 14 */
-/* jshint maxlen: 200 */
 
 // Collection View
 // ---------------
@@ -20,12 +19,7 @@ Marionette.CollectionView = Marionette.View.extend({
     var initOptions = options || {};
     this.sort = _.isUndefined(initOptions.sort) ? true : initOptions.sort;
 
-    if (initOptions.collection && !(initOptions.collection instanceof Backbone.Collection)) {
-      throw new Marionette.Error('The Collection option passed to this view needs to be an instance of a Backbone.Collection');
-    }
-
     this.once('render', this._initialEvents);
-
     this._initChildViewStorage();
 
     Marionette.View.apply(this, arguments);


### PR DESCRIPTION
Resolves #1861 by reverting 1df40a88.

The problem with the commit, I think, is that it isn't actually solving a problem. The original discussion was about the convenience factor of coercing an array passed into a CollectionView into a Collection, and _not_ because there was a problem that people were facing where the resulting error throne wasn't descriptive.

Consequently, to me it looks like we added code that _doesn't help anyone._ These sorts of things are common, I think, where ya just focus so much on something ya feel like you've got to do something, because leaving it be doesn't feel right. In this case, though, I think leaving it be is the best thing for Marionette.

This can also be argued reductio ad absurdum by imagining us throwing 'useful errors' for _every_ option we accept in our constructors. That'd be crazy, right? A combination of the stack trace and documentation are the tools we provide for figuring out the proper form for arguments, and I'm certain that this combination is sufficient for our users.

This could also go as a bug fix, but I opened against minor because we don't have a patch branch at tha moment.
