### PR TITLE
Refactor Behavior to subclass Object

### DIFF
--- a/src/behavior.js
+++ b/src/behavior.js
@@ -6,8 +6,8 @@
 // Behaviors allow you to blackbox View specific interactions
 // into portable logical chunks, keeping your views simple and your code DRY.
 
-Marionette.Behavior = (function(_, Backbone) {
-  function Behavior(options, view) {
+Marionette.Behavior = Marionette.Object.extend({
+  constructor: function(options, view) {
     // Setup reference to the view.
     // this comes in handle when a behavior
     // wants to directly talk up the chain
@@ -16,50 +16,24 @@ Marionette.Behavior = (function(_, Backbone) {
     this.defaults = _.result(this, 'defaults') || {};
     this.options  = _.extend({}, this.defaults, options);
 
-    // proxy behavior $ method to the view
-    // this is useful for doing jquery DOM lookups
-    // scoped to behaviors view.
-    this.$ = function() {
-      return this.view.$.apply(this.view, arguments);
-    };
+    Marionette.Object.apply(this, arguments);
+  },
 
-    // Call the initialize method passing
-    // the arguments from the instance constructor
-    this.initialize.apply(this, arguments);
+  // proxy behavior $ method to the view
+  // this is useful for doing jquery DOM lookups
+  // scoped to behaviors view.
+  $: function() {
+    return this.view.$.apply(this.view, arguments);
+  },
+
+  // Stops the behavior from listening to events.
+  // Overrides Object#destroy to prevent additional events from being triggered.
+  destroy: function() {
+    this.stopListening();
+  },
+
+  proxyViewProperties: function (view) {
+    this.$el = view.$el;
+    this.el = view.el;
   }
-
-  _.extend(Behavior.prototype, Backbone.Events, {
-    initialize: function() {},
-
-    // stopListening to behavior `onListen` events.
-    destroy: function() {
-      this.stopListening();
-    },
-
-    proxyViewProperties: function (view) {
-      this.$el = view.$el;
-      this.el = view.el;
-    },
-
-    // import the `triggerMethod` to trigger events with corresponding
-    // methods if the method exists
-    triggerMethod: Marionette.triggerMethod,
-
-    // Proxy `getOption` to enable getting options from this or this.options by name.
-    getOption: Marionette.proxyGetOption,
-
-    // Proxy `unbindEntityEvents` to enable binding view's events from another entity.
-    bindEntityEvents: Marionette.proxyBindEntityEvents,
-
-    // Proxy `unbindEntityEvents` to enable unbinding view's events from another entity.
-    unbindEntityEvents: Marionette.proxyUnbindEntityEvents
-  });
-
-  // Borrow Backbones extend implementation
-  // this allows us to setup a proper
-  // inheritance pattern that follows suit
-  // with the rest of Marionette views.
-  Behavior.extend = Marionette.extend;
-
-  return Behavior;
-})(_, Backbone);
+});


### PR DESCRIPTION
Cleanup Behavior so that it subclasses Object. This was by far the most red of the three refactors. When all is said and done, Behavior is one of the tiniest classes we [have](https://github.com/jasonLaster/backbone.marionette/blob/6e51fc787edc0907b19d01fe5e0190aaff1acbcf/src/behavior.js). Who knew?!?!
