### PR TITLE
Fix issue with bundled root.Mn alias.

### DIFF
--- a/src/build/bundled.js
+++ b/src/build/bundled.js
@@ -23,6 +23,7 @@
   // @include ../../tmp/backbone.wreqr.bare.js
 
   var previousMarionette = root.Marionette;
+  var previousMn = root.Mn;
 
   var Marionette = Backbone.Marionette = {};
 
@@ -30,6 +31,7 @@
 
   Marionette.noConflict = function() {
     root.Marionette = previousMarionette;
+    root.Mn = previousMn;
     return this;
   };
 


### PR DESCRIPTION
Our bundled version of Marionette doesn't replace `root.Mn`. Now it does.