### PR TITLE
Replaces slice with _.toArray

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -83,9 +83,7 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
     // Overwrite the module class if the user specifies one
     var ModuleClass = Marionette.Module.getClass(moduleDefinition);
 
-    // slice the args, and add this application object as the
-    // first argument of the array
-    var args = slice.call(arguments);
+    var args = _.toArray(arguments);
     args.unshift(this);
 
     // see the Marionette.Module object for more information
@@ -127,24 +125,24 @@ _.extend(Marionette.Application.prototype, Backbone.Events, {
     this._regionManager = this.getRegionManager();
 
     this.listenTo(this._regionManager, 'before:add:region', function() {
-      var args = slice.call(arguments, 0);
+      var args = _.toArray(arguments);
       this.triggerMethod.apply(this, ['before:add:region'].concat(args));
     });
 
     this.listenTo(this._regionManager, 'add:region', function(name, region) {
       this[name] = region;
-      var args = slice.call(arguments, 0);
+      var args = _.toArray(arguments);
       this.triggerMethod.apply(this, ['add:region'].concat(args));
     });
 
     this.listenTo(this._regionManager, 'before:remove:region', function() {
-      var args = slice.call(arguments, 0);
+      var args = _.toArray(arguments);
       this.triggerMethod.apply(this, ['before:remove:region'].concat(args));
     });
 
     this.listenTo(this._regionManager, 'remove:region', function(name) {
       delete this[name];
-      var args = slice.call(arguments, 0);
+      var args = _.toArray(arguments);
       this.triggerMethod.apply(this, ['remove:region'].concat(args));
     });
   },

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -457,7 +457,7 @@ Marionette.CollectionView = Marionette.View.extend({
     // Forward all child view events through the parent,
     // prepending "childview:" to the event name
     this.listenTo(view, 'all', function() {
-      var args = slice.call(arguments);
+      var args = _.toArray(arguments);
       var rootEvent = args[0];
       var childEvents = this.normalizeMethods(_.result(this, 'childEvents'));
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -20,7 +20,7 @@ Marionette.Controller.extend = Marionette.extend;
 // Ensure it can trigger events with Backbone.Events
 _.extend(Marionette.Controller.prototype, Backbone.Events, {
   destroy: function() {
-    var args = slice.call(arguments);
+    var args = _.toArray(arguments);
     this.triggerMethod.apply(this, ['before:destroy'].concat(args));
     this.triggerMethod.apply(this, ['destroy'].concat(args));
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,9 +3,6 @@
 // Helpers
 // -------
 
-// For slicing `arguments` in functions
-var slice = Array.prototype.slice;
-
 // Marionette.extend
 // -----------------
 

--- a/src/item-view.js
+++ b/src/item-view.js
@@ -34,7 +34,7 @@ Marionette.ItemView = Marionette.View.extend({
 
   // Serialize a collection by serializing each of its models.
   serializeCollection: function(collection){
-    return collection.toJSON.apply(collection, slice.call(arguments, 1));
+    return collection.toJSON.apply(collection, _.toArray(arguments).slice(1));
   },
 
   // Render the view, defaulting to underscore.js templates.

--- a/src/module.js
+++ b/src/module.js
@@ -144,7 +144,7 @@ _.extend(Marionette.Module, {
 
     // get the custom args passed in after the module definition and
     // get rid of the module name and definition function
-    var customArgs = slice.call(arguments);
+    var customArgs = _.toArray(arguments);
     customArgs.splice(0, 3);
 
     // Split the module names and get the number of submodules.

--- a/src/region.js
+++ b/src/region.js
@@ -23,7 +23,7 @@ Marionette.Region = function(options) {
   this.$el = this.getEl(this.el);
 
   if (this.initialize) {
-    var args = slice.apply(arguments);
+    var args = _.toArray(arguments);
     this.initialize.apply(this, args);
   }
 };

--- a/src/template-cache.js
+++ b/src/template-cache.js
@@ -36,7 +36,7 @@ _.extend(Marionette.TemplateCache, {
   // `clear("#t1", "#t2", "...")`
   clear: function() {
     var i;
-    var args = slice.call(arguments);
+    var args = _.toArray(arguments);
     var length = args.length;
 
     if (length > 0) {

--- a/src/view.js
+++ b/src/view.js
@@ -33,7 +33,7 @@ Marionette.View = Backbone.View.extend({
   // Serialize a model by returning its attributes. Clones
   // the attributes to allow modification.
   serializeModel: function(model){
-    return model.toJSON.apply(model, slice.call(arguments, 1));
+    return model.toJSON.apply(model, _.toArray(arguments).slice(1));
   },
 
   // Mix in template helper methods. Looks for a
@@ -125,7 +125,7 @@ Marionette.View = Backbone.View.extend({
   // Overriding Backbone.View's undelegateEvents to handle unbinding
   // the `triggers`, `modelEvents`, and `collectionEvents` config
   undelegateEvents: function() {
-    var args = slice.call(arguments);
+    var args = _.toArray(arguments);
     Backbone.View.prototype.undelegateEvents.apply(this, args);
 
     this.unbindEntityEvents(this.model, this.getOption('modelEvents'));
@@ -159,7 +159,7 @@ Marionette.View = Backbone.View.extend({
   destroy: function() {
     if (this.isDestroyed) { return; }
 
-    var args = slice.call(arguments);
+    var args = _.toArray(arguments);
 
     this.triggerMethod.apply(this, ['before:destroy'].concat(args));
 


### PR DESCRIPTION
This is required before #1900 can land. The fact that we have a weird function just hanging around 'in-scope' makes it impossible to use Marionette per-component, unless you specify that helper within each UMD wrapper. And that'd be pretty yucky.

While the motivation for this was originally for the sake of getting that PR in, it's also just better this way, I think. `toArray` is self-describing, whereas `slice.call` requires a bit more knowledge of Javascript to understand.

Work on #1900 is kind of halted until this gets in. If you had a quick moment to :eyes: it'd be much appreciated!
