### PR TITLE
perf: reorderOnSort option for collectionView

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -128,12 +128,36 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     return this;
   },
 
+  // Reorder DOM after sorting. When your element's rendering
+  // do not use their index, you can pass reorderOnSort: true
+  // to only reorder the DOM after a sort instead of rendering
+  // all the collectionView
+  reorder: function () {
+    var children = this.children;
+    var idx = children._indexByModel;
+    var views = children._views;
+    // get the views in the same order as the models
+    var arr = this.collection.models.map(function (model) {
+      var viewid = idx[model.cid];
+      var view = views[viewid];
+      return view.$el;
+    });
+    // transform into a jQuery array
+    var allEls = $(arr).map(function () { return this.toArray(); });
+    allEls.detach();
+    this.$el.append(allEls);
+  },
+
   // Render view after sorting. Override this method to
   // change how the view renders after a `sort` on the collection.
   // An example of this would be to only `renderChildren` in a `CompositeView`
   // rather than the full view.
   resortView: function() {
-    this.render();
+    if (Marionette.getOption(this, 'reorderOnSort')) {
+      this.reorder();
+    } else {
+      this.render();
+    }
   },
 
   // Internal method. This checks for any changes in the order of the collection.

--- a/test/unit/sorted-views.spec.js
+++ b/test/unit/sorted-views.spec.js
@@ -391,4 +391,30 @@ describe('collection/composite view sorting', function() {
       });
     });
   });
+
+  describe('when using `{ reorderOnSort: true }`', function () {
+    beforeEach(function () {
+      this.collectionView = new this.CollectionView({
+        childView: this.ChildView,
+        collection: this.collection,
+        reorderOnSort: true
+      });
+      this.collectionView.render();
+      this.sinon.spy(this.collectionView, 'reorder');
+      this.sinon.spy(this.collectionView, 'render');
+      this.collection.comparator = function (m) {
+        return m.get('bar');
+      };
+      this.collection.sort();
+    });
+
+    it('should call reorder instead of render', function () {
+      expect(this.collectionView.render).not.to.have.been.calledOnce;
+      expect(this.collectionView.reorder).to.have.been.calledOnce;
+    });
+
+    it('should reorder the DOM', function () {
+      expect(this.collectionView.$el).to.have.$text('321');
+    });
+  });
 });


### PR DESCRIPTION
## Why

When the collectionView need to resort, the default implementation is to re-render. This can have performance problems on large CollectionViews where ChildViews are a bit complex.

## How

ChildViews have already been rendered once so instead of re-rendering them, reuse them and only sort DOM nodes.

## Possible problems

ChildViews that knows their index and use it in their rendering will know be able to use this technique since they need to be re-rendered after sorting. This is why this performance improvement is not enabled by default.

See https://github.com/marionettejs/backbone.marionette/issues/1979