### PR TITLE
Passes model and index to emptyViewOptions.

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -213,7 +213,7 @@ Marionette.CollectionView = Marionette.View.extend({
                           this.getOption('childViewOptions');
 
     if (_.isFunction(emptyViewOptions)){
-      emptyViewOptions = emptyViewOptions.call(this);
+      emptyViewOptions = emptyViewOptions.call(this, child, -1);
     }
 
     // build the empty view


### PR DESCRIPTION
Resolves #1873.

Still a work in progress. It needs unit tests and a closer look at that -1 index.
