### PR TITLE
add controller.jsdoc file

### DIFF
--- a/api/controller.jsdoc
+++ b/api/controller.jsdoc
@@ -16,7 +16,6 @@ description: |
   create a new Class altogether.
   
 example: |
-
   A `Marionette.Controller` can be extended, like other
   Backbone and Marionette objects. It supports the standard
   `initialize` method, has a built-in `EventBinder`, and


### PR DESCRIPTION
I intentionally left out this block of text, as it didn't seem to fit w/ the new format: 
## On The Name 'Controller'

The name `Controller` is bound to cause a bit of confusion, which is
rather unfortunate. There was some discussion and debate about what to
call this object, the idea that people would confuse this with an
MVC style controller came up a number of times. In the end, we decided
to call this a controller anyway--as the typical use case is to control
the workflow and process of an application and/or module.

But the truth is, this is a very generic, multi-purpose object that can
serve many different roles, in many different scenarios. We are always open
to suggestions, with good reason and discussion, on renaming objects to
be more descriptive and less confusing. If you would like to suggest a
different name, please do so in either the mailing list or in the Github
Issues list.
