### PR TITLE
Make sure before:render is triggered before modifying layout view.

### DIFF
--- a/src/item-view.js
+++ b/src/item-view.js
@@ -53,11 +53,7 @@ Marionette.ItemView = Marionette.View.extend({
 
     this.triggerMethod('before:render', this);
 
-    this._renderTemplate();
-    this.isRendered = true;
-    this.bindUIElements();
-
-    this.triggerMethod('render', this);
+    this._renderItem();
 
     return this;
   },
@@ -89,6 +85,14 @@ Marionette.ItemView = Marionette.View.extend({
     this.attachElContent(html);
 
     return this;
+  },
+
+  _renderItem: function() {
+    this._renderTemplate();
+    this.isRendered = true;
+    this.bindUIElements();
+
+    this.triggerMethod('render', this);
   },
 
   // Attaches the content of a given view.

--- a/src/layout-view.js
+++ b/src/layout-view.js
@@ -32,6 +32,8 @@ Marionette.LayoutView = Marionette.ItemView.extend({
   render: function() {
     this._ensureViewIsIntact();
 
+    this.triggerMethod('before:render', this);
+
     if (this._firstRender) {
       // if this is the first render, don't do anything to
       // reset the regions
@@ -42,7 +44,9 @@ Marionette.LayoutView = Marionette.ItemView.extend({
       this._reInitializeRegions();
     }
 
-    return Marionette.ItemView.prototype.render.apply(this, arguments);
+    this._renderItem();
+
+    return this;
   },
 
   // Handle destroying regions, and then destroy the view itself.

--- a/test/unit/layout-view.spec.js
+++ b/test/unit/layout-view.spec.js
@@ -363,6 +363,14 @@ describe('layoutView', function() {
       expect(this.region.$el.parent()[0]).to.equal(this.layoutView.el);
     });
 
+    it('triggers "before:render" before emptying the regions', function() {
+      var cb = function() {
+        expect(this.region.$el).to.exist;
+      };
+      this.layoutView.listenTo(this.layoutView, 'before:render', _.bind(cb, this));
+      this.layoutView.render();
+    });
+
     it('should call empty twice', function() {
       expect(this.region.empty).to.have.been.calledThrice;
     });


### PR DESCRIPTION
To me, the implications of the `before:render` event is that it runs before rendering any changes in the DOM. This is true for ItemView, but LayoutView was resetting its regions before triggering the event. This means that the DOM has already been modified because the subviews have been removed.

I ran into this while trying to write some code that would find the currently focused element on the page (which could be in a view or its subviews) and record that element so it could be re-focused after re-rendering. The code didn't work because the subviews were already gone, and I had to override `render` instead.