### PR TITLE
Fixing broken links in docs.

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -66,7 +66,7 @@ add them after the app is started, they will run immediately.
 ## Application Event
 
 The `Application` object raises a few events during its lifecycle, using the
-[Marionette.triggerMethod](./marionette.functions.md) function. These events
+[Marionette.triggerMethod](./marionette.functions.html) function. These events
 can be used to do additional processing of your application. For example, you
 may want to pre-process some data just before initialization happens. Or you may
 want to wait until your entire application is initialized to start the
@@ -265,4 +265,4 @@ MyApp.removeRegion('someRegion');
 Removing a region will properly close it before removing it from the
 application object.
 
-For more information on regions, see [the region documentation](./marionette.region.md)
+For more information on regions, see [the region documentation](./marionette.region.html)

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -6,12 +6,12 @@ then append the results of the item view's `el` to the collection view's
 `el`.
 
 CollectionView extends directly from Marionette.View. Please see
-[the Marionette.View documentation](marionette.view.md)
+[the Marionette.View documentation](./marionette.view.html)
 for more information on available features and functionality.
 
 Additionally, interactions with Marionette.Region
 will provide features such as `onShow` callbacks, etc. Please see
-[the Region documentation](marionette.region.md) for more information.
+[the Region documentation](./marionette.region.html) for more information.
 
 ## Documentation Index
 
@@ -401,7 +401,7 @@ Backbone.Marionette.CollectionView.extend({
 
 There are several events that will be triggered during the life
 of a collection view. Each of these events is called with the
-[Marionette.triggerMethod](./marionette.functions.md) function,
+[Marionette.triggerMethod](./marionette.functions.html) function,
 which calls a corresponding "on{EventName}" method on the
 view instance (see [above](#callback-methods)).
 

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -6,12 +6,12 @@ branch and leaf in a tree structure, or for scenarios where a
 collection needs to be rendered within a wrapper template.
 
 Please see
-[the Marionette.CollectionView documentation](marionette.collectionview.md)
+[the Marionette.CollectionView documentation](./marionette.collectionview.html)
 for more information on available features and functionality.
 
 Additionally, interactions with Marionette.Region
 will provide features such as `onShow` callbacks, etc. Please see
-[the Region documentation](marionette.region.md) for more information.
+[the Region documentation](./marionette.region.html) for more information.
 
 ## Example Usage: Tree View
 
@@ -163,7 +163,7 @@ Sometimes the `itemViewContainer` configuration is insuficient for
 specifying where the itemView instance should be placed. If this is the
 case, you can override the `appendHtml` method with your own implementation.
 
-For more information on this method, see the [CollectionView's documentation](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.collectionview.md).
+For more information on this method, see the [CollectionView's documentation](./marionette.collectionview.html).
 
 ## Recursive By Default
 
@@ -199,7 +199,7 @@ You can also manually re-render either or both of them:
 ## Events And Callbacks
 
 During the course of rendering a composite, several events will
-be triggered. These events are triggered with the [Marionette.triggerMethod](./marionette.functions.md)
+be triggered. These events are triggered with the [Marionette.triggerMethod](./marionette.functions.html)
 function, which calls a corresponding "on{EventName}" method on the view.
 
 * "composite:model:rendered" / `onCompositeModelRendered` - after the `modelView` has been rendered
@@ -249,4 +249,4 @@ Marionette.CompositeView.extend({
 });
 ```
 
-For more information, see the [Marionette.View](./marionette.view.md) documentation.
+For more information, see the [Marionette.View](./marionette.view.html) documentation.

--- a/docs/marionette.itemview.md
+++ b/docs/marionette.itemview.md
@@ -5,12 +5,12 @@ An `ItemView` is a view that represents a single item. That item may be a
 will be treated as a single item.
 
 ItemView extends directly from Marionette.View. Please see
-[the Marionette.View documentation](marionette.view.md)
+[the Marionette.View documentation](./marionette.view.html)
 for more information on available features and functionality.
 
 Additionally, interactions with Marionette.Region
 will provide features such as `onShow` callbacks, etc. Please see
-[the Region documentation](marionette.region.md) for more information.
+[the Region documentation](./marionette.region.html) for more information.
 
 ## Documentation Index
 
@@ -115,7 +115,7 @@ otherwise interacted with, see the blog post on
 
 There are several events and callback methods that are called
 for an ItemView. These events and methods are triggered with the
-[Marionette.triggerMethod](./marionette.functions.md) function, which
+[Marionette.triggerMethod](./marionette.functions.html) function, which
 triggers the event and a corresponding "on{EventName}" method.
 
 ### "before:render" / onBeforeRender event
@@ -243,7 +243,7 @@ Backbone.Marionette.ItemView.extend({
 
 ## Organizing UI Elements
 
-As documented in [Marionette.View](./marionette.view.md), you can specify a `ui` hash in your `view` that
+As documented in [Marionette.View](./marionette.view.html), you can specify a `ui` hash in your `view` that
 maps UI elements by their jQuery selectors. This is especially useful if you access the
 same UI element more than once in your view's code. Instead of
 duplicating the selector, you can simply reference it by
@@ -284,4 +284,4 @@ Marionette.ItemView.extend({
 });
 ```
 
-For more information, see the [Marionette.View](./marionette.view.md) documentation.
+For more information, see the [Marionette.View](./marionette.view.html) documentation.

--- a/docs/marionette.layout.md
+++ b/docs/marionette.layout.md
@@ -14,12 +14,12 @@ For a more in-depth discussion on Layouts, see the blog post
 [Manage Layouts And Nested Views With Backbone.Marionette](http://lostechies.com/derickbailey/2012/03/22/managing-layouts-and-nested-views-with-backbone-marionette/)
 
 Please see
-[the Marionette.ItemView documentation](marionette.itemview.md)
+[the Marionette.ItemView documentation](./marionette.itemview.html)
 for more information on available features and functionality.
 
 Additionally, interactions with Marionette.Region
 will provide features such as `onShow` callbacks, etc. Please see
-[the Region documentation](marionette.region.md) for more information.
+[the Region documentation](./marionette.region.html) for more information.
 
 ## Documentation Index
 

--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -6,7 +6,7 @@ application. The RegionManager is intended to be
 used by other objects, to facilitate the addition,
 storage, retrieval, and removal of regions from
 that object. For examples of how it can be used,
-see the [Marionette.Application](./marionette.application.md) and [Marionette.Layout](./marionette.layout.md)
+see the [Marionette.Application](./marionette.application.html) and [Marionette.Layout](./marionette.layout.html)
 objects.
 
 ## Documentation Index

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -62,7 +62,7 @@ this.listenTo(this.collection, "add", _.bind(this.reconcileCollection, this.coll
 
 * "show" / `onShow` - Called on the view instance when the view has been rendered and displayed.
 
-This event can be used to react to when a view has been shown via a [region](marionette.region.md).
+This event can be used to react to when a view has been shown via a [region](marionette.region.html).
 All `views` that inherit from the base `Marionette.View` class have this functionality. `ItemView`, 'CollectionView', 'CompositeView', 'Layout'
 
 ```js


### PR DESCRIPTION
These were previously referencing *.md files. However, they need
to point to their respective *.html files on the docs site.