### PR TITLE
Make view members accessible in behavior initialization

### DIFF
--- a/spec/javascripts/behaviors.spec.js
+++ b/spec/javascripts/behaviors.spec.js
@@ -123,6 +123,26 @@ describe('Behaviors', function() {
     });
   });
 
+  describe('behavior initialization order', function() {
+    it('should have access to view.model', function() {
+      var model = new Backbone.Model();
+
+      var behaviorInitialize = function(behaviorOptions, view) {
+        expect(view.model).to.be.equal(model);
+      };
+      
+      Marionette.Behaviors.behaviorsLookup = {
+        foo: Marionette.Behavior.extend({ initialize: behaviorInitialize })
+      };
+
+      var View = Marionette.ItemView.extend({
+        behaviors: { foo: { } }
+      });
+
+      new View({ model: model });
+    });
+  });
+
   describe('behavior events', function() {
     beforeEach(function() {
       this.fooClickStub  = this.sinon.stub();

--- a/src/marionette.view.js
+++ b/src/marionette.view.js
@@ -16,11 +16,11 @@ Marionette.View = Backbone.View.extend({
     // parses out the @ui DSL for events
     this.events = this.normalizeUIKeys(_.result(this, 'events'));
 
+    Backbone.View.apply(this, arguments);
+
     if (_.isObject(this.behaviors)) {
       new Marionette.Behaviors(this);
     }
-
-    Backbone.View.apply(this, arguments);
 
     Marionette.MonitorDOMRefresh(this);
     this.listenTo(this, 'show', this.onShowCalled);


### PR DESCRIPTION
Currently, `Backbone.View`'s constructor is called from `Marionette.View`'s constructor after the behaviors have been initialized. This means that options to the view have not been bound to the view yet (i.e. model, collection) as well as that the view's `initialize` method has not ran yet when the behavior's `initialize` runs.

This PR simply runs `Backbone.View.apply(this, arguments);` before `this._behaviors = Marionette.Behaviors(this);` to fix this.
