### PR TITLE
added onAfterRender to ItemView class

### DIFF
--- a/src/marionette.itemview.js
+++ b/src/marionette.itemview.js
@@ -52,6 +52,10 @@ Marionette.ItemView = Marionette.View.extend({
 
     this.triggerMethod('render', this);
 
+    _.defer(function(){
+      this.triggerMethod('after:render', this);
+    }.bind(this));
+
     return this;
   },
 


### PR DESCRIPTION
One problem I always had was using plugins like [iCheck](https://github.com/fronteed/iCheck/) in my code. The problem was I needed to call iCheck on my elements after everything was rendered and shown. But putting this piece of code doesn't work using `onRender`:

```
 var RadioRowItemView = Marionette.ItemView.extend({
  className: 'form-row',
  template: itemTemplate,
  onRender: function() {
    this.$('input[type="checkbox"]').iCheck();
  }
});
```

As I researched, I think the problem is onRender is called when element is rendered, not when its attached to DOM. So, I looked around to find a solution in Marionette but couldn't find any. Then I thought I could add a small feature to the `ItemView` class to handle these types of situations. A function like `onAfterRender`. I tested my code using `onAfterRender` and it works ok.

According to [Underscore](http://underscorejs.org/#defer): `Defers invoking the function until the current call stack has cleared`. So I thought we could call `onAfterRender` using `defer`:

```
render: function() {
    this._ensureViewIsIntact();

    this.triggerMethod('before:render', this);

    this._renderTemplate();
    this.bindUIElements();

    this.triggerMethod('render', this);

    _.defer(function(){
      this.triggerMethod('after:render', this);
    }.bind(this));

    return this;
  },
```

SpecRunner: passes: 855 failures: 0 duration: 4.17s

PS. iCheck is not the only plugin I had troubles with, I just don't remember which other plugins were there.
