### PR TITLE
Defer the child rendering in CollectionView and CompositeView.

### DIFF
--- a/src/marionette.collectionview.js
+++ b/src/marionette.collectionview.js
@@ -108,7 +108,7 @@ Marionette.CollectionView = Marionette.View.extend({
   render: function() {
     this._ensureViewIsIntact();
     this.triggerMethod('before:render', this);
-    this._renderChildren();
+    _.defer(this._renderChildren.bind(this));
     this.triggerMethod('render', this);
     return this;
   },

--- a/src/marionette.compositeview.js
+++ b/src/marionette.compositeview.js
@@ -77,7 +77,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     this.triggerMethod('before:render', this);
 
     this._renderTemplate();
-    this._renderChildren();
+    _.defer(this._renderChildren.bind(this));
 
     this.triggerMethod('render', this);
     return this;


### PR DESCRIPTION
Notice:
I am not currently involved in the core development of marionette.
That said, in my use case there is no unwanted side effect to my fix.
In the case that this patch is dangerous, I would really appreciate the informed input. :)
Nevertheless, here's my patch.

---

We're already assuming that children are not rendered until they trigger their render event.
Deferring child rendering gives the heap a break and considerably speeds up rendering of huge collections if collection items have multiple behaviors attached to them.

In my specific case, I went from an average load time of 5sec on a large collection with a lot of behaviors to an almost instantaneous rendering.
