### PR TITLE
Remove unused ItemView.destroy method

### DIFF
--- a/src/item-view.js
+++ b/src/item-view.js
@@ -101,13 +101,5 @@ Marionette.ItemView = Marionette.View.extend({
     this.$el.html(html);
 
     return this;
-  },
-
-  // Override the default destroy event to add a few
-  // more events that are triggered.
-  destroy: function() {
-    if (this.isDestroyed) { return; }
-
-    return Marionette.View.prototype.destroy.apply(this, arguments);
   }
 });


### PR DESCRIPTION
Completely handled already by the inherited destroy method
