### PR TITLE
Remove check/error of childView of CompositeView

### DIFF
--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -43,13 +43,6 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   getChildView: function(child) {
     var childView = this.getOption('childView') || this.constructor;
 
-    if (!childView) {
-      throw new Marionette.Error({
-        name: 'NoChildViewError',
-        message: 'A "childView" must be specified'
-      });
-    }
-
     return childView;
   },
 


### PR DESCRIPTION
CompositeView will always default to itself which is never falsey.  This error has never been thrown at least back to Oct 2012.

https://github.com/marionettejs/backbone.marionette/blob/f955f271f7323ba5f5d708fc9f6be568af22949d/src/marionette.compositeview.js#L29
