### PR TITLE
Fixes broken link to marionette.functions

### DIFF
--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -56,7 +56,7 @@ john.graduate();
 ### getOption
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
 
-More information [getOption](./marionette.functions.md).
+More information [getOption](./marionette.functions.html).
 
 ### bindEntityEvents
 Helps bind a backbone "entity" to methods on a target object. More information [bindEntityEvents](./marionette.functions.md).


### PR DESCRIPTION
The link referenced ./marionette.functions.md. It now references ./marionette.functions.html. We should check the docs for other places this may exist. I noticed the last commit merged in resolved a similar broken link.
