### PR TITLE
Allow non-DOM-backed regions with `allowMissingEl`

### DIFF
--- a/api/region.jsdoc
+++ b/api/region.jsdoc
@@ -152,8 +152,9 @@ properties:
 functions:
   buildRegion: |
     Returns a new Region from the `regionConfig` object. This is used by the RegionManager to
-    create a new Region instance.
-    
+    create a new Region instance. Any options supplied in the `regionConfig` other than
+    `selector` and `regionClass` are provided as the instance's `options`.
+
     @api public
     @static
     @param {Object} regionConfig
@@ -189,6 +190,12 @@ functions:
     Shows `newView` inside the region if `newView` is not already shown within the region. The previous view, if one exists,
     will be destroyed in this process. The `show` methods fires the show and swap triggerMethods.
     
+    By default, a region must have a containing element in the DOM, and if this element is not available, an error
+    is thrown. In some instances it may be desirable to allow a view to define a region which its template does not
+    provide, such as regions defined by a parent `LayoutView` class that are used by only some of its subclasses.
+    In these instances, the region should be defined with the `allowMissingEl` option, suppressing the missing
+    element error and causing `show` calls to be treated as no-ops.
+
     You can modify the behavior of `show` by passing in an options object.
     
     `preventDestroy`

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -111,7 +111,16 @@ not need to supply a `selector` or `el` property on the object
 literal.
 
 Any other properties you set on the object literal will be
-used as options passed to the region instance.
+used as options passed to the region instance, including the
+`allowMissingEl` option.
+
+Ordinarily regions enforce the presence of a backing DOM element.
+In some instances it may be desirable to allow regions to be
+instantiated and used without an element, such as when regions
+defined by a parent `LayoutView` class are used by only some of its
+subclasses. In these instances, the region can be defined with the
+`allowMissingEl` option, suppressing the missing element error and
+causing `show` calls to the region to be treated as no-ops.
 
 ```js
 var MyRegion      = Marionette.Region.extend();

--- a/src/region.js
+++ b/src/region.js
@@ -1,4 +1,4 @@
-/* jshint maxcomplexity: 10, maxstatements: 29, maxlen: 120 */
+/* jshint maxcomplexity: 10, maxstatements: 30, maxlen: 120 */
 
 // Region
 // ------
@@ -38,7 +38,10 @@ Marionette.Region = Marionette.Object.extend({
   // The `forceShow` option can be used to force a view to be
   // re-rendered if it's already shown in the region.
   show: function(view, options){
-    this._ensureElement();
+    if (!this._ensureElement()) {
+      return;
+    }
+
     this._ensureViewIsIntact(view);
 
     var showOptions     = options || {};
@@ -110,8 +113,13 @@ Marionette.Region = Marionette.Object.extend({
     }
 
     if (!this.$el || this.$el.length === 0) {
-      throw new Marionette.Error('An "el" ' + this.$el.selector + ' must exist in DOM');
+      if (this.getOption('allowMissingEl')) {
+        return false;
+      } else {
+        throw new Marionette.Error('An "el" ' + this.$el.selector + ' must exist in DOM');
+      }
     }
+    return true;
   },
 
   _ensureViewIsIntact: function(view) {
@@ -219,13 +227,14 @@ Marionette.Region = Marionette.Object.extend({
   // and a default region class to use if none is specified in the config.
   //
   // The config object should either be a string as a jQuery DOM selector,
-  // a Region class directly, or an object literal that specifies both
-  // a selector and regionClass:
+  // a Region class directly, or an object literal that specifies a selector,
+  // a custom regionClass, and any options to be supplied to the region:
   //
   // ```js
   // {
   //   selector: "#foo",
-  //   regionClass: MyCustomRegion
+  //   regionClass: MyCustomRegion,
+  //   allowMissingEl: false
   // }
   // ```
   //
@@ -255,7 +264,7 @@ Marionette.Region = Marionette.Object.extend({
 
   // Build the region from a configuration object
   // ```js
-  // { selector: '#foo', regionClass: FooRegion }
+  // { selector: '#foo', regionClass: FooRegion, allowMissingEl: false }
   // ```
   _buildRegionFromObject: function(regionConfig, DefaultRegionClass) {
     var RegionClass = regionConfig.regionClass || DefaultRegionClass;

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -65,20 +65,48 @@ describe('region', function() {
           $(this.el).html('some content');
         }
       });
+      this.myView = new this.MyView();
 
       this.setFixtures('<div id="region"></div>');
-      this.myRegion = new this.MyRegion();
     });
 
     describe('when showing a view', function() {
-      it('should throw an exception saying an "el" doesnt exist in DOM', function() {
-        expect(function(){
-          this.myRegion.show(new this.MyView());
-        }.bind(this)).to.throw('An "el" #not-existed-region must exist in DOM');
+      describe('when allowMissingEl is not set', function() {
+        beforeEach(function() {
+          this.myRegion = new this.MyRegion();
+        });
+
+        it('should throw an exception saying an "el" doesnt exist in DOM', function() {
+          expect(function(){
+            this.myRegion.show(new this.MyView());
+          }.bind(this)).to.throw('An "el" #not-existed-region must exist in DOM');
+        });
+
+        it('should not have a view', function() {
+          expect(this.myRegion.hasView()).to.be.false;
+        });
       });
 
-      it('should not have a view', function() {
-        expect(this.myRegion.hasView()).to.equal(false);
+      describe('when allowMissingEl is set', function() {
+        beforeEach(function() {
+          this.myRegion = new this.MyRegion({ allowMissingEl: true });
+        });
+
+        it('should not throw an exception', function() {
+          expect(function(){
+            this.myRegion.show(new this.MyView());
+          }.bind(this)).not.to.throw();
+        });
+
+        it('should not have a view', function() {
+          expect(this.myRegion.hasView()).to.be.false;
+        });
+
+        it('should not render the view', function() {
+          sinon.spy(this.myView, 'render');
+          this.myRegion.show(this.myView);
+          expect(this.myView.render).not.to.have.been.called;
+        });
       });
     });
   });


### PR DESCRIPTION
- `allowMissingEl` option is respected by `_ensureElement`
- `_ensureElement` returns boolean, indicating whether or not element is available
- `Region#show` early-terminates on missing element
- Increase jshint maxstatements allotment for `Region#show`
