### PR TITLE
Make view options implementation consistent

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -11,6 +11,9 @@ Marionette.CollectionView = Marionette.View.extend({
   // that are forwarded through the collectionview
   childViewEventPrefix: 'childview',
 
+  // flag for maintaining the sorted order of the collection
+  sort: true,
+
   // constructor
   // option to pass `{sort: false}` to prevent the `CollectionView` from
   // maintaining the sorted order of the collection.
@@ -19,10 +22,6 @@ Marionette.CollectionView = Marionette.View.extend({
   // option to pass `{comparator: compFunction()}` to allow the `CollectionView`
   // to use a custom sort order for the collection.
   constructor: function(options){
-    var initOptions = options || {};
-    if (_.isUndefined(this.sort)){
-      this.sort = _.isUndefined(initOptions.sort) ? true : initOptions.sort;
-    }
 
     this.once('render', this._initialEvents);
     this._initChildViewStorage();
@@ -30,6 +29,7 @@ Marionette.CollectionView = Marionette.View.extend({
     Marionette.View.apply(this, arguments);
 
     this.on('show', this._onShowCalled);
+
     this.initRenderBuffer();
   },
 
@@ -83,7 +83,7 @@ Marionette.CollectionView = Marionette.View.extend({
       this.listenTo(this.collection, 'remove', this._onCollectionRemove);
       this.listenTo(this.collection, 'reset', this.render);
 
-      if (this.sort) {
+      if (this.getOption('sort')) {
         this.listenTo(this.collection, 'sort', this._sortViews);
       }
     }
@@ -321,7 +321,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // Internal method. This decrements or increments the indices of views after the
   // added/removed view to keep in sync with the collection.
   _updateIndices: function(view, increment, index) {
-    if (!this.sort) {
+    if (!this.getOption('sort')) {
       return;
     }
 
@@ -452,7 +452,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // the correct position.
   _insertBefore: function(childView, index) {
     var currentView;
-    var findPosition = this.sort && (index < this.children.length - 1);
+    var findPosition = this.getOption('sort') && (index < this.children.length - 1);
     if (findPosition) {
       // Find the view after this one
       currentView = this.children.find(function (view) {

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -30,7 +30,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
       this.listenTo(this.collection, 'remove', this._onCollectionRemove);
       this.listenTo(this.collection, 'reset', this._renderChildren);
 
-      if (this.sort) {
+      if (this.getOption('sort')) {
         this.listenTo(this.collection, 'sort', this._sortViews);
       }
     }

--- a/src/view.js
+++ b/src/view.js
@@ -19,7 +19,7 @@ Marionette.View = Backbone.View.extend({
 
     this._behaviors = Marionette.Behaviors(this);
 
-    Backbone.View.apply(this, arguments);
+    Backbone.View.call(this, this.options);
 
     Marionette.MonitorDOMRefresh(this);
   },

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -350,6 +350,14 @@ describe('collection view', function() {
     });
   });
 
+  describe('when instantiating a view with a different sort option than in the view\'s definition', function () {
+    it('should maintain the instantiated sort option', function () {
+      this.CollectionView = Marionette.CollectionView.extend({ sort: false }); 
+      this.newCollectionView = new this.CollectionView({ sort: true });
+      expect(this.newCollectionView.getOption('sort')).to.equal(true);
+    });
+  });
+
   describe('when a model is added to the collection', function() {
     beforeEach(function() {
       this.collection = new Backbone.Collection();

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -192,6 +192,29 @@ describe('base view', function() {
     });
   });
 
+  // http://backbonejs.org/#View-constructor
+  describe('when constructing a view with Backbone viewOptions', function () {
+    it('should attach the viewOptions to the view if options are on the view', function () {
+      this.MyView = Marionette.View.extend({
+        options: {
+          className: '.some-class'
+        } 
+      });
+      this.myView = new this.MyView();
+      expect(this.myView.className).to.equal('.some-class');
+    });
+
+    it('should attach the viewOptions to the view if options are passed as a function', function () {
+      var options = function(){
+        return {
+          className: '.some-class'
+        };
+      };  
+      this.myView = new Marionette.View(options);
+      expect(this.myView.className).to.equal('.some-class');
+    });
+  });
+
   describe('should expose its options in the constructor', function() {
     beforeEach(function() {
       this.options = {foo: 'bar'};


### PR DESCRIPTION
This addresses fixing the bug related to https://github.com/marionettejs/backbone.marionette/issues/2242

While fixing the issue related to the `sort` option on `CollectionView` when `options` is a function, I ran into an additional bug.

Because `this.sort` is utilized it is possible to set the `sort` for future instantiations of an extended `CollectionView`  I've fixed this bug in this PR as well, but can split it up if necessary.

If this :eyes: :+1: I'll get the tests written / adjusted

### Bug proof
As Expected:
```
var MyCollectionView = Marionette.CollectionView.extend(); // Not setting sort

var myCollectionView = new MyCollectionView({ sort: true });

console.log(myCollectionView.sort); -> logs true
```

Unexpected:
```
var MyCollectionView = Marionette.CollectionView.extend({ sort: false }); 

var myCollectionView = new MyCollectionView({ sort: true });

console.log(myCollectionView.sort); -> logs false
```

**Todo**
- [x] Test for `Backbone.View` `viewOptions` when `options` passed as function
- [x] Test for `Backbone.View` `viewOptions` when `options` is set on `View` definition
- [x] Test for 'sort' when `CollectionView` instantiation overrides `CollectionView` definition `sort`