### PR TITLE
Passes model and index to emptyViewOptions.

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -338,6 +338,8 @@ Similar to `childView` and `childViewOptions`, there is an `emptyViewOptions` pr
 
 If `emptyViewOptions` aren't provided the CollectionView will default to passing the `childViewOptions` to the `emptyView`.
 
+`emptyViewOptions` recieves three arguments, the `collectionView` instance, a generic `Backbone.Model` instance, and -1.
+
 ```js
 var EmptyView = Backbone.Marionette.ItemView({
   initialize: function(options){

--- a/spec/javascripts/collectionView.emptyView.spec.js
+++ b/spec/javascripts/collectionView.emptyView.spec.js
@@ -30,12 +30,15 @@ describe('collectionview - emptyView', function() {
       this.CollectionView = this.EmptyCollectionView.extend({
         childEvents: {
           'render': this.childRenderSpy
-        }
+        },
+        emptyViewOptions: function() {}
       });
 
       this.collectionView = new this.CollectionView({
         collection: this.collection,
       });
+
+      this.emptyViewOptionsSpy = sinon.spy(this.collectionView, 'emptyViewOptions');
 
       this.beforeRenderSpy = this.sinon.spy(this.collectionView, 'onBeforeRenderEmpty');
       this.renderSpy = this.sinon.spy(this.collectionView, 'onRenderEmpty');
@@ -45,6 +48,17 @@ describe('collectionview - emptyView', function() {
 
     it('should append the html for the emptyView', function() {
       expect(this.collectionView.$el).to.have.$html('<span>empty</span>');
+    });
+
+    it('should pass the correct emptyViewOptions params', function() {
+      expect(this.emptyViewOptionsSpy)
+      .to.have.been.calledOnce;
+
+      expect(this.emptyViewOptionsSpy.getCall(0).args[0])
+      .to.be.instanceOf(Backbone.Model);
+
+      expect(this.emptyViewOptionsSpy.getCall(0).args[1])
+      .to.eql(-1);
     });
 
     it('should emit emptyView events', function() {

--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -213,7 +213,7 @@ Marionette.CollectionView = Marionette.View.extend({
                           this.getOption('childViewOptions');
 
     if (_.isFunction(emptyViewOptions)){
-      emptyViewOptions = emptyViewOptions.call(this);
+      emptyViewOptions = emptyViewOptions.call(this, child, -1);
     }
 
     // build the empty view


### PR DESCRIPTION
Fixes #1873.
