### PR TITLE
Be consistent with _.each iteration

### DIFF
--- a/src/behaviors.js
+++ b/src/behaviors.js
@@ -55,18 +55,19 @@ Marionette.Behaviors = (function(Marionette, _) {
         // a user to use the @ui. syntax.
         behaviorEvents = Marionette.normalizeUIKeys(behaviorEvents, ui);
 
-        _.each(_.keys(behaviorEvents), function(key, j) {
+        var j = 0;
+        _.each(behaviorEvents, function(behaviour, key) {
           var match     = key.match(delegateEventSplitter);
 
           // Set event name to be namespaced using the view cid,
           // the behavior index, and the behavior event index
           // to generate a non colliding event namespace
           // http://api.jquery.com/event.namespace/
-          var eventName = match[1] + '.' + [this.cid, i, j, ' '].join(''),
+          var eventName = match[1] + '.' + [this.cid, i, j++, ' '].join(''),
               selector  = match[2];
 
           var eventKey  = eventName + selector;
-          var handler   = _.isFunction(behaviorEvents[key]) ? behaviorEvents[key] : b[behaviorEvents[key]];
+          var handler   = _.isFunction(behaviour) ? behaviour : b[behaviour];
 
           _events[eventKey] = _.bind(handler, b);
         }, this);

--- a/src/view.js
+++ b/src/view.js
@@ -204,8 +204,7 @@ Marionette.View = Backbone.View.extend({
     this.ui = {};
 
     // bind each of the selectors
-    _.each(_.keys(bindings), function(key) {
-      var selector = bindings[key];
+    _.each(bindings, function(selector, key) {
       this.ui[key] = this.$(selector);
     }, this);
   },


### PR DESCRIPTION
`_.each` should be more rigid going forward (jashkenas/underscore#1990) (both underscore and lodash will be using similar check in their respective next versions).

Along with https://github.com/megawac/backbone.marionette/commit/504eca1710b59394c3fe6b921bbc80fdf814b5f6 this fixes #2108. Thats all there is to it
