### PR TITLE
Updated docs and source to correct event naming

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -498,7 +498,7 @@ myView.render();
 
 ### "render" event
 
-A "collection:rendered" / `onCollectionRendered` event will also be fired. This allows you to
+A "render:collection" / `onRenderCollection` event will also be fired. This allows you to
 add more than one callback to execute after the view is rendered,
 and allows parent views and other parts of the application to
 know that the view was rendered.

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -203,7 +203,7 @@ Marionette.CollectionView = Marionette.View.extend({
   },
 
   // Render and show the emptyView. Similar to addChild method
-  // but "child:added" events are not fired, and the event from
+  // but "add:child" events are not fired, and the event from
   // emptyView are not forwarded
   addEmptyView: function(child, EmptyView) {
 


### PR DESCRIPTION
Applies to #2155

**marionette.collectionview.md**
Updated event naming in docs from "collection:rendered" -> "render:collection" along with the associated "on" version of the event (i.e. onCollectionRendered -> onRenderCollection)

**collection-view.js**
Updated event naming in source comments  from "child:added" -> "add:child"
