### PR TITLE
Adds onAttach event.

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -113,6 +113,7 @@
     <script src="test/unit/item-view.spec.js"></script>
     <script src="test/unit/layout-view.dynamic-regions.spec.js"></script>
     <script src="test/unit/layout-view.spec.js"></script>
+    <script src="test/unit/on-attach.spec.js"></script>
     <script src="test/unit/mixin-underscore-collection.spec.js"></script>
     <script src="test/unit/module.spec.js"></script>
     <script src="test/unit/module.stop.spec.js"></script>

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -33,6 +33,8 @@ will provide features such as `onShow` callbacks, etc. Please see
 * [Re-Rendering A LayoutView](#re-rendering-a-layoutview)
   * [Avoid Re-Rendering The Entire LayoutView](#avoid-re-rendering-the-entire-layoutview)
 * [Nested LayoutViews And Views](#nested-layoutviews-and-views)
+  * [Efficient Nested View Structures](#efficient-nested-view-structures)
+    * [Use of the `attach` Event](#use-of-the--attach--event)
 * [Destroying A LayoutView](#destroying-a-layoutview)
 * [Custom Region Class](#custom-region-class)
 * [Adding And Removing Regions](#adding-and-removing-regions)
@@ -208,7 +210,7 @@ var layoutView = new Marionette.LayoutView();
 MyApp.getRegion('main').show(layoutView);
 ```
 
-You can nest LayoutViews as deeply as you want. This provides for a well organized,
+You can nest layoutViews as deeply as you want. This provides for a well organized,
 nested view structure.
 
 For example, to nest 3 layouts:
@@ -223,6 +225,38 @@ MyApp.getRegion('main').show(layout1);
 layout1.getRegion('region1').show(layout2);
 layout2.getRegion('region2').show(layout3);
 ```
+
+### Efficient Nested View Structures
+
+The above example works great, but it causes three separate paints: one for each layout that's being
+shown. Marionette provides a simple mechanism to infinitely nest views in a single paint: just render all
+of the children in the `onBeforeShow` callback.
+
+```js
+var ParentLayout = Marionette.LayoutView.extend({
+  onBeforeShow: function() {
+    this.getRegion('header').show(new HeaderView());
+    this.getRegion('footer').show(new FooterView());
+  }
+});
+
+myRegion.show(new ParentLayout());
+```
+
+In this example, the doubly-nested view structure will be rendered in a single paint.
+
+#### Use of the `attach` event
+
+Often times you need to know when your views in the view tree have been attached to the `document`,
+like when using certain jQuery plugins. The `attach` event, and associated `onAttach` callback, are perfect for this
+use case. Start with a Region that's a child of the `document` and show any LayoutView in it: every view in the tree
+(including the parent LayoutView) will have the `attach` event triggered on it when they have been
+attached to the `document`.
+
+Note that inefficient tree rendering will cause the `attach` event to be fired multiple times. This
+situation can occur if you render the children views *after* the parent has been rendered, such as using
+`onShow` to render children. As a rule of thumb, most of the time you'll want to render any nested views in
+the `onBeforeShow` callback.
 
 ## Destroying A LayoutView
 

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -17,6 +17,7 @@ behaviors that are shared across all views.
 * [View onShow](#view-onshow)
 * [View destroy](#view-destroy)
 * [View onBeforeDestroy](#view-onbeforedestroy)
+* [View "attach" / onAttach event](#view-attach--onattach-event)
 * [View "dom:refresh" / onDomRefresh event](#view-domrefresh--ondomrefresh-event)
 * [View.triggers](#viewtriggers)
 * [View.events](#viewevents)
@@ -127,6 +128,23 @@ v.destroy(arg1, arg2);
 When destroying a view, an `onBeforeDestroy` method will be called, if it
 has been provided, just before the view destroys. It will be passed any arguments
 that `destroy` was invoked with.
+
+### View "attach" / onAttach event
+
+Every view in Marionette has a special event called "attach," which is triggered anytime that showing
+the view in a Region causes it to be attached to the `document`. Like other Marionette events, it also
+executes a callback method, `onAttach`, if you've specified one. The `"attach"` event is great for jQuery
+plugins or other logic that must be executed *after* the view is attached to the `document`.
+
+Because the `attach` event is only fired when the view is a child of the `document`, it is a requirement
+that the Region you're showing it in be a child of the `document` at the time that you call `show`.
+
+This event is unique in that it propagates down the view tree. For instance, when a CollectionView's
+`attach` event is fired, all of its children views will have the `attach` event fired as well. In
+addition, deeply nested Layout View structures will all have their `attach` event fired at the proper
+time, too.
+
+For more on efficient, deeply-nested view structures, refer to the LayoutView docs.
 
 ### View "dom:refresh" / onDomRefresh event
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,6 +9,14 @@
 // Borrow the Backbone `extend` method so we can use it as needed
 Marionette.extend = Backbone.Model.extend;
 
+// Marionette.isNodeAttached
+// -------------------------
+
+// Determine if `el` is a child of the document
+Marionette.isNodeAttached = function(el) {
+  return Backbone.$.contains(document.documentElement, el);
+};
+
 // Marionette.getOption
 // --------------------
 

--- a/src/layout-view.js
+++ b/src/layout-view.js
@@ -136,6 +136,24 @@ Marionette.LayoutView = Marionette.ItemView.extend({
     return new Marionette.RegionManager();
   },
 
+  // Returns every nested view within this Layout
+  getNestedViews: function() {
+
+    // Get each view of each region
+    var views = _.pluck(this.regionManager.getRegions(), 'currentView');
+
+    // Ignore empty regions
+    views = _.filter(views, function(view) { return !!view; });
+
+    var nestedViews = [];
+    _.each(views, function(view) {
+      if (!view || !view.getNestedViews) { return; }
+      nestedViews = nestedViews.concat(view.getNestedViews());
+    });
+    views = views.concat(nestedViews);
+    return views;
+  },
+
   // Internal method to initialize the region manager
   // and all regions in it
   _initRegionManager: function() {

--- a/src/region.js
+++ b/src/region.js
@@ -1,4 +1,4 @@
-/* jshint maxcomplexity: 10, maxstatements: 29, maxlen: 120 */
+/* jshint maxcomplexity: 10, maxstatements: 32, maxlen: 120 */
 
 // Region
 // ------
@@ -182,6 +182,10 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
       this.attachHtml(view);
       this.currentView = view;
+
+      if (view.triggerAttach) {
+        view.triggerAttach();
+      }
 
       if (isChangingView) {
         this.triggerMethod('swap', view);

--- a/src/view.js
+++ b/src/view.js
@@ -276,6 +276,17 @@ Marionette.View = Backbone.View.extend({
     return ret;
   },
 
+  // Inform every nested view that it has been attached
+  triggerAttach: function() {
+    if (!Marionette.isNodeAttached(this.el)) { return; }
+    this.triggerMethod('attach');
+    if (!this.getNestedViews && !this.children) { return; }
+    var childrenViews = this.getNestedViews ? this.getNestedViews() : this.children._views;
+    _.each(childrenViews, function(childView) {
+      Marionette.triggerMethodOn(childView, 'attach');
+    });
+  },
+
   // import the `triggerMethod` to trigger events with corresponding
   // methods if the method exists
   triggerMethod: function() {

--- a/test/unit/on-attach.spec.js
+++ b/test/unit/on-attach.spec.js
@@ -1,0 +1,554 @@
+describe('onAttach', function() {
+  'use strict';
+
+  beforeEach(function() {
+
+    // A Region to show our LayoutView within
+    this.setFixtures('<div id="region"></div>');
+    this.el = $('#region')[0];
+    this.region = new (Backbone.Marionette.Region.extend({
+      el: this.el
+    }))();
+
+    // A view we can use as nested child views
+    this.BasicView = Marionette.ItemView.extend({
+      template: false,
+      onAttach: function() {}
+    });
+  });
+
+  describe('When calling triggerAttach', function() {
+    describe('and the el of the view is a child of the document', function() {
+      beforeEach(function() {
+        this.setFixtures('<div class="view"></div>');
+
+        this.MyView = Marionette.ItemView.extend({
+          el: '.view'
+        });
+
+        this.myView = new this.MyView();
+        this.sinon.stub(this.myView, 'triggerMethod');
+        this.myView.triggerAttach();
+      });
+
+      it('should triggerMethod the attach event', function() {
+        expect(this.myView.triggerMethod)
+          .to.have.been.calledOnce
+          .and.calledWithExactly('attach');
+      });
+    });
+
+    describe('and the el of the view is not a child of the document', function() {
+      beforeEach(function() {
+        this.myView = new Marionette.ItemView();
+        this.sinon.stub(this.myView, 'triggerMethod');
+        this.myView.triggerAttach();
+      });
+
+      it('should not triggerMethod the attach event', function() {
+        expect(this.myView.triggerMethod).to.not.have.beenCalled;
+      });
+    });
+  });
+
+  describe('When calling triggerAttach and the view is a collectionView with children', function() {
+    beforeEach(function() {
+      this.setFixtures('<div class="view"></div>');
+
+      this.collection = new Backbone.Collection([{},{}]);
+
+      this.MyView = Marionette.CollectionView.extend({
+        el: '.view',
+        childView: this.BasicView
+      });
+
+      this.myView = new this.MyView({
+        collection: this.collection
+      });
+
+      this.myView.render();
+
+      _.each(this.myView.children._views, function(view) {
+        this.sinon.stub(view, 'triggerMethod');
+      }, this);
+
+      this.myView.triggerAttach();
+    });
+
+    it('should triggerMethod the attach event on each child', function() {
+      _.each(this.myView.children._views, function(view) {
+        expect(view.triggerMethod)
+          .to.have.been.calledOnce
+          .and.calledWithExactly('attach');
+      }, this);
+    });
+  });
+
+  describe('when the parent view is initially detached', function() {
+    beforeEach(function() {
+      
+      // A LayoutView class that we can use for all of our tests
+      this.LayoutView = Backbone.Marionette.LayoutView.extend({
+        template: _.template('<main></main><footer></footer>'),
+        regions: {
+          main: 'main',
+          footer: 'footer'
+        },
+        onAttach: function() {}
+      });
+    });
+
+    describe('When showing a View in a Region', function() {
+      beforeEach(function() {
+        this.MyView = Marionette.ItemView.extend({
+          template: _.template(''),
+          onAttach: this.sinon.stub()
+        });
+
+        this.myView = new this.MyView();
+        this.region.show(this.myView);
+      });
+
+      it('should trigger onAttach on the View a single time', function() {
+        expect(this.myView.onAttach).to.have.been.calledOnce;
+      });
+    });
+
+    describe('When showing a LayoutView with a single level of nested views that are attached within onBeforeShow', function() {
+      beforeEach(function() {
+        this.mainView = new this.BasicView();
+        this.footerView = new this.BasicView();
+
+        this.sinon.spy(this.mainView, 'onAttach');
+        this.sinon.spy(this.footerView, 'onAttach');
+
+        var suite = this;
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onBeforeShow: function() {
+            this.getRegion('main').show(suite.mainView);
+            this.getRegion('footer').show(suite.footerView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the LayoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView a single time', function() {
+        expect(this.mainView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the footerView a single time', function() {
+        expect(this.footerView.onAttach).to.have.been.calledOnce;
+      });
+    });
+
+    describe('When showing a LayoutView with two levels of nested views; with onBeforeShow for the first and second level', function() {
+      beforeEach(function() {
+        var suite = this;
+        this.headerView = new this.BasicView();
+        this.sinon.spy(this.headerView, 'onAttach');
+
+        this.MainView = this.LayoutView.extend({
+          template: _.template('<header></header>'),
+          regions: {
+            header: 'header'
+          },
+          onBeforeShow: function() {
+            this.getRegion('header').show(suite.headerView);
+          }
+        });
+        this.mainView = new this.MainView();
+        this.sinon.spy(this.mainView, 'onAttach');
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onBeforeShow: function() {
+            this.getRegion('main').show(suite.mainView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the LayoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView a single time', function() {
+        expect(this.mainView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the headerView a single time', function() {
+        expect(this.headerView.onAttach).to.have.been.calledOnce;
+      });
+    });
+
+    describe('When showing a LayoutView with two levels of nested views; onBeforeShow for the first level, then onShow for the second', function() {
+      beforeEach(function() {
+        var suite = this;
+        this.headerView = new this.BasicView();
+        this.sinon.spy(this.headerView, 'onAttach');
+
+        this.MainView = Marionette.LayoutView.extend({
+          template: _.template('<header></header>'),
+          onAttach: this.sinon.stub(),
+          regions: {
+            header: 'header'
+          },
+          onShow: function() {
+            this.getRegion('header').show(suite.headerView);
+          }
+        });
+        this.mainView = new this.MainView();
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onBeforeShow: function() {
+            this.getRegion('main').show(suite.mainView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the LayoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView a single time', function() {
+        expect(this.mainView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the headerView a single time', function() {
+        expect(this.headerView.onAttach).to.have.been.calledOnce;
+      });
+    });
+
+    describe('When showing a LayoutView with two levels of nested views; with onShow for the first level, onBeforeShow for the second', function() {
+      beforeEach(function() {
+        var suite = this;
+        this.headerView = new this.BasicView();
+        this.sinon.spy(this.headerView, 'onAttach');
+
+        this.MainView = Marionette.LayoutView.extend({
+          template: _.template('<header></header>'),
+          onAttach: this.sinon.stub(),
+          regions: {
+            header: 'header'
+          },
+          onBeforeShow: function() {
+            this.getRegion('header').show(suite.headerView);
+          }
+        });
+        this.mainView = new this.MainView();
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onShow: function() {
+            this.getRegion('main').show(suite.mainView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the LayoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView a single time', function() {
+        expect(this.mainView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the headerView a single time', function() {
+        expect(this.headerView.onAttach).to.have.been.calledOnce;
+      });
+    });
+
+    describe('When showing a LayoutView with a single level of nested views that are attached within onShow', function() {
+      beforeEach(function() {
+        this.mainView = new this.BasicView();
+        this.footerView = new this.BasicView();
+
+        this.sinon.spy(this.mainView, 'onAttach');
+        this.sinon.spy(this.footerView, 'onAttach');
+
+        var suite = this;
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onShow: function() {
+            this.getRegion('main').show(suite.mainView);
+            this.getRegion('footer').show(suite.footerView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the layoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView a single time', function() {
+        expect(this.mainView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the footerView a single time', function() {
+        expect(this.footerView.onAttach).to.have.been.calledOnce;
+      });
+    });
+  });
+
+  describe('when the parent view is initially attached', function() {
+    beforeEach(function() {
+      this.setFixtures('<div class="layout-view"></div>');
+
+      // A LayoutView class that we can use for all of our tests
+      this.LayoutView = Backbone.Marionette.LayoutView.extend({
+        el: '.layout-view',
+        template: _.template('<main></main><footer></footer>'),
+        regions: {
+          main: 'main',
+          footer: 'footer'
+        },
+        onAttach: function() {}
+      });
+    });
+
+    describe('When showing a View in a Region', function() {
+      beforeEach(function() {
+        this.MyView = Marionette.ItemView.extend({
+          el: '.layout-view',
+          template: _.template(''),
+          onAttach: this.sinon.stub()
+        });
+
+        this.myView = new this.MyView();
+        this.region.show(this.myView);
+      });
+
+      it('should trigger onAttach on the View a single time', function() {
+        expect(this.myView.onAttach).to.have.been.calledOnce;
+      });
+    });
+
+    describe('When showing a LayoutView with a single level of nested views that are attached within onBeforeShow', function() {
+      beforeEach(function() {
+        this.mainView = new this.BasicView();
+        this.footerView = new this.BasicView();
+
+        this.sinon.spy(this.mainView, 'onAttach');
+        this.sinon.spy(this.footerView, 'onAttach');
+
+        var suite = this;
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onBeforeShow: function() {
+            this.getRegion('main').show(suite.mainView);
+            this.getRegion('footer').show(suite.footerView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the LayoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView twice', function() {
+        expect(this.mainView.onAttach).to.have.been.calledTwice;
+      });
+
+      it('should trigger onAttach on the footerView twice', function() {
+        expect(this.footerView.onAttach).to.have.been.calledTwice;
+      });
+    });
+
+    describe('When showing a LayoutView with two levels of nested views; with onBeforeShow for the first and second level', function() {
+      beforeEach(function() {
+        var suite = this;
+        this.headerView = new this.BasicView();
+        this.sinon.spy(this.headerView, 'onAttach');
+
+        this.MainView = Marionette.LayoutView.extend({
+          template: _.template('<header></header>'),
+          onAttach: this.sinon.stub(),
+          regions: {
+            header: 'header'
+          },
+          onBeforeShow: function() {
+            this.getRegion('header').show(suite.headerView);
+          }
+        });
+        this.mainView = new this.MainView();
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onBeforeShow: function() {
+            console.log('attached?', Marionette.isNodeAttached(this.el));
+            this.getRegion('main').show(suite.mainView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the LayoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView twice', function() {
+        expect(this.mainView.onAttach).to.have.been.calledTwice;
+      });
+
+      it('should trigger onAttach on the headerView twice', function() {
+        expect(this.headerView.onAttach).to.have.been.calledTwice;
+      });
+    });
+
+    describe('When showing a LayoutView with two levels of nested views; onBeforeShow for the first level, then onShow for the second', function() {
+      beforeEach(function() {
+        var suite = this;
+        this.headerView = new this.BasicView();
+        this.sinon.spy(this.headerView, 'onAttach');
+
+        this.MainView = Marionette.LayoutView.extend({
+          template: _.template('<header></header>'),
+          onAttach: this.sinon.stub(),
+          regions: {
+            header: 'header'
+          },
+          onShow: function() {
+            this.getRegion('header').show(suite.headerView);
+          }
+        });
+        this.mainView = new this.MainView();
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onBeforeShow: function() {
+            this.getRegion('main').show(suite.mainView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the LayoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView twice', function() {
+        expect(this.mainView.onAttach).to.have.been.calledTwice;
+      });
+
+      it('should trigger onAttach on the headerView twice', function() {
+        expect(this.headerView.onAttach).to.have.been.calledTwice;
+      });
+    });
+
+    describe('When showing a LayoutView with two levels of nested views; with onShow for the first level, onBeforeShow for the second', function() {
+      beforeEach(function() {
+        var suite = this;
+        this.headerView = new this.BasicView();
+        this.sinon.spy(this.headerView, 'onAttach');
+
+        this.MainView = Marionette.LayoutView.extend({
+          template: _.template('<header></header>'),
+          onAttach: this.sinon.stub(),
+          regions: {
+            header: 'header'
+          },
+          onBeforeShow: function() {
+            this.getRegion('header').show(suite.headerView);
+          }
+        });
+        this.mainView = new this.MainView();
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onShow: function() {
+            this.getRegion('main').show(suite.mainView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the LayoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView a single time', function() {
+        expect(this.mainView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the headerView a single time', function() {
+        expect(this.headerView.onAttach).to.have.been.calledOnce;
+      });
+    });
+
+    describe('When showing a LayoutView with a single level of nested views that are attached within onShow', function() {
+      beforeEach(function() {
+        this.mainView = new this.BasicView();
+        this.footerView = new this.BasicView();
+
+        this.sinon.spy(this.mainView, 'onAttach');
+        this.sinon.spy(this.footerView, 'onAttach');
+
+        var suite = this;
+
+        this.CustomLayoutView = this.LayoutView.extend({
+          onShow: function() {
+            this.getRegion('main').show(suite.mainView);
+            this.getRegion('footer').show(suite.footerView);
+          }
+        });
+
+        this.layoutView = new this.CustomLayoutView();
+        this.sinon.spy(this.layoutView, 'onAttach');
+
+        this.region.show(this.layoutView);
+      });
+
+      it('should trigger onAttach on the layoutView a single time', function() {
+        expect(this.layoutView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the mainView a single time', function() {
+        expect(this.mainView.onAttach).to.have.been.calledOnce;
+      });
+
+      it('should trigger onAttach on the footerView a single time', function() {
+        expect(this.footerView.onAttach).to.have.been.calledOnce;
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### This PR is being split up

To make this easier to review, I'm splitting it up into three bite-sized chunks.

– #1946 - Adds isNodeAttached helper
– #1949 - Adds _getNestedView
– TBA - Adds triggerAttached triggerMethod
# 

Mmk, this is ready for review.
- Works properly for infinitely nested LayoutViews
- Also works on collectionViews
- Documented
- Backwards compatible

This adds `onAttach`. Ref #1856 for more about why this event is important.
# 

To do: It adds three new public methods that need documentation
- triggerAttach (view). This should prob. just be private
- getNestedViews (layoutView)
- isNodeAttached

I'll do this once I get thumbs on the implementation.
