### PR TITLE
Remove deleted test from SpecRunner

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -97,7 +97,6 @@
     <script src="test/unit/behaviors.spec.js"></script>
     <script src="test/unit/bind-entity-events.spec.js"></script>
     <script src="test/unit/callbacks.spec.js"></script>
-    <script src="test/unit/collection-view.attach-to-dom.spec.js"></script>
     <script src="test/unit/collection-view.empty-view.spec.js"></script>
     <script src="test/unit/collection-view.item-view-options.spec.js"></script>
     <script src="test/unit/collection-view.reset.spec.js"></script>


### PR DESCRIPTION
I removed the test in
https://github.com/marionettejs/backbone.marionette/pull/2095

But I didn't remove it from the SpecRunner.html file :cry:
