### PR TITLE
Update marionette.regionmanager.md

### DIFF
--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -62,7 +62,7 @@ var mananger = new Marionette.RegionManager({
   }
 });
 
-mananger.getRegion('aRegion').show(new MyView);
+mananger.get('aRegion').show(new MyView);
 ```
 
 ## RegionManager.addRegion


### PR DESCRIPTION
'getRegion' doesn't seem to exist with RegionManager in 2.3.2. We rather use 'get'.