### PR TITLE
Minor: simplify RegionManager emptyRegions

### DIFF
--- a/src/region-manager.js
+++ b/src/region-manager.js
@@ -91,10 +91,7 @@ Marionette.RegionManager = Marionette.Controller.extend({
   // leave them attached
   emptyRegions: function() {
     var regions = this.getRegions();
-    _.each(regions, function(region) {
-      region.empty();
-    }, this);
-
+    _.invoke(regions, 'empty');
     return regions;
   },
 


### PR DESCRIPTION
Just a minor simplification, may be slightly slower as invoke constructs an array of returns; however I don't think that should be an issue as this will unlikely (never?) be a hot method
