### PR TITLE
Update Marionette.Renderer to render template with provided context

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -9,7 +9,7 @@ Marionette.Renderer = {
   // passed to the `TemplateCache` object to retrieve the
   // template function. Override this method to provide your own
   // custom rendering and template handling for all of Marionette.
-  render: function(template, data) {
+  render: function(template, data, context) {
     if (!template) {
       throw new Marionette.Error({
         name: 'TemplateNotFoundError',
@@ -24,6 +24,6 @@ Marionette.Renderer = {
       templateFunc = Marionette.TemplateCache.get(template);
     }
 
-    return templateFunc(data);
+    return templateFunc.call(context, data);
   }
 };

--- a/test/unit/renderer.spec.js
+++ b/test/unit/renderer.spec.js
@@ -75,4 +75,22 @@ describe('renderer', function() {
       expect(this.renderSpy).to.have.been.calledOnce.and.returned(this.data.foo);
     });
   });
+
+  describe('when using context in `render` method', function() {
+    beforeEach(function() {
+      this.view = new Marionette.ItemView({
+        foo: 'bar',
+
+        template: function() {
+          return this.getOption('foo');
+        }
+      });
+
+      this.result = this.view.render().$el.html();
+    });
+
+    it('should render ItemView using its context', function() {
+      expect(this.result).to.equal('bar');
+    });
+  });
 });


### PR DESCRIPTION
I am not sure why it is not added in the current code base. In Marionette.ItemView#_renderTemplate

```
var html = Marionette.Renderer.render(template, data, this);
```

So I think it makes sense that we apply the provided context to the template function in Marionette.Renderer
