### PR TITLE
Exclude generated coverage files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *.swo
 *.orig
+.idea
 tmp/
 ext/
 node_modules/
@@ -12,3 +13,4 @@ bower_components/
 .grunt
 reports
 jsdoc
+test/src/


### PR DESCRIPTION
`npm run coverage` generates a compiled `test/src` directory
