### PR TITLE
Refactor behavior event collision solution.

### DIFF
--- a/src/behaviors.js
+++ b/src/behaviors.js
@@ -9,6 +9,8 @@
 // method for things to work properly.
 
 Marionette.Behaviors = (function(Marionette, _) {
+  // Borrow event splitter from Backbone
+  var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
   function Behaviors(view, behaviors) {
 
@@ -53,21 +55,24 @@ Marionette.Behaviors = (function(Marionette, _) {
         // a user to use the @ui. syntax.
         behaviorEvents = Marionette.normalizeUIKeys(behaviorEvents, ui);
 
-        _.each(_.keys(behaviorEvents), function(key) {
-          // Append white-space at the end of each key to prevent behavior key collisions.
-          // This is relying on the fact that backbone events considers "click .foo" the same as
-          // "click .foo ".
+        _.each(_.keys(behaviorEvents), function(key, j) {
+          var match     = key.match(delegateEventSplitter);
 
-          // +2 is used because new Array(1) or 0 is "" and not " "
-          var whitespace = (new Array(i + 2)).join(' ');
-          var eventKey   = key + whitespace;
-          var handler    = _.isFunction(behaviorEvents[key]) ? behaviorEvents[key] : b[behaviorEvents[key]];
+          // Set event name to be namespaced using the view cid,
+          // the behavior index, and the behavior event index
+          // to generate a non colliding event namespace
+          // http://api.jquery.com/event.namespace/
+          var eventName = match[1] + '.' + [this.cid, i, j, ' '].join(''),
+              selector  = match[2];
+
+          var eventKey  = eventName + selector;
+          var handler   = _.isFunction(behaviorEvents[key]) ? behaviorEvents[key] : b[behaviorEvents[key]];
 
           _events[eventKey] = _.bind(handler, b);
-        });
+        }, this);
 
         _behaviorsEvents = _.extend(_behaviorsEvents, _events);
-      });
+      }, this);
 
       return _behaviorsEvents;
     }


### PR DESCRIPTION
After a talking with @jasonlaster after bbconf about his interesting
discussion with @jashkenas dealing with behaviors and our hackish approach to
resolving key collisions, I have implemented the new solution.

This implementation takes advantage of jquery's namespaced events.
http://api.jquery.com/event.namespace/ It is a feature that while
targeted at jquery plugin authors fits our needs perfectly. Allowing us
to generate a namespaced non-colliding event key that just works.

Backbone actually already does this to an extent under the hood with

``` js
delegate: function(eventName, selector, listener) {
  this.$el.on(eventName + '.delegateEvents' + this.cid, selector, listener);
}
```

So here we are joining the club.
