### PR TITLE
Add preventDestroy option to region.empty()

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -842,4 +842,36 @@ describe('region', function() {
       expect(this.region.currentView).to.be.undefined;
     });
   });
+
+  describe('when destroying a marionette view in a region', function() {
+    beforeEach(function() {
+      this.setFixtures('<div id="region"></div>');
+      this.beforeEmptySpy = new sinon.spy();
+      this.emptySpy = new sinon.spy();
+
+      this.region = new Backbone.Marionette.Region({
+        el: '#region'
+      });
+
+      this.region.on('before:empty', this.beforeEmptySpy);
+      this.region.on('empty', this.emptySpy);
+
+      this.View = Backbone.Marionette.View.extend({
+        template: _.template('')
+      });
+
+      this.view = new this.View();
+
+      this.region.show(this.view);
+      this.region.empty();
+    });
+
+    it('should trigger a empty event once', function() {
+      expect(this.emptySpy).to.have.been.calledOnce;
+    });
+
+    it('should trigger a before:empty event once', function() {
+      expect(this.beforeEmptySpy).to.have.been.calledOnce;
+    });
+  });
 });

--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -290,7 +290,7 @@ describe('region', function() {
         this.myRegion = new this.MyRegion();
 
         this.sinon.spy(this.view1, 'destroy');
-
+        this.regionEmptySpy = this.sinon.spy(this.myRegion, 'empty');
         this.myRegion.show(this.view1);
       });
 
@@ -301,6 +301,12 @@ describe('region', function() {
 
         it('shouldnt "destroy" the old view', function() {
           expect(this.view1.destroy.callCount).to.equal(0);
+        });
+
+        it('shouldnt empty the region when the old view is destroyed', function() {
+          this.view1.trigger('destroy');
+
+          expect(this.regionEmptySpy).to.have.been.calledOnce;
         });
 
         it('should replace the content in the DOM', function() {

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -165,7 +165,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
       // If this happens we need to remove the reference
       // to the currentView since once a view has been destroyed
       // we can not reuse it.
-      view.once('destroy', _.bind(this.empty, this));
+      view.once('destroy', this.empty, this);
       view.render();
 
       if (isChangingView) {
@@ -229,6 +229,7 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     // we should not remove anything
     if (!view) { return; }
 
+    view.off('destroy', this.empty, this);
     this.triggerMethod('before:empty', view);
     this._destroyView();
     this.triggerMethod('empty', view);

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -141,10 +141,6 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     // We are only changing the view if there is a current view to change to begin with
     var isChangingView = !!this.currentView;
 
-    // Only destroy the current view if we don't want to `preventDestroy` and if
-    // the view given in the first argument is different than `currentView`
-    var _shouldDestroyView = isDifferentView && !preventDestroy;
-
     // Only show the view given in the first argument if it is different than
     // the current view or if we want to re-show the view. Note that if
     // `_shouldDestroyView` is true, then `_shouldShowView` is also necessarily true.
@@ -154,8 +150,8 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
       this.triggerMethod('before:swapOut', this.currentView);
     }
 
-    if (_shouldDestroyView) {
-      this.empty();
+    if (isDifferentView) {
+      this.empty({ preventDestroy : preventDestroy });
     }
 
     if (_shouldShowView) {
@@ -222,8 +218,11 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
   // Destroy the current view, if there is one. If there is no
   // current view, it does nothing and returns immediately.
-  empty: function() {
+  empty: function(options) {
     var view = this.currentView;
+
+    var emptyOptions     = options || {};
+    var preventDestroy  = !!emptyOptions.preventDestroy;
 
     // If there is no view in the region
     // we should not remove anything
@@ -231,7 +230,12 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     view.off('destroy', this.empty, this);
     this.triggerMethod('before:empty', view);
-    this._destroyView();
+    // Don't destroy the view if we don't want to `preventDestroy`
+    if (!preventDestroy) {
+      this._destroyView();
+    }
+    // Empty the node of HTML
+    this.el.innerHTML='';
     this.triggerMethod('empty', view);
 
     // Remove region pointer to the currentView


### PR DESCRIPTION
This is more of a change of behaviour, not just a fix for #1920 or #1911 
This allows calling region.empty() without destroying the view. The regions node is emptied, and events are unbound, but the view is left in tact.

When changing views, we use region.empty() .. forwarding the preventDestroy option if it was passed. But region.empty() will still unbind the events for us.

This may not be an approach you want to take, feel free to disregard if so. But it was easier to code than explain :)