### PR TITLE
Missing semicolon in marionette.application docs

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -66,7 +66,7 @@ The events that are currently triggered, are:
 
 ```js
 MyApp.on("before:start", function(options){
-  options.moreData = "Yo dawg, I heard you like options so I put some options in your options!"
+  options.moreData = "Yo dawg, I heard you like options so I put some options in your options!";
 });
 
 MyApp.on("start", function(options){


### PR DESCRIPTION
I was following the docs and copied this code into my application. My grunt task run jshint and I noticed this error.