### PR TITLE
Add mergeOptions helper.

### DIFF
--- a/api/helpers.yaml
+++ b/api/helpers.yaml
@@ -78,6 +78,33 @@ functions:
           // => true
           ```
 
+  mergeOptions:
+    description: |
+      Merge `keys` from `obj` onto `this`.
+      
+      @api public
+      @static
+      @param {Object} obj
+      @param {Array} keys
+
+    examples:
+      -
+        name: mergeOptions
+        example: |
+          By setting the keys on your prototype, you can create self-documenting classes. Take
+          the example below.
+          
+          ```js
+          var MyView = Marionette.ItemView.extend({
+            myViewOptions: ['color', 'size', 'country'],
+          
+            initialize: function(options) {
+              this.mergeOptions(options, this.myViewOptions),
+              console.log('These are my options:', this.color, this.size, this.country);
+            }
+          });
+          ```
+
   getOption:
     description: |
       Retrieve an object, function or other value from a target object or its `options`, with

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -41,6 +41,7 @@ instead of these deprecated features.
   * [Overriding the default RegionManager](#overriding-the-default-regionmanager)
   * [Get Region By Name](#get-region-by-name)
   * [Removing Regions](#removing-regions)
+* [Application.mergeOptions](#applicationmergeoptions)
 * [Application.getOption](#applicationgetoption)
 * [Adding Initializers (deprecated)](#adding-initializers)
 * [The Application Channel (deprecated)](#the-application-channel)
@@ -292,6 +293,21 @@ application object.
 
 For more information on regions, see [the region documentation](./marionette.region.md) Also, the API that Applications use to
 manage regions comes from the RegionManager Class, which is documented [over here](./marionette.regionmanager.md).
+
+### Application.mergeOptions
+Merge keys from the `options` object directly onto the Application instance.
+
+```js
+var MyApp = Marionette.Application.extend({
+  initialize: function(options) {
+    this.mergeOptions(options, ['myOption']);
+
+    console.log('The option is:', this.myOption);
+  }
+})
+```
+
+More information at [mergeOptions](./marionette.functions.md#marionettemergeoptions)
 
 ### Application.getOption
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.

--- a/docs/marionette.controller.md
+++ b/docs/marionette.controller.md
@@ -12,6 +12,7 @@ your Router's callbacks.
 
 * [Basic Use](#basic-use)
 * [Destroying A Controller](#destroying-a-controller)
+* [mergeOptions](#mergeoptions)
 * [getOption](#getoption)
 * [Prior Usage](#prior-usage)
 
@@ -39,6 +40,13 @@ var myRouter = new Marionette.AppRouter({
   }
 });
 ```
+
+## mergeOptions
+
+Merge keys from the `options` object directly onto the instance. This is the preferred way to access options
+passed into the Controller.
+
+More information at [mergeOptions](./marionette.functions.md#marionettemergeoptions)
 
 ## getOption
 

--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -11,6 +11,7 @@ a way to get the same behaviors and conventions from your own code.
 
 * [Marionette.extend](#marionetteextend)
 * [Marionette.isNodeAttached](#marionetteisnodeattached)
+* [Marionette.mergeOptions](#marionettemergeoptions)
 * [Marionette.getOption](#marionettegetoption)
 * [Marionette.proxyGetOption](#marionetteproxygetoption)
 * [Marionette.triggerMethod](#marionettetriggermethod)
@@ -65,6 +66,26 @@ Marionette.isNodeAttached(div);
 $('body').append(div);
 Marionette.isNodeAttached(div);
 // => true
+```
+
+## Marionette.mergeOptions
+
+A handy function to pluck certain `options` and attach them directly to an instance.
+Most Marionette Classes, such as the Views, come with this method.
+
+```js
+var MyView = ItemView.extend({
+  myViewOptions: ['color', 'size', 'country'],
+
+  initialize: function(options) {
+    this.mergeOptions(options, this.myViewOptions);
+  },
+
+  onRender: function() {
+    // The merged options will be attached directly to the prototype
+    this.$el.addClass(this.color);
+  }
+});
 ```
 
 ## Marionette.getOption

--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -11,6 +11,7 @@ like `initialize` and `Backbone.Events`.
 * [initialize](#initialize)
 * [events](#events)
 * [Destroying An Object](#destroying-a-object)
+* [mergeOptions](#mergeoptions)
 * [getOption](#getoption)
 * [bindEntityEvents](#bindentityevents)
 * [Basic Use](#basic-use)
@@ -52,6 +53,13 @@ john.on('announce', function(message) {
 
 john.graduate();
 ```
+
+## mergeOptions
+
+Merge keys from the `options` object directly onto the instance. This is the preferred way to access options
+passed into the Object.
+
+More information at [mergeOptions](./marionette.functions.md#marionettemergeoptions)
 
 ### getOption
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -24,6 +24,7 @@ behaviors that are shared across all views.
 * [View.modelEvents and View.collectionEvents](#viewmodelevents-and-viewcollectionevents)
 * [View.serializeModel](#viewserializemodel)
 * [View.bindUIElements](#viewbinduielements)
+* [View.mergeOptions](#viewmergeoptions)
 * [View.getOption](#viewgetoption)
 * [View.bindEntityEvents](#viewbindentityevents)
 * [View.templateHelpers](#viewtemplatehelpers)
@@ -390,6 +391,24 @@ This functionality is provided via the `bindUIElements` method.
 Since View doesn't implement the render method, then if you directly extend
 from View you will need to invoke this method from your render method.
 In ItemView and CompositeView this is already taken care of.
+
+## View.mergeOptions
+The preferred way to manage your view's options is with `mergeOptions`. It accepts two arguments: the `options` object
+and the keys to merge onto the instance directly.
+
+```js
+var ProfileView = Marionette.ItemView.extend({
+  profileViewOptions: ['user', 'age'],
+
+  initialize: function(options) {
+    this.mergeOptions(options, this.profileViewOptions);
+
+    console.log('The merged options are:', this.user, this.age);
+  }
+});
+```
+
+More information [mergeOptions](./marionette.functions.md#marionettemergeoptions)
 
 ## View.getOption
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -74,6 +74,8 @@ Marionette.AppRouter = Backbone.Router.extend({
     this.route(route, methodName, _.bind(method, controller));
   },
 
+  mergeOptions: Marionette.mergeOptions,
+
   // Proxy `getOption` to enable getting options from this or this.options by name.
   getOption: Marionette.proxyGetOption,
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -32,6 +32,9 @@ _.extend(Marionette.Controller.prototype, Backbone.Events, {
   // methods if the method exists
   triggerMethod: Marionette.triggerMethod,
 
+  // A handy way to merge options onto the instance
+  mergeOptions: Marionette.mergeOptions,
+
   // Proxy `getOption` to enable getting options from this or this.options by name.
   getOption: Marionette.proxyGetOption
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,6 +17,11 @@ Marionette.isNodeAttached = function(el) {
   return Backbone.$.contains(document.documentElement, el);
 };
 
+// Merge `keys` from `options` onto `this`
+Marionette.mergeOptions = function(options, keys) {
+  if (!options) { return; }
+  _.extend(this, _.pick(options, keys));
+};
 
 // Marionette.getOption
 // --------------------

--- a/src/object.js
+++ b/src/object.js
@@ -30,6 +30,9 @@ _.extend(Marionette.Object.prototype, Backbone.Events, {
   // methods if the method exists
   triggerMethod: Marionette.triggerMethod,
 
+  // A handy way to merge options onto the instance
+  mergeOptions: Marionette.mergeOptions,
+
   // Proxy `getOption` to enable getting options from this or this.options by name.
   getOption: Marionette.proxyGetOption,
 

--- a/src/view.js
+++ b/src/view.js
@@ -304,6 +304,9 @@ Marionette.View = Backbone.View.extend({
   // events=>function references/names to a hash of events=>function references
   normalizeMethods: Marionette.normalizeMethods,
 
+  // A handy way to merge passed-in options onto the instance
+  mergeOptions: Marionette.mergeOptions,
+
   // Proxy `getOption` to enable getting options from this or this.options by name.
   getOption: Marionette.proxyGetOption,
 

--- a/test/unit/merge-options.spec.js
+++ b/test/unit/merge-options.spec.js
@@ -1,0 +1,66 @@
+describe('mergeOptions', function() {
+  'use strict';
+
+  beforeEach(function() {
+    this.MyView = Marionette.ItemView.extend({
+      myViewOptions: ['color', 'size'],
+
+      initialize: function(options) {
+        this.mergeOptions(options, this.myViewOptions);
+      }
+    });
+  });
+
+  describe('when instantiating a view with no options', function() {
+    it('should not throw an Error', function() {
+      var suite = this;
+      expect(function() {
+        suite.myView = new suite.MyView();
+      }).to.not.throw(Error);
+    });
+  });
+
+  describe('when instantiating a view with options, none matching the keys', function() {
+    beforeEach(function() {
+      this.myView = new this.MyView({
+        hungry: true,
+        country: 'USA'
+      });
+    });
+
+    it('should not merge any of those options', function() {
+      expect(this.myView).to.not.contain.keys('hungry', 'country');
+    });
+  });
+
+  describe('when instantiating a view with options, some matching the keys', function() {
+    beforeEach(function() {
+      this.myView = new this.MyView({
+        hungry: true,
+        country: 'USA',
+        color: 'blue'
+      });
+    });
+
+    it('should not merge the ones that do not match', function() {
+      expect(this.myView).to.not.contain.keys('hungry', 'country');
+    });
+
+    it('should merge the ones that match', function() {
+      expect(this.myView).to.contain.keys('color');
+    });
+  });
+
+  describe('when instantiating a view with options, all matching the keys', function() {
+    beforeEach(function() {
+      this.myView = new this.MyView({
+        size: 'large',
+        color: 'blue'
+      });
+    });
+
+    it('should merge all of the options', function() {
+      expect(this.myView).to.contain.keys('color', 'size');
+    });
+  });
+});


### PR DESCRIPTION
Will add docs once I get approval of this implementation.

Usage:

```js
var MyView = Marionette.ItemView.extend({
  initialize: function(options) {
    this.mergeOptions(options, ['color', 'size', 'location']);
  },

  someMethod: function() {
    if (this.color) {}
  }
});
```

This would replace `getOptions` as the preferred way to access options passed into your views.

The way I use it is:

```js
var MyView = Marionette.ItemView.extend({
  myViewOptions: ['color', 'size', 'location'],

  initialize: function(options) {
    this.mergeOptions(options, this.myViewOptions);
  },

  someMethod: function() {
    if (this.color) {}
  }
});
```