### PR TITLE
Use map in View.configureTriggers

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -76,10 +76,9 @@ Marionette.View = Backbone.View.extend({
 
     // Configure the triggers, prevent default
     // action and stop propagation of DOM events
-    return _.reduce(triggers, function(events, value, key) {
-      events[key] = this._buildViewTrigger(value);
-      return events;
-    }, {}, this);
+    return _.map(triggers, function(value) {
+      return this._buildViewTrigger(value);
+    }, this);
   },
 
   // Overriding Backbone.View's delegateEvents to handle


### PR DESCRIPTION
Because you have same count of keys in the `triggers` and return value, `_.map` more suitable for it.
I've found your discussion in https://github.com/marionettejs/backbone.marionette/pull/2009 and decided to contribute it