### PR TITLE
Remove destroy listener from previous view on region show.

### DIFF
--- a/spec/javascripts/region.spec.js
+++ b/spec/javascripts/region.spec.js
@@ -290,6 +290,8 @@ describe('region', function() {
         this.myRegion = new this.MyRegion();
 
         this.sinon.spy(this.view1, 'destroy');
+        this.sinon.spy(this.view1, 'off');
+        this.sinon.spy(this.view2, 'destroy');
 
         this.myRegion.show(this.view1);
       });
@@ -301,6 +303,16 @@ describe('region', function() {
 
         it('shouldnt "destroy" the old view', function() {
           expect(this.view1.destroy.callCount).to.equal(0);
+        });
+
+        it('should remove destroy listener from old view', function() {
+          expect(this.view1.off).to.be.calledOnce;
+        });
+
+        it('should not empty region after destorying old view', function() {
+          expect(this.view1.off).to.be.calledOnce;
+          this.view1.destroy();
+          expect(this.view2.destroy).not.to.have.been.called;
         });
 
         it('should replace the content in the DOM', function() {

--- a/src/marionette.region.js
+++ b/src/marionette.region.js
@@ -1,4 +1,4 @@
-/* jshint maxcomplexity: 10, maxstatements: 29 */
+/* jshint maxcomplexity: 10, maxstatements: 30 */
 
 // Region
 // ------
@@ -156,6 +156,12 @@ _.extend(Marionette.Region.prototype, Backbone.Events, {
 
     if (_shouldDestroyView) {
       this.empty();
+
+    // A `destroy` event is attached to the clean up manually removed views.
+    // We need to detach this event when a new view is going to be shown as it
+    // is no longer relevant.
+    } else if (isChangingView && _shouldShowView) {
+      this.currentView.off('destroy', this.empty, this);
     }
 
     if (_shouldShowView) {


### PR DESCRIPTION
Fix for https://github.com/marionettejs/backbone.marionette/issues/2079
