### PR TITLE
Add `isRendered` property to Views

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -111,6 +111,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this._ensureViewIsIntact();
     this.triggerMethod('before:render', this);
     this._renderChildren();
+    this.isRendered = true;
     this.triggerMethod('render', this);
     return this;
   },

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -62,7 +62,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // Renders the model and the collection.
   render: function() {
     this._ensureViewIsIntact();
-    this.isRendered = true;
+    this._isRendering = true;
     this.resetChildViewContainer();
 
     this.triggerMethod('before:render', this);
@@ -70,12 +70,14 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     this._renderTemplate();
     this._renderChildren();
 
+    this._isRendering = false;
+    this.isRendered = true;
     this.triggerMethod('render', this);
     return this;
   },
 
   _renderChildren: function() {
-    if (this.isRendered) {
+    if (this.isRendered || this._isRendering) {
       Marionette.CollectionView.prototype._renderChildren.call(this);
     }
   },

--- a/src/item-view.js
+++ b/src/item-view.js
@@ -81,12 +81,13 @@ Marionette.ItemView = Marionette.View.extend({
     }
 
     // Add in entity data and template helpers
-    var data = this.serializeData();
-    data = this.mixinTemplateHelpers(data);
+    var data = this.mixinTemplateHelpers(this.serializeData());
 
     // Render and add to el
     var html = Marionette.Renderer.render(template, data, this);
     this.attachElContent(html);
+
+    this.isRendered = true;
 
     return this;
   },

--- a/src/view.js
+++ b/src/view.js
@@ -169,6 +169,8 @@ Marionette.View = Backbone.View.extend({
     // unbind UI elements
     this.unbindUIElements();
 
+    this.isRendered = false;
+
     // remove the view from the DOM
     this.remove();
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -16,8 +16,12 @@ describe('collection view', function() {
 
     this.MockCollectionView = Backbone.Marionette.CollectionView.extend({
       childView: this.ChildView,
-      onBeforeRender: function() {},
-      onRender: function() {},
+      onBeforeRender: function() {
+        return this.isRendered;
+      },
+      onRender: function() {
+        return this.isRendered;
+      },
       onBeforeAddChild: function() {},
       onAddChild: function() {},
       onBeforeRemoveChild: function() {},
@@ -165,6 +169,18 @@ describe('collection view', function() {
       expect(this.collectionView.onRender).to.have.been.called;
     });
 
+    it('should call "onBeforeRender" before "onRender"', function() {
+      expect(this.collectionView.onBeforeRender).to.have.been.calledBefore(this.collectionView.onRender);
+    });
+
+    it('should not be rendered when "onBeforeRender" is called', function() {
+      expect(this.collectionView.onBeforeRender.lastCall.returnValue).not.to.be.ok;
+    });
+
+    it('should be rendered when "onRender" is called', function() {
+      expect(this.collectionView.onRender.lastCall.returnValue).to.be.true;
+    });
+
     it('should trigger a "before:render" event', function() {
       expect(this.collectionView.trigger).to.have.been.calledWith('before:render', this.collectionView);
     });
@@ -211,6 +227,10 @@ describe('collection view', function() {
       expect(this.collectionView.getChildView).to.have.been.calledTwice.
         and.calledWith(this.collection.models[0]).
         and.calledWith(this.collection.models[1]);
+    });
+
+    it('should be marked rendered', function() {
+      expect(this.collectionView).to.have.property('isRendered', true);
     });
   });
 
@@ -517,8 +537,18 @@ describe('collection view', function() {
       this.EventedView = Backbone.Marionette.CollectionView.extend({
         childView: this.ChildView,
         someCallback: function() {},
-        onBeforeDestroy: function() {},
-        onDestroy: function() {}
+        onBeforeDestroy: function() {
+          return {
+            isRendered: this.isRendered,
+            isDestroyed: this.isDestroyed
+          };
+        },
+        onDestroy: function() {
+          return {
+            isRendered: this.isRendered,
+            isDestroyed: this.isDestroyed
+          };
+        }
       });
 
       this.destroyHandler = this.sinon.stub();
@@ -599,6 +629,18 @@ describe('collection view', function() {
       expect(this.collectionView.onBeforeDestroy).to.have.been.called;
     });
 
+    it('should call "onBeforeDestroy" before "onDestroy"', function() {
+      expect(this.collectionView.onBeforeDestroy).to.have.been.calledBefore(this.collectionView.onDestroy);
+    });
+
+    it('should not be destroyed when "onBeforeDestroy" is called', function() {
+      expect(this.collectionView.onBeforeDestroy.lastCall.returnValue.isDestroyed).not.to.be.ok;
+    });
+
+    it('should be destroyed when "onDestroy" is called', function() {
+      expect(this.collectionView.onDestroy.lastCall.returnValue.isDestroyed).to.be.true;
+    });
+
     it('should trigger a "before:destroy" event', function() {
       expect(this.collectionView.trigger).to.have.been.calledWith('before:destroy:collection');
     });
@@ -618,6 +660,14 @@ describe('collection view', function() {
 
     it('should return the collection view', function() {
       expect(this.collectionView.destroy).to.have.returned(this.collectionView);
+    });
+
+    it('should be marked destroyed', function() {
+      expect(this.collectionView).to.have.property('isDestroyed', true);
+    });
+
+    it('should be marked not rendered', function() {
+      expect(this.collectionView).to.have.property('isRendered', false);
     });
   });
 

--- a/test/unit/composite-view.spec.js
+++ b/test/unit/composite-view.spec.js
@@ -239,7 +239,12 @@ describe('composite view', function() {
       this.CompositeView = Backbone.Marionette.CompositeView.extend({
         childView: this.ChildView,
         template: this.templateFn,
-        onRender: function() {}
+        onBeforeRender: function() {
+          return this.isRendered;
+        },
+        onRender: function() {
+          return this.isRendered;
+        }
       });
 
       this.order = [];
@@ -267,6 +272,7 @@ describe('composite view', function() {
       });
 
       this.sinon.spy(this.compositeView, 'trigger');
+      this.sinon.spy(this.compositeView, 'onBeforeRender');
       this.sinon.spy(this.compositeView, 'onRender');
 
       this.compositeView.render();
@@ -294,12 +300,28 @@ describe('composite view', function() {
       expect(this.order[2]).to.equal(this.compositeView);
     });
 
-    it('should call "onRender"', function() {
-      expect(this.compositeView.onRender).to.have.been.called;
+    it('should call "onBeforeRender"', function() {
+      expect(this.compositeView.onBeforeRender).to.have.been.calledOnce;
     });
 
-    it('should only call "onRender" once', function() {
-      expect(this.compositeView.onRender.callCount).to.equal(1);
+    it('should call "onRender"', function() {
+      expect(this.compositeView.onRender).to.have.been.calledOnce;
+    });
+
+    it('should call "onBeforeRender" before "onRender"', function() {
+      expect(this.compositeView.onBeforeRender).to.have.been.calledBefore(this.compositeView.onRender);
+    });
+
+    it('should not be rendered when "onBeforeRender" is called', function() {
+      expect(this.compositeView.onBeforeRender.lastCall.returnValue).not.to.be.ok;
+    });
+
+    it('should be rendered when "onRender" is called', function() {
+      expect(this.compositeView.onRender.lastCall.returnValue).to.be.true;
+    });
+
+    it('should mark as rendered', function() {
+      expect(this.compositeView).to.have.property('isRendered', true);
     });
   });
 
@@ -590,7 +612,15 @@ describe('composite view', function() {
     });
 
     it('should destroy the collection of views', function() {
-      expect(this.CompositeModelView.prototype.destroy.callCount).to.equal(1);
+      expect(this.CompositeModelView.prototype.destroy).to.have.been.calledOnce;
+    });
+
+    it('should be marked destroyed', function() {
+      expect(this.compositeView).to.have.property('isDestroyed', true);
+    });
+
+    it('should be marked not rendered', function() {
+      expect(this.compositeView).to.have.property('isRendered', false);
     });
   });
 

--- a/test/unit/destroying-views.spec.js
+++ b/test/unit/destroying-views.spec.js
@@ -3,7 +3,9 @@ describe('destroying views', function() {
 
   describe('when destroying a Marionette.View multiple times', function() {
     beforeEach(function() {
-      this.onDestroyStub = this.sinon.stub();
+      this.onDestroyStub = this.sinon.spy(function () {
+        return this.isRendered;
+      });
 
       this.view = new Marionette.View();
       this.view.onDestroy = this.onDestroyStub;

--- a/test/unit/item-view.spec.js
+++ b/test/unit/item-view.spec.js
@@ -102,8 +102,12 @@ describe('item view', function() {
 
   describe('when rendering', function() {
     beforeEach(function() {
-      this.onBeforeRenderStub = this.sinon.stub();
-      this.onRenderStub       = this.sinon.stub();
+      this.onBeforeRenderStub = this.sinon.spy(function() {
+        return this.isRendered;
+      });
+      this.onRenderStub       = this.sinon.spy(function() {
+        return this.isRendered;
+      });
 
       this.View = Marionette.ItemView.extend({
         template       : this.templateStub,
@@ -124,12 +128,28 @@ describe('item view', function() {
       expect(this.onRenderStub).to.have.been.calledOnce;
     });
 
+    it('should call "onBeforeRender" before "onRender"', function() {
+      expect(this.onBeforeRenderStub).to.have.been.calledBefore(this.onRenderStub);
+    });
+
+    it('should not be rendered when "onBeforeRender" is called', function() {
+      expect(this.onBeforeRenderStub.lastCall.returnValue).not.to.be.ok;
+    });
+
+    it('should be rendered when "onRender" is called', function() {
+      expect(this.onRenderStub.lastCall.returnValue).to.be.true;
+    });
+
     it('should trigger a before:render event', function() {
       expect(this.triggerSpy).to.have.been.calledWith('before:render', this.view);
     });
 
     it('should trigger a rendered event', function() {
       expect(this.triggerSpy).to.have.been.calledWith('render', this.view);
+    });
+
+    it('should mark as rendered', function() {
+      expect(this.view).to.have.property('isRendered', true);
     });
   });
 
@@ -196,8 +216,18 @@ describe('item view', function() {
 
   describe('when destroying an item view', function() {
     beforeEach(function() {
-      this.onBeforeDestroyStub = this.sinon.stub();
-      this.onDestroyStub       = this.sinon.stub();
+      this.onBeforeDestroyStub = this.sinon.spy(function() {
+        return {
+          isRendered: this.isRendered,
+          isDestroyed: this.isDestroyed
+        };
+      });
+      this.onDestroyStub = this.sinon.spy(function() {
+        return {
+          isRendered: this.isRendered,
+          isDestroyed: this.isDestroyed
+        };
+      });
 
       this.View = Marionette.ItemView.extend({
         template        : this.templateStub,
@@ -242,6 +272,26 @@ describe('item view', function() {
 
     it('should return the view', function() {
       expect(this.view.destroy).to.have.returned(this.view);
+    });
+
+    it('should not be destroyed when "onBeforeDestroy" is called', function () {
+      expect(this.onBeforeDestroyStub.lastCall.returnValue.isDestroyed).not.to.be.ok;
+    });
+
+    it('should be destroyed when "onDestroy" is called', function() {
+      expect(this.onDestroyStub.lastCall.returnValue.isDestroyed).to.be.true;
+    });
+
+    it('should be rendered when "onDestroy" is called', function() {
+      expect(this.onDestroyStub.lastCall.returnValue.isRendered).to.be.true;
+    });
+
+    it('should be marked destroyed', function() {
+      expect(this.view).to.have.property('isDestroyed', true);
+    });
+
+    it('should be marked not rendered', function() {
+      expect(this.view).to.have.property('isRendered', false);
     });
   });
 

--- a/test/unit/layout-view.spec.js
+++ b/test/unit/layout-view.spec.js
@@ -12,6 +12,17 @@ describe('layoutView', function() {
       regions: {
         regionOne: '#regionOne',
         regionTwo: '#regionTwo'
+      },
+      initialize: function() {
+        if (this.model) {
+          this.listenTo(this.model, 'change', this.render);
+        }
+      },
+      onBeforeRender: function() {
+        return this.isRendered;
+      },
+      onRender: function() {
+        return this.isRendered;
       }
     });
 
@@ -154,6 +165,9 @@ describe('layoutView', function() {
   describe('on rendering', function() {
     beforeEach(function() {
       this.layoutViewManager = new this.LayoutView();
+      sinon.spy(this.layoutViewManager, 'onRender');
+      sinon.spy(this.layoutViewManager, 'onBeforeRender');
+      sinon.spy(this.layoutViewManager, 'trigger');
       this.layoutViewManager.render();
     });
 
@@ -161,6 +175,38 @@ describe('layoutView', function() {
       this.layoutViewManager.regionOne._ensureElement();
       var el = this.layoutViewManager.$('#regionOne');
       expect(this.layoutViewManager.regionOne.$el[0]).to.equal(el[0]);
+    });
+
+    it('should call "onBeforeRender" before rendering', function() {
+      expect(this.layoutViewManager.onBeforeRender).to.have.been.calledOnce;
+    });
+
+    it('should call "onRender" after rendering', function() {
+      expect(this.layoutViewManager.onRender).to.have.been.calledOnce;
+    });
+
+    it('should call "onBeforeRender" before "onRender"', function() {
+      expect(this.layoutViewManager.onBeforeRender).to.have.been.calledBefore(this.layoutViewManager.onRender);
+    });
+
+    it('should not be rendered when "onBeforeRender" is called', function() {
+      expect(this.layoutViewManager.onBeforeRender.lastCall.returnValue).not.to.be.ok;
+    });
+
+    it('should be rendered when "onRender" is called', function() {
+      expect(this.layoutViewManager.onRender.lastCall.returnValue).to.be.true;
+    });
+
+    it('should trigger a "before:render" event', function() {
+      expect(this.layoutViewManager.trigger).to.have.been.calledWith('before:render', this.layoutViewManager);
+    });
+
+    it('should trigger a "render" event', function() {
+      expect(this.layoutViewManager.trigger).to.have.been.calledWith('render', this.layoutViewManager);
+    });
+
+    it('should be marked rendered', function() {
+      expect(this.layoutViewManager).to.have.property('isRendered', true);
     });
   });
 
@@ -192,6 +238,14 @@ describe('layoutView', function() {
 
     it('should return the view', function() {
       expect(this.layoutViewManager.destroy).to.have.always.returned(this.layoutViewManager);
+    });
+
+    it('should be marked destroyed', function() {
+      expect(this.layoutViewManager).to.have.property('isDestroyed', true);
+    });
+
+    it('should be marked not rendered', function() {
+      expect(this.layoutViewManager).to.have.property('isRendered', false);
     });
   });
 


### PR DESCRIPTION
`isRendered` is falsey before view has been rendered, and during `onBeforeRender`
`isRendered` is true when view has been rendered, and during `onRender`
`isRendered` is truthy before view has been destroyed, and during `onBeforeDestroy`
`isRendered` is false after view has been destroyed, and during `onDestroy`

CompositeView's previously used an `isRendered` property. This property has been renamed to `_isRendering`