### PR TITLE
Use call when there are no params

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -43,11 +43,7 @@ Marionette.proxyGetOption = function(optionName) {
 // undefined return a default value
 Marionette._getValue = function(value, context, params) {
   if (_.isFunction(value)) {
-    // We need to ensure that params is not undefined
-    // to prevent `apply` from failing in ie8
-    params = params || [];
-
-    value = value.apply(context, params);
+    value = params ? value.apply(context, params) : value.call(context);
   }
   return value;
 };


### PR DESCRIPTION
Still guards against [IE8 apply undefined](https://github.com/marionettejs/backbone.marionette/issues/2225#issuecomment-72225361) by not `apply`ing without params. :wink: