### PR TITLE
Update Marionette.Renderer to render template with provided context

### DIFF
--- a/src/marionette.renderer.js
+++ b/src/marionette.renderer.js
@@ -9,7 +9,7 @@ Marionette.Renderer = {
   // passed to the `TemplateCache` object to retrieve the
   // template function. Override this method to provide your own
   // custom rendering and template handling for all of Marionette.
-  render: function(template, data) {
+  render: function(template, data, context) {
     if (!template) {
       throw new Marionette.Error({
         name: 'TemplateNotFoundError',
@@ -24,6 +24,6 @@ Marionette.Renderer = {
       templateFunc = Marionette.TemplateCache.get(template);
     }
 
-    return templateFunc(data);
+    return templateFunc.call(context, data);
   }
 };


### PR DESCRIPTION
I am not sure why it is not added in the current code base. In Marionette.ItemView#_renderTemplate

```
var html = Marionette.Renderer.render(template, data, this);
```

So I think it makes sense that we apply the provided context to the template function in Marionette.Renderer 
