### PR TITLE
Update marionette.itemview.md

### DIFF
--- a/docs/marionette.itemview.md
+++ b/docs/marionette.itemview.md
@@ -61,7 +61,7 @@ var my_template_html = '<div><%= args.name %></div>'
 var MyView = Backbone.Marionette.ItemView.extend({
   template : function(serialized_model) {
     var name = serialized_model.name;
-    return _.template(my_template_html, { variable: 'args' })({
+    return _.template(my_template_html)({
         name : name,
         some_custom_attribute : some_custom_key
     });
@@ -71,12 +71,9 @@ var MyView = Backbone.Marionette.ItemView.extend({
 new MyView().render();
 ```
 
-Note that using a template function allows passing custom arguments into the _.template function,
-including a "settings" argument, as used in the example above.
+Note that using a template function allows passing custom arguments into the _.template function and allows for more control over how the _.template function is called.
 
-According to the [Underscore docs](http://underscorejs.org/#template), using the "variable" setting
-"can significantly improve the speed at which a template is able to render." Using this setting
-also requires you to read data arguments from an object, as demonstrated in the example above.
+For more information on the _.template function see the [Underscore docs](http://underscorejs.org/#template).
 
 ## Rendering A Collection In An ItemView
 


### PR DESCRIPTION
The old example for 'variable' in the documentation did not work for me. The 'settings' argument is the 2nd or 3rd argument of the _.template function. The model is then passed in as a parameter to the then generated template function. I attempted to update the documentation to reflect this.
