### PR TITLE
Removes slice from jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,15 +1,14 @@
 {
   "globals": {
-    "define"             : true,
-    "require"            : true,
-    "module"             : true,
-    "exports"            : true,
-    "$"                  : true,
-    "jQuery"             : true,
-    "_"                  : true,
-    "Backbone"           : true,
-    "Marionette"         : true,
-    "slice"              : true
+    "define"     : true,
+    "require"    : true,
+    "module"     : true,
+    "exports"    : true,
+    "$"          : true,
+    "jQuery"     : true,
+    "_"          : true,
+    "Backbone"   : true,
+    "Marionette" : true
   },
 
   "bitwise"       : true,


### PR DESCRIPTION
As of #1939 we no longer use the in-scope `slice` method. I also made the spacing a little less ridic.
