### PR TITLE
Trigger method optimizations

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -120,25 +120,21 @@ Marionette.Application = Marionette.Object.extend({
     this._regionManager = this.getRegionManager();
 
     this.listenTo(this._regionManager, 'before:add:region', function() {
-      var args = _.toArray(arguments);
-      this.triggerMethod.apply(this, ['before:add:region'].concat(args));
+      Marionette._triggerMethod(this, 'before:add:region', arguments);
     });
 
     this.listenTo(this._regionManager, 'add:region', function(name, region) {
       this[name] = region;
-      var args = _.toArray(arguments);
-      this.triggerMethod.apply(this, ['add:region'].concat(args));
+      Marionette._triggerMethod(this, 'add:region', arguments);
     });
 
     this.listenTo(this._regionManager, 'before:remove:region', function() {
-      var args = _.toArray(arguments);
-      this.triggerMethod.apply(this, ['before:remove:region'].concat(args));
+      Marionette._triggerMethod(this, 'before:remove:region', arguments);
     });
 
     this.listenTo(this._regionManager, 'remove:region', function(name) {
       delete this[name];
-      var args = _.toArray(arguments);
-      this.triggerMethod.apply(this, ['remove:region'].concat(args));
+      Marionette._triggerMethod(this, 'remove:region', arguments);
     });
   },
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -20,9 +20,8 @@ Marionette.Controller.extend = Marionette.extend;
 // Ensure it can trigger events with Backbone.Events
 _.extend(Marionette.Controller.prototype, Backbone.Events, {
   destroy: function() {
-    var args = _.toArray(arguments);
-    this.triggerMethod.apply(this, ['before:destroy'].concat(args));
-    this.triggerMethod.apply(this, ['destroy'].concat(args));
+    Marionette._triggerMethod(this, 'before:destroy', arguments);
+    Marionette._triggerMethod(this, 'destroy', arguments);
 
     this.stopListening();
     this.off();

--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -1,15 +1,8 @@
 // Trigger Method
 // --------------
 
-// Trigger an event and/or a corresponding method name. Examples:
-//
-// `this.triggerMethod("foo")` will trigger the "foo" event and
-// call the "onFoo" method.
-//
-// `this.triggerMethod("foo:bar")` will trigger the "foo:bar" event and
-// call the "onFooBar" method.
-Marionette.triggerMethod = function(event) {
 
+Marionette._triggerMethod = (function() {
   // split the event name on the ":"
   var splitter = /(^|:)(\w)/gi;
 
@@ -19,23 +12,46 @@ Marionette.triggerMethod = function(event) {
     return eventName.toUpperCase();
   }
 
-  // get the method name from the event name
-  var methodName = 'on' + event.replace(splitter, getEventName);
-  var method = this[methodName];
-  var result;
+  return function(context, event, args) {
+    var noEventArg = arguments.length < 3;
+    if (noEventArg) {
+      args = event;
+      event = args[0];
+    }
 
-  // call the onMethodName if it exists
-  if (_.isFunction(method)) {
-    // pass all arguments, except the event name
-    result = method.apply(this, _.tail(arguments));
-  }
+    // get the method name from the event name
+    var methodName = 'on' + event.replace(splitter, getEventName);
+    var method = context[methodName];
+    var result;
 
-  // trigger the event, if a trigger method exists
-  if (_.isFunction(this.trigger)) {
-    this.trigger.apply(this, arguments);
-  }
+    // call the onMethodName if it exists
+    if (_.isFunction(method)) {
+      // pass all args, except the event name
+      result = method.apply(context, noEventArg ? _.rest(args) : args);
+    }
 
-  return result;
+    // trigger the event, if a trigger method exists
+    if (_.isFunction(context.trigger)) {
+      if (noEventArg + args.length > 1) {
+        context.trigger.apply(context, noEventArg ? args : [event].concat(_.rest(args, 0)));
+      } else {
+        context.trigger(event);
+      }
+    }
+
+    return result;
+  };
+})();
+
+// Trigger an event and/or a corresponding method name. Examples:
+//
+// `this.triggerMethod("foo")` will trigger the "foo" event and
+// call the "onFoo" method.
+//
+// `this.triggerMethod("foo:bar")` will trigger the "foo:bar" event and
+// call the "onFooBar" method.
+Marionette.triggerMethod = function(event) {
+  return Marionette._triggerMethod(this, arguments);
 };
 
 // triggerMethodOn invokes triggerMethod on a specific context

--- a/src/view.js
+++ b/src/view.js
@@ -276,12 +276,12 @@ Marionette.View = Backbone.View.extend({
   // import the `triggerMethod` to trigger events with corresponding
   // methods if the method exists
   triggerMethod: function() {
-    var triggerMethod = Marionette.triggerMethod;
-    var ret = triggerMethod.apply(this, arguments);
+    var triggerMethod = Marionette._triggerMethod;
+    var ret = triggerMethod(this, arguments);
     var behaviors = this._behaviors;
     // Use good ol' for as this is a very hot function
     for (var i = 0, length = behaviors && behaviors.length; i < length; i++) {
-      triggerMethod.apply(behaviors[i], arguments);
+      triggerMethod(behaviors[i], arguments);
     }
 
     return ret;

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -520,6 +520,10 @@ describe('collection view', function() {
       expect(_.size(this.collectionView.children)).to.equal(0);
     });
 
+    it('should not affect the underlying collection', function() {
+      expect(this.collection).to.have.length(1);
+    });
+
     it('should unbind any listener to custom view events', function() {
       expect(this.collectionView.stopListening).to.have.been.called;
     });

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -862,6 +862,8 @@ describe('region', function() {
       this.setFixtures('<div id="region"></div>');
       this.beforeEmptySpy = new sinon.spy();
       this.emptySpy = new sinon.spy();
+      this.onBeforeDestroy = this.sinon.stub();
+      this.onDestroy = this.sinon.stub();
 
       this.region = new Backbone.Marionette.Region({
         el: '#region'
@@ -876,6 +878,9 @@ describe('region', function() {
 
       this.view = new this.View();
 
+      this.view.on('before:destroy', this.onBeforeDestroy);
+      this.view.on('destroy', this.onDestroy);
+
       this.region.show(this.view);
       this.region.currentView.destroy();
     });
@@ -884,6 +889,14 @@ describe('region', function() {
       expect(this.beforeEmptySpy).to.have.been.calledOnce.and.calledWith(this.view);
       expect(this.emptySpy).to.have.been.calledOnce.calledWith(this.view);
       expect(this.region.currentView).to.be.undefined;
+    });
+
+    it('view "before:destroy" event is triggered once', function() {
+      expect(this.onBeforeDestroy).to.have.been.calledOnce;
+    });
+
+    it('view "destroy" event is triggered once', function() {
+      expect(this.onDestroy).to.have.been.calledOnce;
     });
   });
 


### PR DESCRIPTION
This pr adds a special internal function

``` js
Marionette._triggerMethod
```

How should I benchmark this. The only benchmark I've used so far is the reported running time of the test-suite. According to `mocha` post these changes the tests run `300ms - 400ms` faster (with a couple extra tests). Note: `triggerMethod` is called 7790 times in the specs

Feel free to reject as this really dirties the code, but I feel it may be worth it for such a hot function
