### PR TITLE
Adds isNodeAttached helper method.

### DIFF
--- a/api/helpers.jsdoc
+++ b/api/helpers.jsdoc
@@ -53,6 +53,31 @@ functions:
           var b = new Bar();
           ```
 
+  isNodeAttached:
+    description: |
+      Determines whether the passed-in node is a child of the `document` or not.
+      
+      @api public
+      @static
+      @param {Node} el
+      @return {Boolean}
+      
+    examples:
+      -
+        name: Testing whether an element is a child of the document or not
+        example: |
+          This method returns `false` when the node isn't attached to the `document`; otherwise it returns `true`.
+          
+          ```js
+          var div = document.createElement('div');
+          Marionette.isNodeAttached(div);
+          // => false
+
+          $('body').append(div);
+          Marionette.isNodeAttached(div);
+          // => true
+          ```
+
   getOption:
     description: |
       Retrieve an object, function or other value from a target object or its `options`, with

--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -10,6 +10,7 @@ a way to get the same behaviors and conventions from your own code.
 ## Documentation Index
 
 * [Marionette.extend](#marionetteextend)
+* [Marionette.isNodeAttached](#marionetteisnodeattached)
 * [Marionette.getOption](#marionettegetoption)
 * [Marionette.proxyGetOption](#marionetteproxygetoption)
 * [Marionette.triggerMethod](#marionettetriggermethod)
@@ -50,6 +51,20 @@ var Bar = Foo.extend({
 
 // Create an instance of Bar
 var b = new Bar();
+```
+
+## Marionette.isNodeAttached
+
+Determines whether the passed-in node is a child of the `document` or not.
+
+```js
+var div = document.createElement('div');
+Marionette.isNodeAttached(div);
+// => false
+
+$('body').append(div);
+Marionette.isNodeAttached(div);
+// => true
 ```
 
 ## Marionette.getOption

--- a/src/dom-refresh.js
+++ b/src/dom-refresh.js
@@ -21,15 +21,11 @@ Marionette.MonitorDOMRefresh = (function(documentElement) {
 
   // Trigger the "dom:refresh" event and corresponding "onDomRefresh" method
   function triggerDOMRefresh(view) {
-    if (view._isShown && view._isRendered && isInDOM(view)) {
+    if (view._isShown && view._isRendered && Marionette.isNodeAttached(view.el)) {
       if (_.isFunction(view.triggerMethod)) {
         view.triggerMethod('dom:refresh');
       }
     }
-  }
-
-  function isInDOM(view) {
-    return Backbone.$.contains(documentElement, view.el);
   }
 
   // Export public API

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,6 +9,15 @@
 // Borrow the Backbone `extend` method so we can use it as needed
 Marionette.extend = Backbone.Model.extend;
 
+// Marionette.isNodeAttached
+// -------------------------
+
+// Determine if `el` is a child of the document
+Marionette.isNodeAttached = function(el) {
+  return Backbone.$.contains(document.documentElement, el);
+};
+
+
 // Marionette.getOption
 // --------------------
 

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -1,3 +1,13 @@
+describe("isNodeAttached", function() {
+  'use strict';
+
+  describe("document.documentElement", function() {
+    it("should exist", function() {
+      expect(document.documentElement).to.not.be.undefined;
+    });
+  });
+});
+
 describe("normalizeUIKeys", function () {
   'use strict';
 


### PR DESCRIPTION
PR 1 for `onAttach`

This adds a helper method `isNodeAttached`. It lets you know if an element is a child of the document or not. I also updated `triggerDOMRefresh` to take advantage of the new helper.
