### PR TITLE
Add before:show event to ChildView when added after show

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -347,6 +347,12 @@ Marionette.CollectionView = Marionette.View.extend({
 
     this.triggerMethod('before:add:child', view);
 
+    // trigger the 'before:show' event on `view` if the collection view
+    // has already been shown
+    if (this._isShown && !this.isBuffering) {
+      Marionette.triggerMethodOn(view, 'before:show');
+    }
+
     // Store the child view itself so we can properly
     // remove and/or destroy it later
     this.children.add(view);

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -926,6 +926,7 @@ describe('collection view', function() {
   describe('when a child view is added to a collection view, after the collection view has been shown', function() {
     beforeEach(function() {
       this.ChildView = Backbone.Marionette.ItemView.extend({
+        onBeforeShow: function() {},
         onShow: function() {},
         onDomRefresh: function() {},
         onRender: function() {},
@@ -937,6 +938,7 @@ describe('collection view', function() {
         onShow: function() {}
       });
 
+      this.sinon.spy(this.ChildView.prototype, 'onBeforeShow');
       this.sinon.spy(this.ChildView.prototype, 'onShow');
       this.sinon.spy(this.ChildView.prototype, 'onDomRefresh');
 
@@ -961,6 +963,14 @@ describe('collection view', function() {
 
     it('should not use the render buffer', function() {
       expect(this.collectionView.attachBuffer).not.to.have.been.called;
+    });
+
+    it('should call the "onBeforeShow" method of the child view', function() {
+      expect(this.ChildView.prototype.onBeforeShow).to.have.been.called;
+    });
+
+    it('should call the childs "onBeforeShow" method with itself as the context', function() {
+      expect(this.ChildView.prototype.onBeforeShow).to.have.been.calledOn(this.view);
     });
 
     it('should call the "onShow" method of the child view', function() {


### PR DESCRIPTION
Essentially duplicated from 
https://github.com/marionettejs/backbone.marionette/blob/master/src/collection-view.js#L228

Already the behavior if the `CollectionView` is buffering: 
https://github.com/marionettejs/backbone.marionette/blob/master/src/collection-view.js#L53

But if adding to a collection using 'collection.add' after the 'CollectionView' is shown only the 'show' event was occurring.