### PR TITLE
Allow non-DOM-backed regions

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -56,8 +56,12 @@ describe('region', function() {
 
   describe('when creating a new region and the "el" does not exist in DOM', function() {
     beforeEach(function() {
-      this.MyRegion = Backbone.Marionette.Region.extend({
+      this.MyConcreteRegion = Backbone.Marionette.Region.extend({
         el: '#not-existed-region'
+      });
+      this.MyEphemeralRegion = Backbone.Marionette.Region.extend({
+        el: '#not-existed-region',
+        _throwOnMissingRegionElement: function() {}
       });
 
       this.MyView = Backbone.Marionette.View.extend({
@@ -67,18 +71,26 @@ describe('region', function() {
       });
 
       this.setFixtures('<div id="region"></div>');
-      this.myRegion = new this.MyRegion();
+      this.myConcreteRegion = new this.MyConcreteRegion();
+      this.myEphemeralRegion = new this.MyEphemeralRegion();
     });
 
     describe('when showing a view', function() {
       it('should throw an exception saying an "el" doesnt exist in DOM', function() {
         expect(function(){
-          this.myRegion.show(new this.MyView());
+          this.myConcreteRegion.show(new this.MyView());
         }.bind(this)).to.throw('An "el" #not-existed-region must exist in DOM');
       });
 
+      it('should not throw an exception', function() {
+        expect(function(){
+          this.myEphemeralRegion.show(new this.MyView());
+        }.bind(this)).not.to.throw();
+      });
+
       it('should not have a view', function() {
-        expect(this.myRegion.hasView()).to.equal(false);
+        expect(this.myConcreteRegion.hasView()).to.be.false;
+        expect(this.myEphemeralRegion.hasView()).to.be.false;
       });
     });
   });

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -1,4 +1,4 @@
-/* jshint maxcomplexity: 10, maxstatements: 29 */
+/* jshint maxcomplexity: 10, maxstatements: 30 */
 
 // Region
 // ------
@@ -131,7 +131,9 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
   // re-rendered if it's already shown in the region.
 
   show: function(view, options){
-    this._ensureElement();
+    if (!this._ensureElement()) {
+      return;
+    }
 
     var showOptions     = options || {};
     var isDifferentView = view !== this.currentView;
@@ -203,8 +205,10 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
     }
 
     if (!this.$el || this.$el.length === 0) {
-      throw new Marionette.Error('An "el" ' + this.$el.selector + ' must exist in DOM');
+      this._throwOnMissingRegionElement();
+      return false;
     }
+    return true;
   },
 
   // Override this method to change how the region finds the
@@ -281,6 +285,12 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     delete this.$el;
     return this;
+  },
+
+  // Throws an error when showing a view in a region which
+  // is not backed by a DOM element.
+  _throwOnMissingRegionElement: function () {
+    throw new Marionette.Error('An "el" ' + this.$el.selector + ' must exist in DOM');
   },
 
   // Proxy `getOption` to enable getting options from this or this.options by name.


### PR DESCRIPTION
- Factor error-throwing out of `_ensureElement` to `_throwOnMissingRegionElement`
- Spec overriding `_throwOnMissingRegionElement` to no-op
- `_ensureElement` returns boolean, indicating whether or not element is available
- `Region#show` early-terminates on missing element
- Increase jshint maxstatements allotment
