### PR TITLE
Adds _getNestedView to Layout and Collection Views.

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -117,6 +117,8 @@
     <script src="test/unit/module.spec.js"></script>
     <script src="test/unit/module.stop.spec.js"></script>
     <script src="test/unit/normalize-methods.spec.js"></script>
+    <script src="test/unit/get-immediate-children.spec.js"></script>
+    <script src="test/unit/get-nested-views.spec.js"></script>
     <script src="test/unit/on-dom-refresh.spec.js"></script>
     <script src="test/unit/object.spec.js"></script>
     <script src="test/unit/precompiled-template-rendering.spec.js"></script>

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -471,5 +471,9 @@ Marionette.CollectionView = Marionette.View.extend({
 
       this.triggerMethod.apply(this, args);
     }, this);
+  },
+
+  _getImmediateChildren: function() {
+    return _.values(this.children._views);
   }
 });

--- a/src/layout-view.js
+++ b/src/layout-view.js
@@ -158,5 +158,12 @@ Marionette.LayoutView = Marionette.ItemView.extend({
       delete this[name];
       this.triggerMethod('remove:region', name, region);
     });
+  },
+
+  _getImmediateChildren: function() {
+    return _.chain(this.regionManager.getRegions())
+      .pluck('currentView')
+      .filter(function(view) { return !!view; })
+      .value();
   }
 });

--- a/src/view.js
+++ b/src/view.js
@@ -290,6 +290,27 @@ Marionette.View = Backbone.View.extend({
     return ret;
   },
 
+  // This method returns any views that are immediate
+  // children of this view
+  _getImmediateChildren: function() {
+    return [];
+  },
+
+  // Returns an array of every nested view within this view
+  _getNestedViews: function() {
+    var children = this._getImmediateChildren();
+
+    if (!children.length) { return children; }
+
+    var nestedViews = [];
+    _.each(children, function(view) {
+      if (!view._getNestedViews) { return; }
+      nestedViews = nestedViews.concat(view._getNestedViews());
+    });
+    children = children.concat(nestedViews);
+    return children;
+  },
+
   // Imports the "normalizeMethods" to transform hashes of
   // events=>function references/names to a hash of events=>function references
   normalizeMethods: Marionette.normalizeMethods,

--- a/test/unit/get-immediate-children.spec.js
+++ b/test/unit/get-immediate-children.spec.js
@@ -1,0 +1,109 @@
+describe('_getImmediateChildren', function() {
+  beforeEach(function() {
+
+    // A suitable view to use as a child
+    this.BaseView = Marionette.ItemView.extend({
+      template: false
+    });
+  });
+
+  describe('Marionette.View', function() {
+    beforeEach(function() {
+      this.view = new Marionette.View();
+    });
+    it('should return an empty array for getImmediateChildren', function() {
+      expect(this.view._getImmediateChildren())
+        .to.be.instanceof(Array)
+        .and.to.have.length(0);
+    });
+  });
+
+  describe('Marionette.CollectionView', function() {
+    describe('when empty', function() {
+      beforeEach(function() {
+        this.collectionView = new Marionette.CollectionView();
+      });
+      it('should return an empty array for getImmediateChildren', function() {
+        expect(this.collectionView._getImmediateChildren())
+          .to.be.instanceof(Array)
+          .and.to.have.length(0);
+      });
+    });
+
+    describe('when there are children', function() {
+      beforeEach(function() {
+        this.collectionView = new Marionette.CollectionView({
+          collection: new Backbone.Collection([{}, {}]),
+          childView: this.BaseView
+        });
+        this.collectionView.render();
+        this.childOne = this.collectionView.children.findByIndex(0);
+        this.childTwo = this.collectionView.children.findByIndex(1);
+      });
+      it('should return an empty array for getImmediateChildren', function() {
+        expect(this.collectionView._getImmediateChildren())
+          .to.be.instanceof(Array)
+          .and.to.have.length(2)
+          .and.to.contain(this.childOne)
+          .and.to.contain(this.childTwo);
+      });
+    });
+  });
+
+  describe('Marionette.LayoutView', function() {
+    describe('without regions', function() {
+      beforeEach(function() {
+        this.layoutView = new Marionette.LayoutView({
+          template: false
+        });
+      });
+      it('should return an empty array for getImmediateChildren', function() {
+        expect(this.layoutView._getImmediateChildren())
+          .to.be.instanceof(Array)
+          .and.to.have.length(0);
+      });
+    });
+
+    describe('when there are empty regions', function() {
+      beforeEach(function() {
+        this.layoutView = new Marionette.LayoutView({
+          template: _.template('<main></main><footer></footer>'),
+          regions: {
+            main: '.main',
+            footer: '.footer'
+          }
+        });
+        this.layoutView.render();
+      });
+      it('should return an empty array for getImmediateChildren', function() {
+        expect(this.layoutView._getImmediateChildren())
+          .to.be.instanceof(Array)
+          .and.to.have.length(0);
+      });
+    });
+
+    describe('when there are non-empty regions', function() {
+      beforeEach(function() {
+        this.layoutView = new Marionette.LayoutView({
+          template: _.template('<main></main><footer></footer>'),
+          regions: {
+            main: 'main',
+            footer: 'footer'
+          }
+        });
+        this.layoutView.render();
+        this.childOne = new this.BaseView();
+        this.childTwo = new this.BaseView();
+        this.layoutView.getRegion('main').show(this.childOne);
+        this.layoutView.getRegion('footer').show(this.childTwo);
+      });
+      it('should return an empty array for getImmediateChildren', function() {
+        expect(this.layoutView._getImmediateChildren())
+          .to.be.instanceof(Array)
+          .and.to.have.length(2)
+          .and.to.contain(this.childOne)
+          .and.to.contain(this.childTwo);
+      });
+    });
+  });
+});

--- a/test/unit/get-nested-views.spec.js
+++ b/test/unit/get-nested-views.spec.js
@@ -1,0 +1,188 @@
+describe('getNestedView', function() {
+  beforeEach(function() {
+    this.template = _.template('<div class="main"></div><div class="subheader"></div>');
+  });
+
+  describe('Starting with an ItemView', function() {
+    beforeEach(function() {
+      this.itemView = new Marionette.ItemView({
+        template: false
+      });
+    });
+
+    it('should return an empty array', function() {
+      expect(this.itemView._getNestedViews())
+        .to.be.instanceof(Array)
+        .and.to.have.length(0);
+    });
+  });
+
+  describe('Starting with a LayoutView with no regions', function() {
+    beforeEach(function() {
+      this.layoutView = new Marionette.LayoutView({
+        template: this.template
+      });
+    });
+
+    it('should return an empty array', function() {
+      expect(this.layoutView._getNestedViews())
+        .to.be.instanceof(Array)
+        .and.to.have.length(0);
+    });
+  });
+
+  describe('Starting with a layoutView with regions', function() {
+    beforeEach(function() {
+      this.Layout = Marionette.LayoutView.extend({
+        template: this.template,
+
+        regions: {
+          main: '.main',
+          subheader: '.subheader'
+        }
+      });
+
+      this.layoutView = new this.Layout();
+
+      this.layoutView.render();
+
+      // A suitable base item view to use as a child
+      this.BaseView = Marionette.ItemView.extend({
+        template: false
+      });
+    });
+
+    it('should return an empty array', function() {
+      expect(this.layoutView._getNestedViews())
+        .to.be.instanceof(Array)
+        .and.to.have.length(0);
+    });
+
+    describe('a LayoutView with two regions, both with child views', function() {
+      beforeEach(function() {
+        this.childOne = new this.BaseView();
+        this.childTwo = new this.BaseView();
+
+        this.layoutView.getRegion('main').show(this.childOne);
+        this.layoutView.getRegion('subheader').show(this.childTwo);
+      });
+
+      it('it should return an array with both views inside of it', function() {
+        expect(this.layoutView._getNestedViews())
+          .to.be.instanceof(Array)
+          .and.to.have.length(2)
+          .and.to.contain(this.childOne)
+          .and.to.contain(this.childTwo);
+      });
+    });
+
+    describe('a LayoutView with two regions, one of them empty', function() {
+      beforeEach(function() {
+        this.childOne = new this.BaseView();
+
+        this.layoutView.getRegion('main').show(this.childOne);
+      });
+
+      it('it should return an array with the one view inside of it', function() {
+        expect(this.layoutView._getNestedViews())
+          .to.be.instanceof(Array)
+          .and.to.have.length(1)
+          .and.to.contain(this.childOne);
+      });
+    });
+
+    describe('a LayoutView containing a regular Backbone View', function() {
+      beforeEach(function() {
+        this.childOne = new Backbone.View();
+        this.layoutView.getRegion('main').show(this.childOne);
+      });
+
+      it('it should return an array with the one view inside of it', function() {
+        expect(this.layoutView._getNestedViews())
+          .to.be.instanceof(Array)
+          .and.to.have.length(1)
+          .and.to.contain(this.childOne);
+      });
+    });
+
+    describe('a LayoutView with another LayoutView as a child, and that LayoutView has children of its own', function() {
+      beforeEach(function() {
+        this.childOne = new this.Layout();
+        this.subChildOne = new this.BaseView();
+        this.layoutView.getRegion('main').show(this.childOne);
+        this.childOne.getRegion('subheader').show(this.subChildOne);
+      });
+
+      it('it should return an array of both nested views', function() {
+        expect(this.layoutView._getNestedViews())
+          .to.be.instanceof(Array)
+          .and.to.have.length(2)
+          .and.to.contain(this.childOne)
+          .and.to.contain(this.subChildOne);
+      });
+    });
+
+    describe('a LayoutView with an empty CollectionView as a child', function() {
+      beforeEach(function() {
+        this.childOne = new Marionette.CollectionView();
+        this.layoutView.getRegion('main').show(this.childOne);
+      });
+
+      it('it should return an array with that one view inside of it', function() {
+        expect(this.layoutView._getNestedViews())
+          .to.be.instanceof(Array)
+          .and.to.have.length(1)
+          .and.to.contain(this.childOne);
+      });
+    });
+
+    describe('a LayoutView with a CollectionView with children', function() {
+      beforeEach(function() {
+        this.childOne = new Marionette.CollectionView({
+          collection: new Backbone.Collection([{}, {}, {}]),
+          childView: Marionette.ItemView.extend({template: false})
+        });
+        
+        this.layoutView.getRegion('main').show(this.childOne);
+        this.subChildOne = this.childOne.children.findByIndex(0);
+        this.subChildTwo = this.childOne.children.findByIndex(1);
+        this.subChildThree = this.childOne.children.findByIndex(2);
+      });
+
+      it('it should return an array with the child and its children in it', function() {
+        expect(this.layoutView._getNestedViews())
+          .to.be.instanceof(Array)
+          .and.to.have.length(4)
+          .and.to.contain(this.childOne)
+          .and.to.contain(this.subChildOne)
+          .and.to.contain(this.subChildTwo)
+          .and.to.contain(this.subChildThree);
+      });
+    });
+
+    describe('a LayoutView with a CollectionView of LayoutViews, one of them having children of its own', function() {
+      beforeEach(function() {
+        this.childOne = new Marionette.CollectionView({
+          collection: new Backbone.Collection([{}, {}]),
+          childView: this.Layout
+        });
+        
+        this.subSubChildOne = new this.BaseView();
+        this.layoutView.getRegion('main').show(this.childOne);
+        this.subChildOne = this.childOne.children.findByIndex(0);
+        this.subChildTwo = this.childOne.children.findByIndex(1);
+        this.subChildOne.getRegion('main').show(this.subSubChildOne);
+      });
+
+      it('it should return an array with the child and its children in it', function() {
+        expect(this.layoutView._getNestedViews())
+          .to.be.instanceof(Array)
+          .and.to.have.length(4)
+          .and.to.contain(this.childOne)
+          .and.to.contain(this.subChildOne)
+          .and.to.contain(this.subChildTwo)
+          .and.to.contain(this.subSubChildOne);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Part 2 of adding [onAttach](https://github.com/marionettejs/backbone.marionette/pull/1886). This adds `_getNestedViews` to LayoutView and CollectionView.

@jasonLaster made a good point that they should only be used when creating new abstractions, so I opted for making them private.

These aren't used now, but the third and final PR will add the `onAttach` event that _will_ use this.
