### PR TITLE
Documentation fix: broken link to Marionette.View

### DIFF
--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -260,4 +260,4 @@ Marionette.CompositeView.extend({
 });
 ```
 
-For more information, see the [Marionette.View](./marionette.view.md) documentation.
+For more information, see the [Marionette.View](./marionette.view.html) documentation.


### PR DESCRIPTION
Fix link to point to marionette.view.html rather than marionette.view.md.
