### PR TITLE
Add child events for layout children views

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -245,7 +245,7 @@ var ChildView = new Marionette.ItemView.extend({
   showMessage: function () {
     console.log('The button was clicked.');
 
-    this.trigger('show:message');
+    this.triggerMethod('show:message');
   }
 });
 

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -27,6 +27,7 @@ will provide features such as `onShow` callbacks, etc. Please see
 
 * [Basic Usage](#basic-usage)
 * [Region Options](#region-options)
+* [LayoutView.childEvents](#layoutview-childevents)
 * [Specifying Regions As A Function](#specifying-regions-as-a-function)
 * [Overriding the default RegionManager](#overriding-the-default-regionmanager)
 * [Region Availability](#region-availability)
@@ -101,6 +102,74 @@ new Marionette.LayoutView({
  }
 })
 ```
+
+### LayoutView childEvents
+
+You can specify a `childEvents` hash or method which allows you to capture all
+bubbling `childEvents` without having to manually set bindings.
+
+The keys of the hash can either be a function or a string
+that is the name of a method on the layout view.
+
+The function is called in the context of the view. The first parameter is
+the child view, which emitted the event, the remainder are the arguments
+associated with the event.
+
+```js
+// childEvents can be specified as a hash...
+var MyLayoutView = Marionette.LayoutView.extend({
+
+  // This callback will be called whenever a child is rendered or emits a `render` event
+  childEvents: {
+    render: function(childView) {
+      console.log("a childView has been rendered");
+    }
+  }
+});
+
+// ...or as a function that returns a hash.
+var MyLayoutView = Marionette.LayoutView.extend({
+
+  childEvents: function() {
+    return {
+      render: this.onChildRender
+    }
+  },
+
+  onChildRender: function(childView) {
+  }
+});
+```
+
+This also works for custom events that you might fire on your child views.
+
+```js
+  // The child view fires a custom event, `show:message`
+  var ChildView = new Marionette.ItemView.extend({
+    events: {
+      'click .button': 'showMessage'
+    },
+
+    showMessage: function (e) {
+      console.log('The button was clicked.');
+      this.triggerMethod('show:message', msg);
+    }
+  });
+
+  // The parent uses childEvents to catch that custom event on the child view
+  var ParentView = new Marionette.LayoutView.extend({
+    childEvents: {
+      'show:message': function (childView, msg) {
+        console.log('The show:message event bubbled up to the parent.');
+      }
+    },
+
+    onChildviewShowMessage: function (childView, msg) {
+      console.log('The show:message event bubbled up to the parent.');
+    }
+  });
+```
+
 
 ### Specifying Regions As A Function
 

--- a/src/layout-view.js
+++ b/src/layout-view.js
@@ -14,6 +14,10 @@ Marionette.LayoutView = Marionette.ItemView.extend({
     destroyImmediate: false
   },
 
+  // used as the prefix for child view events
+  // that are forwarded through the layoutview
+  childViewEventPrefix: 'childview',
+
   // Ensure the regions are available when the `initialize` method
   // is called.
   constructor: function(options) {

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -198,7 +198,7 @@ describe('base view', function() {
       this.MyView = Marionette.View.extend({
         options: {
           className: '.some-class'
-        } 
+        }
       });
       this.myView = new this.MyView();
       expect(this.myView.className).to.equal('.some-class');
@@ -209,7 +209,7 @@ describe('base view', function() {
         return {
           className: '.some-class'
         };
-      };  
+      };
       this.myView = new Marionette.View(options);
       expect(this.myView.className).to.equal('.some-class');
     });
@@ -263,6 +263,79 @@ describe('base view', function() {
 
     it("should return all attributes", function(){
       expect(view.serializeModel(model)).to.be.eql(modelData);
+    });
+  });
+
+  describe("when proxying events to a parent layout", function() {
+
+    beforeEach(function() {
+      this.LayoutView = Marionette.LayoutView.extend({
+        template: _.template('<div class="child"></div>'),
+
+        regions: {
+          'child': '.child',
+        },
+
+        childEvents: {
+          'boom': 'onBoom'
+        },
+
+      });
+
+      this.ChildView = Marionette.ItemView.extend({
+        template: false
+      });
+
+      this.layoutView = new this.LayoutView();
+      this.childView = new this.ChildView();
+      this.layoutView.render();
+
+      this.layoutEventHandler = this.sinon.spy();
+      this.layoutView.on('childview:boom', this.layoutEventHandler);
+
+      this.layoutEventOnHandler = this.sinon.spy();
+      this.layoutView.onChildviewBoom = this.layoutEventOnHandler;
+
+      this.layoutViewOnBoomHandler = this.sinon.spy();
+      this.layoutView.onBoom = this.layoutViewOnBoomHandler;
+    });
+
+    describe('when there is not a containing layout', function() {
+      beforeEach(function(){
+        this.childView.triggerMethod('boom', 'foo', 'bar');
+      });
+
+      it('does not emit the event on the layout', function() {
+        expect(this.layoutEventHandler).not.to.have.been.called;
+      });
+    });
+
+    describe('when there is a containing layout', function() {
+      beforeEach(function(){
+        this.layoutView.showChildView('child', this.childView);
+        this.childView.triggerMethod('boom', 'foo', 'bar');
+      });
+
+      it('emits the event on the layout', function() {
+        expect(this.layoutEventHandler)
+          .to.have.been.calledWith(this.childView, 'foo', 'bar')
+          .and.to.have.been.calledOn(this.layoutView)
+          .and.CalledOnce;
+      });
+
+      it('invokes the layout on handler', function() {
+        expect(this.layoutEventOnHandler)
+          .to.have.been.calledWith(this.childView, 'foo', 'bar')
+          .and.to.have.been.calledOn(this.layoutView)
+          .and.CalledOnce;
+      });
+
+      it('invokes the layout childEvents handler', function() {
+        expect(this.layoutViewOnBoomHandler)
+          .to.have.been.calledWith(this.childView, 'foo', 'bar')
+          .and.to.have.been.calledOn(this.layoutView)
+          .and.CalledOnce;
+      });
     });
   });
 });


### PR DESCRIPTION
Region events are one of the most common requets we've received:
events in a layout like you can listen for child events in a collection
view.

```js
LayoutView.extend({

  childEvents: {
    'submit': 'onChildViewSubmit'
    'fail': 'onChildViewFail'
  },

  onChildViewSubmit: function(childView, successMsg) {},
  onChildViewFail: function(childView, failMsg) {}
})
```

### Workarounds:
The first is share a radio channel,
the second is share a common eventable object (think model). Messaging
through a channel can be ugly because it encourages an explosion of
channels that can be hard to keep track of. Think lots of little wires
through the app. Messaging through a shared eventable object, is ugly
because it's a source of indirection that's unexpected. It's not obvious
that the model is being used in this way.

### Event Bubbling:
This is not event bubbling where an event will go all the way up the
view tree. I do not want to rule that out, as it might be nice, but
there are more design considerations there.

### Utility Methods
When we introduced the `_parent` reference, we discussed that there was
support for getting nested children for proxying events, but there was
no support for getting ancestor views for proxying events and other
internal utilities. We now have support for this, but will obviously
discourage end users from tapping into the power. With great power
comes...

### Docs
I'll add them when the time comes 


### Major
This should be mostly trivial to get onto major. There's one ref to LayoutView, but besides that everything should be fine