### PR TITLE
Allow an underscore as a splitter in the method string name that is passed in

### DIFF
--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -6,7 +6,7 @@
 
 Marionette._triggerMethod = (function() {
   // split the event name on the ":"
-  var splitter = /(^|:)(\w)/gi;
+  var splitter = /(^|:|_)(\w)/gi;
 
   // take the event section ("section1:section2:section3")
   // and turn it in to uppercase name


### PR DESCRIPTION
This would allow a string "method_name" to properly convert to "onMethodName" for the function.

This is helpful to me as the keys that are being walked through my application also link up with css class names and item views that are properly named. I believe this would be consistent with similar string manipulation.