### PR TITLE
Doc fix: the order of Module initialize parameters

### DIFF
--- a/docs/marionette.module.md
+++ b/docs/marionette.module.md
@@ -241,7 +241,7 @@ var FooModule = Marionette.Module.extend({
   constructor: function(moduleName, app, options) {
   },
 
-  initialize: function(options, moduleName, app) {
+  initialize: function(moduleName, app, options) {
   },
 
   onStart: function(options) {


### PR DESCRIPTION
Correct the order of Module class initialize parameters, which should be moduleName, app, and options
