### PR TITLE
Updates Module documentation.

### DIFF
--- a/docs/marionette.module.md
+++ b/docs/marionette.module.md
@@ -238,9 +238,6 @@ The extend function of a Module is identical to the extend functions on other Ba
 var FooModule = Marionette.Module.extend({
   startWithParent: false,
 
-  constructor: function(moduleName, app, options) {
-  },
-
   initialize: function(options, moduleName, app) {
   },
 


### PR DESCRIPTION
Opening in favor of #1933.

Our documentation shows overwriting the constructor, which obv. breaks the instance unless you call the prototype's constructor. This can be confusing for new folks who might just copy+paste the example, so I removed that bit of code.
