### PR TITLE
Added "v" before version in UrlRoot property

### DIFF
--- a/src/marionette.error.js
+++ b/src/marionette.error.js
@@ -1,7 +1,7 @@
 var errorProps = ['description', 'fileName', 'lineNumber', 'name', 'message', 'number'];
 
 Marionette.Error = Marionette.extend.call(Error, {
-  urlRoot: 'http://marionettejs.com/docs/' + Marionette.VERSION + '/',
+  urlRoot: 'http://marionettejs.com/docs/v' + Marionette.VERSION + '/',
 
   constructor: function(message, options) {
     if (_.isObject(message)) {


### PR DESCRIPTION
The new documentation expects the version segment to be prepended with `v`, otherwise it will go to a `404` page.
