### PR TITLE
Use bind instead of partial in TriggerHandlersForBehaviours

### DIFF
--- a/src/behaviors.js
+++ b/src/behaviors.js
@@ -153,7 +153,7 @@ Marionette.Behaviors = (function(Marionette, _) {
 
       triggersHash = Marionette.normalizeUIKeys(triggersHash, ui);
 
-      _.each(triggersHash, _.partial(this._setHandlerForBehavior, behavior, i), this);
+      _.each(triggersHash, _.bind(this._setHandlerForBehavior, this, behavior, i));
     },
 
     // Internal method to create and assign the trigger handler for a given


### PR DESCRIPTION
[minor as hell] This is serviced slightly more naturally by bind and will be slightly faster going forwards (one less `.call`)
