### PR TITLE
Correct the placement of the swapOut trigger to be in accordance with the documentation_.

### DIFF
--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -175,11 +175,12 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
       this.triggerMethod('before:show', view);
       Marionette.triggerMethodOn(view, 'before:show');
 
+      this.attachHtml(view);
+
       if (isChangingView) {
         this.triggerMethod('swapOut', this.currentView);
       }
 
-      this.attachHtml(view);
       this.currentView = view;
 
       if (isChangingView) {


### PR DESCRIPTION
The proposed documentation (#1859) says:

Triggered when the new view has replaced the old view within the Region.
However swapOut is triggered before the described action has happened. We have to move

this.triggerMethod('swapOut', this.currentView);
to be after

this.attachHtml(view);
More info on #1866
