### PR TITLE
Updates docs to use getter methods.

### DIFF
--- a/api/application.jsdoc
+++ b/api/application.jsdoc
@@ -180,7 +180,7 @@ functions:
             var myView = new MyView({
               model: options.someModel
             });
-            MyApp.mainRegion.show(myView);
+            MyApp.getRegion('main').show(myView);
           });
           
           MyApp.addInitializer(function(options){
@@ -318,7 +318,7 @@ functions:
 
     examples: 
       -
-        name: Get Region By Name
+        name: Get Region by name
         example: |
           A region can be retrieved by name, using the `getRegion` method:
           
@@ -331,8 +331,7 @@ functions:
           var r1Again = app.r1;
           ```
           
-          Accessing a region by named attribute is equivalent to accessing
-          it from the `getRegion` method.
+          This is the preferred method of accessing Regions on the Application instance.
 
     
   getRegions: |

--- a/api/regionmanager.jsdoc
+++ b/api/regionmanager.jsdoc
@@ -23,7 +23,7 @@ constructor: |
     quux: "ul.quux"
   });
 
-  regions.baz.show(myView);
+  regions.getRegion("baz").show(myView);
 
   rm.removeRegion("foo");
   ```
@@ -81,9 +81,9 @@ functions:
             };
           });
 
-          regions.main;        //=> 'main' region instance
-          regions.navigation;  //=> 'navigation' region instance
-          otherRegions.footer; //=> 'footer' region instance
+          regions.getRegion("main");        //=> 'main' region instance
+          regions.getRegion("navigation");  //=> 'navigation' region instance
+          otherRegions.getRegion("footer"); //=> 'footer' region instance
           ```
 
       -
@@ -139,7 +139,7 @@ functions:
 
     examples:
       -
-        name: Adding a region
+        name: Adding and then accessing a region
 
         example: |
           ```js
@@ -165,8 +165,8 @@ functions:
 
           var regions = rm.getRegions();
 
-          regions.foo; //=> foo region
-          regions.bar; //=> bar region
+          regions.getRegion("foo"); //=> foo region
+          regions.getRegion("bar"); //=> bar region
           ```
 
   removeRegion:

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -323,13 +323,10 @@ A region can be retrieved by name, using the `getRegion` method:
 var app = new Marionette.Application();
 app.addRegions({ r1: "#region1" });
 
-// r1 === r1Again; true
-var r1 = app.getRegion("r1");
-var r1Again = app.r1;
+var myRegion = app.getRegion('r1');
 ```
 
-Accessing a region by named attribute is equivalent to accessing
-it from the `getRegion` method.
+Regions are also attached directly to the Application instance, but this is not recommended usage.
 
 ### Removing Regions
 

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -71,11 +71,10 @@ Once you've rendered the layoutView, you now have direct access
 to all of the specified regions as region managers.
 
 ```js
-layoutView.menu.show(new MenuView());
+layoutView.getRegion('menu').show(new MenuView());
 
-layoutView.content.show(new MainContentView());
+layoutView.getRegion('content').show(new MainContentView());
 ```
-
 
 ### Region Options
 
@@ -190,44 +189,39 @@ Since the `LayoutView` extends directly from `ItemView`, it
 has all of the core functionality of an item view. This includes
 the methods necessary to be shown within an existing region manager.
 
+In the following example, we will use the Application's Regions
+as the base of a deeply nested view structure.
+
 ```js
-var MyApp = new Backbone.Marionette.Application();
+// Create an Application
+var MyApp = new Marionette.Application();
+
+// Add a region
 MyApp.addRegions({
-  mainRegion: "#main"
+  main: "main"
 });
 
-var layoutView = new AppLayout();
-MyApp.mainRegion.show(layoutView);
+// Create a new LayoutView
+var layoutView = new Marionette.LayoutView();
 
-layoutView.show(new MenuView());
+// Lastly, show the LayoutView in the App's mainRegion
+MyApp.getRegion('main').show(layoutView);
 ```
 
-You can nest layoutViews into region managers as deeply as you want.
-This provides for a well organized, nested view structure.
+You can nest LayoutViews as deeply as you want. This provides for a well organized,
+nested view structure.
 
-For example, to nest 3 layouts (all of these are equivalent):
+For example, to nest 3 layouts:
 
 ```js
 var layout1 = new Layout1();
 var layout2 = new Layout2();
 var layout3 = new Layout3();
-MyApp.mainRegion.show(layout1);
-layout1.region1.show(layout2);
-layout2.region2.show(layout3);
-```
 
-```js
-MyApp.mainRegion.show(new Layout1());
-MyApp.mainRegion.currentView.myRegion1.show(new Layout2());
-MyApp.mainRegion.currentView.myRegion1.currentView.myRegion2.show(new Layout3());
-```
+MyApp.getRegion('main').show(layout1);
 
-Or if you like chaining:
-
-```js
-MyApp.mainRegion.show(new Layout1())
-  .currentView.myRegion1.show(new Layout2())
-  .currentView.myRegion2.show(new Layout3());
+layout1.getRegion('region1').show(layout2);
+layout2.getRegion('region2').show(layout3);
 ```
 
 ## Destroying A LayoutView
@@ -294,7 +288,7 @@ var layoutView = new MyLayoutView();
 // ...
 
 layoutView.addRegion("foo", "#foo");
-layoutView.foo.show(new someView());
+layoutView.getRegion('foo').show(new someView());
 ```
 
 addRegions:

--- a/docs/marionette.module.md
+++ b/docs/marionette.module.md
@@ -35,8 +35,6 @@ var MyApp = new Backbone.Marionette.Application();
 // Creates a new module named "MyModule"
 var myModule = MyApp.module("MyModule");
 
-MyApp.MyModule; // => a new Marionette.Module object
-
 myModule === MyApp.MyModule; // => true
 ```
 
@@ -52,7 +50,6 @@ var myModule = MyApp.module("MyModule");
 
 // Returns the module you just created
 var theSameModule = MyApp.module("MyModule");
-
 ```
 
 ## Module Definitions
@@ -256,7 +253,6 @@ MyApp.module("Foo", FooModule);
 
 If all of the module's functionality is defined inside its class, then the class can be passed in directly. `MyApp.module("Foo", FooModule)`
 
-
 ## Defining Sub-Modules
 
 Sub-Modules (or 'child' Modules) can be defined in a single call by passing
@@ -273,6 +269,21 @@ MyApp.Parent.Child.GrandChild; // => a valid module object
 When defining sub-modules using the dot-notation, the
 parent modules do not need to exist; they'll be created for you. If a parent
 has already been instantiated then that instance will be used.
+
+## Accessing Modules
+
+Although modules are attached directly to the Application instance we don't recommend accessing them this way. Instead,
+use the `.module()` function to access your modules.
+
+Let's look at two examples of accessing a module named `MyModule.Submodule`.
+
+```js
+// Not recommended
+var myModule = App.MyModule.Submodule;
+
+// Recommended
+var MyModule = App.module('MyModule.Submodule');
+```
 
 ## Starting And Stopping Modules
 

--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -45,7 +45,7 @@ var regions = rm.addRegions({
   quux: "ul.quux"
 });
 
-regions.baz.show(myView);
+regions.get('baz').show(myView);
 
 rm.removeRegion("foo");
 ```
@@ -100,9 +100,9 @@ var otherRegions = rm.addRegions(function(regionDefinition) {
   };
 });
 
-regions.main;        //=> 'main' region instance
-regions.navigation;  //=> 'navigation' region instance
-otherRegions.footer; //=> 'footer' region instance
+regions.get('main');        //=> 'main' region instance
+regions.get('navigation');  //=> 'navigation' region instance
+otherRegions.get('footer'); //=> 'footer' region instance
 ```
 
 If you supply a function to `addRegions`, it will be


### PR DESCRIPTION
Our docs didn't explicitly suggest using the getter methods, and at times even used direct references in the examples.

We've deprecated direct access, so I made the docs more explicit about that.

I also updated the wording or examples in a few places.

Resolves #1890 
