### PR TITLE
Add Marionette feature flags

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -77,6 +77,7 @@
     <script src="src/renderer.js"></script>
     <script src="src/template-cache.js"></script>
     <script src="src/object.js"></script>
+    <script src="src/features.js"></script>
     <script src="src/controller.js"></script>
     <script src="src/app-router.js"></script>
     <script src="src/application.js"></script>
@@ -90,6 +91,7 @@
     <script src="src/layout-view.js"></script>
     <script src="src/collection-view.js"></script>
     <script src="src/composite-view.js"></script>
+
 
     <script src="test/unit/application.app-regions.spec.js"></script>
     <script src="test/unit/application.spec.js"></script>
@@ -108,6 +110,7 @@
     <script src="test/unit/controller.spec.js"></script>
     <script src="test/unit/destroying-views.spec.js"></script>
     <script src="test/unit/error.spec.js"></script>
+    <script src="test/unit/features.spec.js"></script>
     <script src="test/unit/get-immediate-children.spec.js"></script>
     <script src="test/unit/get-nested-views.spec.js"></script>
     <script src="test/unit/get-option.spec.js"></script>

--- a/src/build/core.js
+++ b/src/build/core.js
@@ -33,6 +33,7 @@
   // Get the Deferred creator for later use
   Marionette.Deferred = Backbone.$.Deferred;
 
+  // @include ../features.js
   // @include ../helpers.js
   // @include ../trigger-method.js
   // @include ../dom-refresh.js

--- a/src/features.js
+++ b/src/features.js
@@ -1,0 +1,6 @@
+Marionette.FEATURES = {
+};
+
+Marionette.isEnabled = function(name) {
+  return !!Marionette.FEATURES[name];
+};

--- a/test/unit/features.spec.js
+++ b/test/unit/features.spec.js
@@ -1,0 +1,20 @@
+describe('features', function() {
+
+  beforeEach(function() {
+    Marionette.FEATURES = {};
+  });
+
+  it('enabled when its present and true', function() {
+    Marionette.FEATURES.foo = true;
+    expect(Marionette.isEnabled('foo')).to.be.true;
+  });
+
+  it('disabled when its present and false', function() {
+    Marionette.FEATURES.foo = false;
+    expect(Marionette.isEnabled('foo')).to.be.false;
+  });
+
+  it('disabled when not present', function() {
+    expect(Marionette.isEnabled('foo')).to.be.false;
+  });
+});

--- a/test/unit/setup/node.js
+++ b/test/unit/setup/node.js
@@ -43,6 +43,7 @@ requireHelper('trigger-method');
 requireHelper('helpers');
 requireHelper('dom-refresh');
 requireHelper('object');
+requireHelper('features');
 requireHelper('controller');
 requireHelper('app-router');
 requireHelper('application');


### PR DESCRIPTION
Feature flags are added onto the Marionette.FEATURES
object:

```js
Marionette.FEATURES = {
  fooFlag: false
};
```

and are checked in the library code via a simple `isEnabled` check:

```js
Marionette.isEnabled('fooFlag')
```

The goal of feature flags is to be able to add *breaking* features in
a minor release behind a feature flag. There are two benefits to this
strategy:
1) users can access the new feature immediately
2) the code can be merged onto master much sooner, which prevents higher
risk merges down the road.