### PR TITLE
Revert "Deprecate getOption"

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -294,19 +294,6 @@ For more information on regions, see [the region documentation](./marionette.reg
 manage regions comes from the RegionManager Class, which is documented [over here](./marionette.regionmanager.md).
 
 ### Application.getOption
-
-> Warning: deprecated
->
-> This feature is deprecated, and is scheduled to be removed in version 3 of Marionette. Instead
-> of getOption, you should add `options` to the instance in either the `constructor` or `initialize`
-> methods.
->
-> ```js
-> initialize: function(options) {
->   this.myOption = options.myOption;
-> }
-> ```
-
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
 
 More information [getOption](./marionette.functions.md#marionettegetoption)

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -93,7 +93,7 @@ var DestroyWarn = Marionette.Behavior.extend({
   },
 
   warnBeforeDestroy: function() {
-    alert(this.warningMessage);
+    alert(this.options.message);
     // every Behavior has a hook into the
     // view that it is attached to
     this.view.destroy();
@@ -111,7 +111,7 @@ var ToolTip = Marionette.Behavior.extend({
 
   onShow: function() {
     this.ui.tooltip.tooltip({
-      text: this.tooltipText
+      text: this.options.text
     });
   }
 });

--- a/docs/marionette.controller.md
+++ b/docs/marionette.controller.md
@@ -42,18 +42,6 @@ var myRouter = new Marionette.AppRouter({
 
 ## getOption
 
-> Warning: deprecated
->
-> This feature is deprecated, and is scheduled to be removed in version 3 of Marionette. Instead
-> of getOption, you should add `options` to the instance in either the `constructor` or `initialize`
-> methods.
->
-> ```js
-> initialize: function(options) {
->   this.myOption = options.myOption;
-> }
-> ```
-
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
 
 More information [getOption](./marionette.functions.md#marionettegetoption)

--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -69,18 +69,6 @@ Marionette.isNodeAttached(div);
 
 ## Marionette.getOption
 
-> Warning: deprecated
->
-> This feature is deprecated, and is scheduled to be removed in version 3 of Marionette. Instead
-> of getOption, you should add `options` to the instance in either the `constructor` or `initialize`
-> methods.
->
-> ```js
-> initialize: function(options) {
->   this.myOption = options.myOption;
-> }
-> ```
-
 Retrieve an object's attribute either directly from the object, or from
 the object's `this.options`, with `this.options` taking precedence.
 
@@ -131,18 +119,6 @@ In this example, "bar" is returned both times because the second
 example has an undefined value for `f`.
 
 ## Marionette.proxyGetOption
-
-> Warning: deprecated
->
-> This feature is deprecated, and is scheduled to be removed in version 3 of Marionette. Instead
-> of getOption, you should add `options` to the instance in either the `constructor` or `initialize`
-> methods.
->
-> ```js
-> initialize: function(options) {
->   this.myOption = options.myOption;
-> }
-> ```
 
 This method proxies `Marionette.getOption` so that it can be easily added to an instance.
 

--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -54,19 +54,6 @@ john.graduate();
 ```
 
 ### getOption
-
-> Warning: deprecated
->
-> This feature is deprecated, and is scheduled to be removed in version 3 of Marionette. Instead
-> of getOption, you should add `options` to the instance in either the `constructor` or `initialize`
-> methods.
->
-> ```js
-> initialize: function(options) {
->   this.myOption = options.myOption;
-> }
-> ```
-
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
 
 More information [getOption](./marionette.functions.md#marionettegetoption).

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -392,19 +392,6 @@ from View you will need to invoke this method from your render method.
 In ItemView and CompositeView this is already taken care of.
 
 ## View.getOption
-
-> Warning: deprecated
->
-> This feature is deprecated, and is scheduled to be removed in version 3 of Marionette. Instead
-> of getOption, you should add `options` to the instance in either the `constructor` or `initialize`
-> methods.
->
-> ```js
-> initialize: function(options) {
->   this.myOption = options.myOption;
-> }
-> ```
-
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
 
 More information [getOption](./marionette.functions.md#marionettegetoption)


### PR DESCRIPTION
Going to revert the merge on #2272

It is one thing to encourage people to use mergeOptions and another to deprecate getOption
(needs more discussion) 