### PR TITLE
Create view, region, and regionManager parent references

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -118,6 +118,7 @@ Marionette.Application = Marionette.Object.extend({
   // Internal method to set up the region manager
   _initRegionManager: function() {
     this._regionManager = this.getRegionManager();
+    this._regionManager._parent = this;
 
     this.listenTo(this._regionManager, 'before:add:region', function() {
       Marionette._triggerMethod(this, 'before:add:region', arguments);

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -213,6 +213,8 @@ Marionette.CollectionView = Marionette.View.extend({
     // build the empty view
     var view = this.buildChildView(child, EmptyView, emptyViewOptions);
 
+    view._parent = this;
+
     // Proxy emptyView events
     this.proxyChildEvents(view);
 
@@ -271,6 +273,8 @@ Marionette.CollectionView = Marionette.View.extend({
     this._updateIndices(view, true, index);
 
     this._addChildView(view, index);
+
+    view._parent = this;
 
     return view;
   },
@@ -349,6 +353,7 @@ Marionette.CollectionView = Marionette.View.extend({
       if (view.destroy) { view.destroy(); }
       else if (view.remove) { view.remove(); }
 
+      delete view._parent;
       this.stopListening(view);
       this.children.remove(view);
       this.triggerMethod('remove:child', view);

--- a/src/layout-view.js
+++ b/src/layout-view.js
@@ -138,6 +138,7 @@ Marionette.LayoutView = Marionette.ItemView.extend({
   // and all regions in it
   _initRegionManager: function() {
     this.regionManager = this.getRegionManager();
+    this.regionManager._parent = this;
 
     this.listenTo(this.regionManager, 'before:add:region', function(name) {
       this.triggerMethod('before:add:region', name);

--- a/src/region-manager.js
+++ b/src/region-manager.js
@@ -51,6 +51,7 @@ Marionette.RegionManager = Marionette.Controller.extend({
 
     this.triggerMethod('before:add:region', name, region);
 
+    region._parent = this;
     this._store(name, region);
 
     this.triggerMethod('add:region', name, region);
@@ -113,6 +114,8 @@ Marionette.RegionManager = Marionette.Controller.extend({
     this.triggerMethod('before:remove:region', name, region);
     region.empty();
     region.stopListening();
+
+    delete region._parent;
     delete this._regions[name];
     this._setLength();
     this.triggerMethod('remove:region', name, region);

--- a/src/region.js
+++ b/src/region.js
@@ -1,4 +1,4 @@
-/* jshint maxcomplexity: 16, maxstatements: 40, maxlen: 120 */
+/* jshint maxcomplexity: 16, maxstatements: 45, maxlen: 120 */
 
 // Region
 // ------
@@ -65,6 +65,10 @@ Marionette.Region = Marionette.Object.extend({
       this.triggerMethod('before:swapOut', this.currentView);
     }
 
+    if (this.currentView) {
+      delete this.currentView._parent;
+    }
+
     if (_shouldDestroyView) {
       this.empty();
     }
@@ -78,6 +82,8 @@ Marionette.Region = Marionette.Object.extend({
       // we can not reuse it.
       view.once('destroy', this.empty, this);
       view.render();
+
+      view._parent = this;
 
       if (isChangingView) {
         this.triggerMethod('before:swap', view);

--- a/test/unit/application.app-regions.spec.js
+++ b/test/unit/application.app-regions.spec.js
@@ -13,6 +13,9 @@ describe('application regions', function() {
       this.fooRegion = new Marionette.Region({ el: '#foo-region' });
       this.barRegion = new Marionette.Region({ el: '#bar-region' });
 
+      this.fooRegion._parent = this.app._regionManager;
+      this.barRegion._parent = this.app._regionManager;
+
       this.app.addRegions({
         fooRegion: '#foo-region',
         barRegion: '#bar-region'
@@ -23,6 +26,10 @@ describe('application regions', function() {
     it('should initialize the regions', function() {
       expect(this.app.fooRegion).to.deep.equal(this.fooRegion);
       expect(this.app.barRegion).to.deep.equal(this.barRegion);
+    });
+
+    it('should create backlink to regionManager', function() {
+      expect(this.app._regionManager._parent).to.deep.equal(this.app);
     });
 
     it('should trigger a before:add:region event', function() {
@@ -63,6 +70,8 @@ describe('application regions', function() {
         el: this.fooSelector,
         fooOption: this.fooOption
       });
+
+      this.fooRegion._parent = this.app._regionManager;
 
       this.app.addRegions({
         fooRegion: {
@@ -329,6 +338,7 @@ describe('application regions', function() {
       this.FooRegion = Marionette.Region.extend({ el: this.fooSelector });
 
       this.fooRegion = new this.FooRegion();
+      this.fooRegion._parent = this.app._regionManager;
 
       this.app.addRegions({
         fooRegion: this.FooRegion
@@ -350,14 +360,22 @@ describe('application regions', function() {
 
   describe('when adding regions with a function', function() {
     beforeEach(function() {
+      this.app = new Marionette.Application();
+
       this.fooSelector = '#foo-region';
       this.barSelector = '#bar-region';
 
-      this.fooRegion = new Marionette.Region({ el: this.fooSelector });
-      this.BarRegion = Marionette.Region.extend();
-      this.barRegion = new this.BarRegion({ el: this.barSelector });
+      this.fooRegion = new Marionette.Region({
+        el: this.fooSelector
+      });
+      this.fooRegion._parent = this.app._regionManager;
 
-      this.app = new Marionette.Application();
+
+      this.BarRegion = Marionette.Region.extend();
+      this.barRegion = new this.BarRegion({
+        el: this.barSelector
+      });
+      this.barRegion._parent = this.app._regionManager;
 
       this.regionDefinition = this.sinon.stub().returns({
         fooRegion: this.fooSelector,
@@ -395,6 +413,8 @@ describe('application regions', function() {
     beforeEach(function() {
       this.app = new Marionette.Application();
       this.fooRegion = new Marionette.Region({ el: '#foo-region' });
+      this.fooRegion._parent = this.app._regionManager;
+
       this.app.addRegions({
         fooRegion: '#foo-region'
       });

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -151,6 +151,12 @@ describe('collection view', function() {
       expect(_.size(this.collectionView.children)).to.equal(2);
     });
 
+    it('children should reference collectionView', function() {
+      var children = this.collectionView._getImmediateChildren();
+      expect(children[0]._parent).to.deep.equal(this.collectionView);
+      expect(children[1]._parent).to.deep.equal(this.collectionView);
+    });
+
     it('should call "onBeforeRender" before rendering', function() {
       expect(this.collectionView.onBeforeRender).to.have.been.called;
     });
@@ -345,6 +351,12 @@ describe('collection view', function() {
 
     it('should trigger the childview:render event from the collectionView', function() {
       expect(this.childViewRender).to.have.been.called;
+    });
+
+    it('children should reference collectionView', function() {
+      var children = this.collectionView._getImmediateChildren();
+      expect(children[0]._parent).to.deep.equal(this.collectionView);
+      expect(children[1]._parent).to.deep.equal(this.collectionView);
     });
   });
 
@@ -778,6 +790,11 @@ describe('collection view', function() {
     it('should not retain any references to this view', function() {
       expect(_.size(this.collectionView.children)).to.equal(0);
     });
+
+    it('childView should be undefined', function() {
+      expect(this.childView).to.be.undefined;
+    });
+
   });
 
   describe('when the collection of a collection view is reset', function() {

--- a/test/unit/layout-view.dynamic-regions.spec.js
+++ b/test/unit/layout-view.dynamic-regions.spec.js
@@ -9,14 +9,17 @@ describe('layoutView - dynamic regions', function() {
 
   describe('when adding regions with a function', function() {
     beforeEach(function() {
+      this.app = new Marionette.Application();
+
       this.fooSelector = '#foo-region';
       this.barSelector = '#bar-region';
 
       this.fooRegion = new Marionette.Region({ el: this.fooSelector });
+      this.fooRegion._parent = this.app._regionManager;
+
       this.BarRegion = Marionette.Region.extend();
       this.barRegion = new this.BarRegion({ el: this.barSelector });
-
-      this.app = new Marionette.Application();
+      this.barRegion._parent = this.app._regionManager;
 
       this.regionDefinition = this.sinon.stub().returns({
         fooRegion: this.fooSelector,

--- a/test/unit/layout-view.spec.js
+++ b/test/unit/layout-view.spec.js
@@ -50,6 +50,12 @@ describe('layoutView', function() {
     it('should instantiate the specified region before initialize', function() {
       expect(this.regionOne).to.equal(this.layoutViewManager.regionOne);
     });
+
+    it('should create backlink with region manager', function() {
+      it('should instantiate the specified region managers', function() {
+        expect(this.layoutViewManager._parent).to.deep.equal(this.layoutViewManager);
+      });
+    });
   });
 
   describe('on instantiation with no regions defined', function() {

--- a/test/unit/region-manager.spec.js
+++ b/test/unit/region-manager.spec.js
@@ -242,9 +242,14 @@ describe('regionManager', function() {
       describe('without defaults', function() {
         beforeEach(function() {
           this.fooRegion = new Marionette.Region({ el: this.fooSelector });
+          this.fooRegion._parent = this.regionManager;
+
           this.barRegion = new Marionette.Region({ el: this.barSelector });
+          this.barRegion._parent = this.regionManager;
+
           this.BazRegion = Marionette.Region.extend();
           this.bazRegion = new this.BazRegion({ el: this.bazSelector });
+          this.bazRegion._parent = this.regionManager;
 
           this.regionDefinition = this.sinon.stub().returns({
             fooRegion: this.fooSelector,
@@ -288,7 +293,10 @@ describe('regionManager', function() {
           this.defaults = { regionClass: this.BazRegion };
 
           this.fooRegion = new this.BazRegion({ el: this.fooSelector });
+          this.fooRegion._parent = this.regionManager;
+
           this.barRegion = new this.BazRegion({ el: this.barSelector });
+          this.barRegion._parent = this.regionManager;
 
           this.regionDefinition = this.sinon.stub().returns({
             fooRegion: this.fooSelector,
@@ -386,6 +394,10 @@ describe('regionManager', function() {
 
     it('should adjust the length of the region manager by -1', function() {
       expect(this.regionManager.length).to.equal(0);
+    });
+
+    it('should not reference parent', function() {
+      expect(this.region._parent).to.be.undefined;
     });
 
     it('should return the region', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -172,6 +172,10 @@ describe('region', function() {
       expect(this.myRegion.hasView()).to.equal(true);
     });
 
+    it('should reference region', function() {
+      expect(this.view._parent).to.deep.equal(this.myRegion);
+    });
+
     it('should set $el and el', function() {
       expect(this.myRegion.$el[0]).to.equal(this.myRegion.el);
     });
@@ -279,6 +283,15 @@ describe('region', function() {
         expect(this.myRegion.hasView()).to.equal(true);
       });
 
+
+      it('should reference region', function() {
+        expect(this.view2._parent).to.deep.equal(this.myRegion);
+      });
+
+      it('old view should not reference region', function() {
+        expect(this.view._parent).to.be.undefined;
+      });
+
       it('should trigger a beforeSwapOut event for the region', function() {
         expect(this.onBeforeSwapOutSpy)
         .to.have.been.calledOnce
@@ -331,6 +344,10 @@ describe('region', function() {
           expect(this.view1.destroy.callCount).to.equal(0);
         });
 
+        it('view1 should not reference region', function() {
+          expect(this.view1._parent).to.be.undefined;
+        });
+
         it('should replace the content in the DOM', function() {
           expect(this.myRegion.$el).to.contain.$text('some more content');
           expect(this.myRegion.$el).not.to.contain.$text('some content');
@@ -344,6 +361,10 @@ describe('region', function() {
 
         it('should "destroy" the old view', function() {
           expect(this.view1.destroy).to.have.been.called;
+        });
+
+        it('view1 should not reference region', function() {
+          expect(this.view1._parent).to.be.undefined;
         });
       });
     });


### PR DESCRIPTION
**tl;dr:** Lets add parent references to our view layer so that we can traverse up the region trees.

``` js
view._parent  // => Region or CollectionView
region._parent // => RegionManager
regionManager._parent // => Layout or Application
```

---
### Overview

Marionette is the best platform for building rich layouts because of its amazing support for nesting layouts and lists and the flexibility of regions.

With that said, one of the themes to emerge out of the 2.x work is that while support for _building_ region trees is great, support for communicating up and down the tree is less less than ideal.

When communication breaks down, other patterns emerge as crutches. Two patterns that have become too prevelant are triggering events on shared models and the creation of over-specific channels for one off events. Communicating via models or channels are not inherently bad, but abusing them is. 

What Marionette needs is a great way communicating some events down the tree and some events up the tree.

@jmeas' work for `getNestedViews` will enable events to bubble down. The first event to be triggered will be `onAttach` and `onDetatch`

@samccone started work on a `regionEvents` feature, which would allow layouts to listen to children events. This was going to be implemented with proxied events. While this solution works, I think a better solution would be to maintain parent references. e.g. `view._region //=> region`.
#### Parent References

Parent references in the abstract will make it possible to traverse up our region trees. With parent references, it will be possible to start at a leaf node (View) and travel all the way up to the root (App). 
##### Why is this a good thing?
- It is the kind of backbone architecture I'd expect from a great layout manager.
- It will make event bubbling trivial to implement
- It will greatly improve the inspector and debugging. 
##### Story Time

Last thursday I was helping a friend debug a weird view event bug, after twenty minutes, we realized the view was a zombie and no longer attached to the region tree or the dom. If I could have checked the _region property we'd be done in a minute. If the Inspector could have a link to the parent container that'd be the shit!
##### Another way to look at Parent References

Few people know that Backbone keeps a `_collection` property on the model so that it's easy to reference the collection that a model belongs to. The `view._region`, `region._owner`, and `regionManager._owner` fields are similar back-references for internal purposes.
##### Counter-Arguments

I realize this could be seen as a controversial change even though it's internal to marionette. Curious to hear your thoughts. 

Some possible arguments I can come up with are:
- We don't _actually_ want to communicate events up the tree
- Developers will find a way to abuse the parent references for terrible anti-pattern practices
- We will add complexity, which will become a memory management nightmare

I think these arguments though are quickly disputed:
1. There are lots of events that we parent views listen to now. The problem is that setting up these event handlers is really round-about. 
2. While some developers could use these internal properties for evil, they're private and they're strongly discouraged.
3. We do add complexity by managing parent references. But the view layer is the main reason we exist as a framework, so we better do it right and if we don't someone else will.

---

Curious to hear your thoughts. 
Sorry for the book. I channeled my inner James Smith. :heart: 
