### PR TITLE
listenTo doesn't have a fourth argument.

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -514,7 +514,7 @@ Marionette.CollectionView = Marionette.View.extend({
       }
 
       this.triggerMethod.apply(this, args);
-    }, this);
+    });
   },
 
   _getImmediateChildren: function() {


### PR DESCRIPTION
This is for `proxyChildEvents` on `Marionette.CollectionView`... http://backbonejs.org/#Events-listenTo.