### PR TITLE
Helper function that reliably verifies if a given function is a view "class" (or view constructor)

### DIFF
--- a/src/marionette.helpers.js
+++ b/src/marionette.helpers.js
@@ -120,9 +120,9 @@ Marionette.actAsCollection = function(object, listProperty) {
   });
 };
 
-// Verifies if the argument f is a view "class" (or "constructor"). That is,
-// verifies if f is a function that is the return value of calling Backbone.View.extend,
+// Verifies if the argument fn is a view "class" (or "constructor"). That is,
+// verifies if fn is a function which is the return value of calling Backbone.View.extend,
 // Marionette.View.extend, or any other Marionette view class.
-Marionette.isViewClass = function(f){
-  return _.isFunction(f) && f.prototype instanceof Backbone.View ? true : false;
+Marionette.isViewClass = function(fn){
+  return _.isFunction(fn) && fn.prototype instanceof Backbone.View ? true : false;
 };


### PR DESCRIPTION
If we want to proceed with the suggestions given in issue #1846, this helper function is the first step. But I think it is quite useful by itself.

It would allow us to have dynamic view classes (the view class would be obtained at run-time). The first place to use this would be in CollectionView, but I see it being useful in other parts of Marionette. 

Unfortunately I don't have experience with mocha to write a tests. Hope that will change shortly.
