### PR TITLE
Add missing param to getChildViewContainer API

### DIFF
--- a/api/composite-view.yaml
+++ b/api/composite-view.yaml
@@ -102,6 +102,7 @@ functions:
       
       @api public
       @param {} containerView
+      @param {} childView
 
     examples:
       


### PR DESCRIPTION
As mentioned in [the documentation](https://github.com/marionettejs/backbone.marionette/blob/minor/docs/marionette.compositeview.md#compositeviews-childview-container-selection):

> The `getChildViewContainer` method is passed a second `childView` parameter which, when overridden, allows for a finer tuned container selection by being able to access the `childView` which is about to be appended to the `containerView` returned by `getChildViewContainer`.