### PR TITLE
Fix wrong variable usage in removeRegion

### DIFF
--- a/src/marionette.regionManager.js
+++ b/src/marionette.regionManager.js
@@ -79,7 +79,7 @@ Marionette.RegionManager = (function(Marionette) {
     // remove them
     removeRegions: function() {
       var regions = this.getRegions();
-      _.each(this._regions, function(region, name) {
+      _.each(regions, function(region, name) {
         this._remove(name, region);
       }, this);
 


### PR DESCRIPTION
This inconsistency is now fixed. 
In a complicated use case scenario with listeners on view `destroy` events it led to some hard to track errors.
