### PR TITLE
[Fix] event listener unsetting on region swap.

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -195,15 +195,8 @@ Marionette.Region = Marionette.Object.extend({
   // Override this method to change how the new view is
   // appended to the `$el` that the region is managing
   attachHtml: function(view) {
-    // empty the node and append new view
-    // We can not use `.innerHTML` due to the fact that IE
-    // will not let us clear the html of tables and selects.
-    // We also do not want to use the more declarative `empty` method
-    // that jquery exposes since `.empty` loops over all of the children DOM
-    // nodes and unsets the listeners on each node. While this seems like
-    // a desirable thing, it comes at quite a high perf cost. For that reason
-    // we are simply clearing the html contents of the node.
-    this.$el.html('');
+    this.$el.contents().detach();
+
     this.el.appendChild(view.el);
   },
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -123,6 +123,9 @@ describe('region', function() {
       });
 
       this.MyView = Backbone.View.extend({
+        events: {
+          'click': function(){}
+        },
         render: function() {
           $(this.el).html('some content');
         },
@@ -424,6 +427,11 @@ describe('region', function() {
         it('should replace the content in the DOM', function() {
           expect(this.myRegion.$el).to.contain.$text('some more content');
           expect(this.myRegion.$el).not.to.contain.$text('some content');
+        });
+
+        // https://github.com/marionettejs/backbone.marionette/issues/2159#issue-52745401
+        it('should still have view1\'s, event bindings', function() {
+          expect(jQuery._data(this.view.el, "events" ).click).to.be.defined;
         });
       });
 


### PR DESCRIPTION
### TLDR

Using jquery's `.html` or `.empty` removes event listeners from all nodes that are removed. In the case of marionette this is problematic in that if you are using `preventDestroy` when swapping views in regions your old view would have its DOM events undelegated, thus forcing you to  rebind your events manually. (this was the bug)

Fixes #2159
