### PR TITLE
Improve mixin of view ui hash to behaviors

### DIFF
--- a/api/collection-view.yaml
+++ b/api/collection-view.yaml
@@ -325,7 +325,7 @@ functions:
       @api public
       @param {Marionette.View} view
     
-    filter:
+  filter:
     description: |
       ...
 
@@ -334,3 +334,9 @@ functions:
       @param {Number} index
       @param {Backbone.Collection} collection
 
+  setFilter:
+    description: |
+      ...
+
+      @api public
+      @param {Function} function

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -273,3 +273,21 @@ Marionette.Behavior.extend({
 	}
 });
 ```
+
+### ui
+
+Behaviors can have their own ui hash, which will be mixed into the ui hash of its associated view instance.
+ui elements defined on either the behavior or the view will be made available within events, and triggers.  They
+also are attached directly to the behavior and can be accessed within behavior methods as `this.ui`.
+
+```js
+Marionette.Behavior.extend({
+    ui: {
+        'foo' : 'li.foo'
+    },
+
+    doStuff: function() {
+        this.ui.foo.trigger('something');
+    }
+})
+```

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -19,7 +19,6 @@ behaviors that are shared across all views.
 * [View onBeforeDestroy](#view-onbeforedestroy)
 * [View "attach" / onAttach event](#view-attach--onattach-event)
 * [View "before:attach" / onBeforeAttach event](#view-beforeattach--onbeforeattach-event)
-* [View "dom:refresh" / onDomRefresh event](#view-domrefresh--ondomrefresh-event)
 * [View.triggers](#viewtriggers)
 * [View.events](#viewevents)
 * [View.modelEvents and View.collectionEvents](#viewmodelevents-and-viewcollectionevents)
@@ -33,6 +32,7 @@ behaviors that are shared across all views.
   * [Accessing Data Within The Helpers](#accessing-data-within-the-helpers)
   * [Object Or Function As `templateHelpers`](#object-or-function-as-templatehelpers)
 * [Change Which Template Is Rendered For A View](#change-which-template-is-rendered-for-a-view)
+* [View "dom:refresh" / onDomRefresh event (deprecated)](#view-domrefresh--ondomrefresh-event)
 
 ## Binding To View Events
 
@@ -152,28 +152,6 @@ For more on efficient, deeply-nested view structures, refer to the LayoutView do
 
 This is just like the attach event described above, but it's triggered right before the view is
 attached to the document.
-
-### View "dom:refresh" / onDomRefresh event
-
-Triggered after the view has been rendered, has been shown in the DOM via a Marionette.Region, and has been
-re-rendered.
-
-This event / callback is useful for
-[DOM-dependent UI plugins](http://lostechies.com/derickbailey/2012/02/20/using-jquery-plugins-and-ui-controls-with-backbone/) such as
-[jQueryUI](http://jqueryui.com/) or [KendoUI](http://kendoui.com).
-
-```js
-Backbone.Marionette.ItemView.extend({
-  onDomRefresh: function(){
-    // manipulate the `el` here. it's already
-    // been rendered, and is full of the view's
-    // HTML, ready to go.
-  }
-});
-```
-
-For more information about integration Marionette w/ KendoUI (also applicable to jQueryUI and other UI
-widget suites), see [this blog post on KendoUI + Backbone](http://www.kendoui.com/blogs/teamblog/posts/12-11-26/backbone_and_kendo_ui_a_beautiful_combination.aspx).
 
 ## View.events
 Since Views extend from backbone's view class, you gain the benefits of the [events hash](http://backbonejs.org/#View-delegateEvents).
@@ -563,3 +541,27 @@ var MyView = Backbone.Marionette.ItemView.extend({
 ```
 
 This applies to all view classes.
+
+### View "dom:refresh" / onDomRefresh event
+
+> Warning: deprecated. This method is deprecated, and will be removed in v3.0.0. Use `onAttach` instead.
+
+Triggered after the view has been rendered, has been shown in the DOM via a Marionette.Region, and has been
+re-rendered.
+
+This event / callback is useful for
+[DOM-dependent UI plugins](http://lostechies.com/derickbailey/2012/02/20/using-jquery-plugins-and-ui-controls-with-backbone/) such as
+[jQueryUI](http://jqueryui.com/) or [KendoUI](http://kendoui.com).
+
+```js
+Backbone.Marionette.ItemView.extend({
+  onDomRefresh: function(){
+    // manipulate the `el` here. it's already
+    // been rendered, and is full of the view's
+    // HTML, ready to go.
+  }
+});
+```
+
+For more information about integration Marionette w/ KendoUI (also applicable to jQueryUI and other UI
+widget suites), see [this blog post on KendoUI + Backbone](http://www.kendoui.com/blogs/teamblog/posts/12-11-26/backbone_and_kendo_ui_a_beautiful_combination.aspx).

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -15,6 +15,12 @@ Marionette.Behavior = Marionette.Object.extend({
     this.view = view;
     this.defaults = _.result(this, 'defaults') || {};
     this.options  = _.extend({}, this.defaults, options);
+    // Construct an internal UI hash using
+    // the views UI hash and then the behaviors UI hash.
+    // This allows the user to use UI hash elements
+    // defined in the parent view as well as those
+    // defined in the given behavior.
+    this.ui = _.extend({}, _.result(view, 'ui'), _.result(this, 'ui'));
 
     Marionette.Object.apply(this, arguments);
   },

--- a/src/behaviors.js
+++ b/src/behaviors.js
@@ -37,23 +37,15 @@ Marionette.Behaviors = (function(Marionette, _) {
 
     behaviorEvents: function(behaviorEvents, behaviors) {
       var _behaviorsEvents = {};
-      var viewUI = this._uiBindings || _.result(this, 'ui');
 
       _.each(behaviors, function(b, i) {
         var _events = {};
         var behaviorEvents = _.clone(_.result(b, 'events')) || {};
-        var behaviorUI = b._uiBindings || _.result(b, 'ui');
 
-        // Construct an internal UI hash first using
-        // the views UI hash and then the behaviors UI hash.
-        // This allows the user to use UI hash elements
-        // defined in the parent view as well as those
-        // defined in the given behavior.
-        var ui = _.extend({}, viewUI, behaviorUI);
 
         // Normalize behavior events hash to allow
         // a user to use the @ui. syntax.
-        behaviorEvents = Marionette.normalizeUIKeys(behaviorEvents, ui);
+        behaviorEvents = Marionette.normalizeUIKeys(behaviorEvents, getBehaviorsUI(b));
 
         var j = 0;
         _.each(behaviorEvents, function(behaviour, key) {
@@ -140,7 +132,6 @@ Marionette.Behaviors = (function(Marionette, _) {
   // for views
   function BehaviorTriggersBuilder(view, behaviors) {
     this._view      = view;
-    this._viewUI    = _.result(view, 'ui');
     this._behaviors = behaviors;
     this._triggers  = {};
   }
@@ -154,10 +145,9 @@ Marionette.Behaviors = (function(Marionette, _) {
 
     // Internal method to build all trigger handlers for a given behavior
     _buildTriggerHandlersForBehavior: function(behavior, i) {
-      var ui = _.extend({}, this._viewUI, _.result(behavior, 'ui'));
       var triggersHash = _.clone(_.result(behavior, 'triggers')) || {};
 
-      triggersHash = Marionette.normalizeUIKeys(triggersHash, ui);
+      triggersHash = Marionette.normalizeUIKeys(triggersHash, getBehaviorsUI(behavior));
 
       _.each(triggersHash, _.bind(this._setHandlerForBehavior, this, behavior, i));
     },
@@ -173,6 +163,10 @@ Marionette.Behaviors = (function(Marionette, _) {
       this._triggers[triggerKey] = this._view._buildViewTrigger(eventName);
     }
   });
+
+  function getBehaviorsUI(behavior) {
+    return behavior._uiBindings || behavior.ui;
+  }
 
   return Behaviors;
 

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -276,6 +276,9 @@ describe('Behaviors', function() {
             'click @ui.foo': 'onFooClick',
             'click @ui.bar': 'onBarClick'
           },
+
+          testViewUI: function() { this.ui.bar.trigger('test'); },
+          testBehaviorUI: function() { this.ui.foo.trigger('test'); },
           onRender     : this.onRenderStub,
           onBeforeShow : this.onBeforeShowStub,
           onShow       : this.onShowStub,
@@ -342,6 +345,14 @@ describe('Behaviors', function() {
 
       it('should set the behavior UI element', function() {
         expect(this.onRenderStub).to.have.been.calledOnce;
+      });
+
+      it('should make the view\'s ui hash available to callbacks', function() {
+        expect(this.fooBehavior.testViewUI.bind(this.fooBehavior)).to.not.throw(Error);
+      });
+
+      it('should make the behavior\'s ui hash available to callbacks', function() {
+        expect(this.fooBehavior.testBehaviorUI.bind(this.fooBehavior)).to.not.throw(Error);
       });
 
       describe("the $el", function() {


### PR DESCRIPTION
This commit makes the view ui hash available consistently in
Behaviors, making it available in callbacks as well as the
events and triggers hashes.  There is also some refactoring to simplify
and centralize how the views ui hash is mixed into the Behaviors
reducing duplication

Closes #2338 and #2339 and replaces #2342 