### PR TITLE
Removes iffy IIFE patterns in source.

### DIFF
--- a/src/dom-refresh.js
+++ b/src/dom-refresh.js
@@ -5,22 +5,23 @@
 // in the DOM, trigger a "dom:refresh" event every time it is
 // re-rendered.
 
-Marionette.MonitorDOMRefresh = (function(documentElement) {
+Marionette.MonitorDOMRefresh = function(view) {
+
   // track when the view has been shown in the DOM,
   // using a Marionette.Region (or by other means of triggering "show")
-  function handleShow(view) {
+  function handleShow() {
     view._isShown = true;
-    triggerDOMRefresh(view);
+    triggerDOMRefresh();
   }
 
   // track when the view has been rendered
-  function handleRender(view) {
+  function handleRender() {
     view._isRendered = true;
-    triggerDOMRefresh(view);
+    triggerDOMRefresh();
   }
 
   // Trigger the "dom:refresh" event and corresponding "onDomRefresh" method
-  function triggerDOMRefresh(view) {
+  function triggerDOMRefresh() {
     if (view._isShown && view._isRendered && Marionette.isNodeAttached(view.el)) {
       if (_.isFunction(view.triggerMethod)) {
         view.triggerMethod('dom:refresh');
@@ -28,14 +29,8 @@ Marionette.MonitorDOMRefresh = (function(documentElement) {
     }
   }
 
-  // Export public API
-  return function(view) {
-    view.listenTo(view, 'show', function() {
-      handleShow(view);
-    });
-
-    view.listenTo(view, 'render', function() {
-      handleRender(view);
-    });
-  };
-})(document.documentElement);
+  view.on({
+    show: handleShow,
+    render: handleRender
+  });
+};

--- a/src/region-manager.js
+++ b/src/region-manager.js
@@ -2,135 +2,129 @@
 // --------------
 
 // Manage one or more related `Marionette.Region` objects.
-Marionette.RegionManager = (function(Marionette) {
+Marionette.RegionManager = Marionette.Controller.extend({
+  constructor: function(options) {
+    this._regions = {};
 
-  var RegionManager = Marionette.Controller.extend({
-    constructor: function(options) {
-      this._regions = {};
+    Marionette.Controller.call(this, options);
 
-      Marionette.Controller.call(this, options);
+    this.addRegions(this.getOption('regions'));
+  },
 
-      this.addRegions(this.getOption('regions'));
-    },
-
-    // Add multiple regions using an object literal or a
-    // function that returns an object literal, where
-    // each key becomes the region name, and each value is
-    // the region definition.
-    addRegions: function(regionDefinitions, defaults) {
-      if (_.isFunction(regionDefinitions)) {
-        regionDefinitions = regionDefinitions.apply(this, arguments);
-      }
-
-      var regions = {};
-
-      _.each(regionDefinitions, function(definition, name) {
-        if (_.isString(definition)) {
-          definition = {selector: definition};
-        }
-
-        if (definition.selector) {
-          definition = _.defaults({}, definition, defaults);
-        }
-
-        var region = this.addRegion(name, definition);
-        regions[name] = region;
-      }, this);
-
-      return regions;
-    },
-
-    // Add an individual region to the region manager,
-    // and return the region instance
-    addRegion: function(name, definition) {
-      var region;
-
-      if (definition instanceof Marionette.Region) {
-        region = definition;
-      } else {
-        region = Marionette.Region.buildRegion(definition, Marionette.Region);
-      }
-
-      this.triggerMethod('before:add:region', name, region);
-
-      this._store(name, region);
-
-      this.triggerMethod('add:region', name, region);
-      return region;
-    },
-
-    // Get a region by name
-    get: function(name) {
-      return this._regions[name];
-    },
-
-    // Gets all the regions contained within
-    // the `regionManager` instance.
-    getRegions: function(){
-      return _.clone(this._regions);
-    },
-
-    // Remove a region by name
-    removeRegion: function(name) {
-      var region = this._regions[name];
-      this._remove(name, region);
-
-      return region;
-    },
-
-    // Empty all regions in the region manager, and
-    // remove them
-    removeRegions: function() {
-      var regions = this.getRegions();
-      _.each(this._regions, function(region, name) {
-        this._remove(name, region);
-      }, this);
-
-      return regions;
-    },
-
-    // Empty all regions in the region manager, but
-    // leave them attached
-    emptyRegions: function() {
-      var regions = this.getRegions();
-      _.each(regions, function(region) {
-        region.empty();
-      }, this);
-
-      return regions;
-    },
-
-    // Destroy all regions and shut down the region
-    // manager entirely
-    destroy: function() {
-      this.removeRegions();
-      return Marionette.Controller.prototype.destroy.apply(this, arguments);
-    },
-
-    // internal method to store regions
-    _store: function(name, region) {
-      this._regions[name] = region;
-      this._setLength();
-    },
-
-    // internal method to remove a region
-    _remove: function(name, region) {
-      this.triggerMethod('before:remove:region', name, region);
-      region.empty();
-      region.stopListening();
-      delete this._regions[name];
-      this._setLength();
-      this.triggerMethod('remove:region', name, region);
-    },
-
-    // set the number of regions current held
-    _setLength: function() {
-      this.length = _.size(this._regions);
+  // Add multiple regions using an object literal or a
+  // function that returns an object literal, where
+  // each key becomes the region name, and each value is
+  // the region definition.
+  addRegions: function(regionDefinitions, defaults) {
+    if (_.isFunction(regionDefinitions)) {
+      regionDefinitions = regionDefinitions.apply(this, arguments);
     }
 
-  });
+    var regions = {};
 
-  Marionette.actAsCollection(RegionManager.prototype, '_regions');
+    _.each(regionDefinitions, function(definition, name) {
+      if (_.isString(definition)) {
+        definition = {selector: definition};
+      }
 
-  return RegionManager;
-})(Marionette);
+      if (definition.selector) {
+        definition = _.defaults({}, definition, defaults);
+      }
+
+      var region = this.addRegion(name, definition);
+      regions[name] = region;
+    }, this);
+
+    return regions;
+  },
+
+  // Add an individual region to the region manager,
+  // and return the region instance
+  addRegion: function(name, definition) {
+    var region;
+
+    if (definition instanceof Marionette.Region) {
+      region = definition;
+    } else {
+      region = Marionette.Region.buildRegion(definition, Marionette.Region);
+    }
+
+    this.triggerMethod('before:add:region', name, region);
+
+    this._store(name, region);
+
+    this.triggerMethod('add:region', name, region);
+    return region;
+  },
+
+  // Get a region by name
+  get: function(name) {
+    return this._regions[name];
+  },
+
+  // Gets all the regions contained within
+  // the `regionManager` instance.
+  getRegions: function(){
+    return _.clone(this._regions);
+  },
+
+  // Remove a region by name
+  removeRegion: function(name) {
+    var region = this._regions[name];
+    this._remove(name, region);
+
+    return region;
+  },
+
+  // Empty all regions in the region manager, and
+  // remove them
+  removeRegions: function() {
+    var regions = this.getRegions();
+    _.each(this._regions, function(region, name) {
+      this._remove(name, region);
+    }, this);
+
+    return regions;
+  },
+
+  // Empty all regions in the region manager, but
+  // leave them attached
+  emptyRegions: function() {
+    var regions = this.getRegions();
+    _.each(regions, function(region) {
+      region.empty();
+    }, this);
+
+    return regions;
+  },
+
+  // Destroy all regions and shut down the region
+  // manager entirely
+  destroy: function() {
+    this.removeRegions();
+    return Marionette.Controller.prototype.destroy.apply(this, arguments);
+  },
+
+  // internal method to store regions
+  _store: function(name, region) {
+    this._regions[name] = region;
+    this._setLength();
+  },
+
+  // internal method to remove a region
+  _remove: function(name, region) {
+    this.triggerMethod('before:remove:region', name, region);
+    region.empty();
+    region.stopListening();
+    delete this._regions[name];
+    this._setLength();
+    this.triggerMethod('remove:region', name, region);
+  },
+
+  // set the number of regions current held
+  _setLength: function() {
+    this.length = _.size(this._regions);
+  }
+});
+
+Marionette.actAsCollection(Marionette.RegionManager.prototype, '_regions');

--- a/test/unit/collection-view.reset.spec.js
+++ b/test/unit/collection-view.reset.spec.js
@@ -45,7 +45,7 @@ describe('collection view - reset', function() {
     });
 
     it('should remove the event handlers for the original children', function() {
-      expect(_.toArray(this.collectionView._listeningTo)).to.have.lengthOf(4);
+      expect(_.toArray(this.collectionView._listeningTo)).to.have.lengthOf(3);
     });
   });
 });


### PR DESCRIPTION
Ain't nothin' wrong with an IIFE, but by removing them our Object definitions become slightly more consistent across the codebase. Which is a big :+1: to me.

This gets rid of the IIFE around RegionManager per @paulovieira's suggestion. While I was at it, I also got rid of the one around `triggerMethod` (with the added bonus of removing an unnecessary argument passed to it).

Behaviors is the last one with an IIFE...but that code is basically a mess. It's a big enough refactor to merit its own PR.
