### PR TITLE
First pass at optional root element

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,19 @@
 language: node_js
 node_js:
   - "0.10"
-matrix:
-  include:
-    - node_js: "0.10"
-      env: UNDERSCORE=1.4.4 BACKBONE=1.0
-    - node_js: "0.10"
-      env: UNDERSCORE=1.5 BACKBONE=1.0
-    - node_js: "0.10"
-      env: UNDERSCORE=1.7 BACKBONE=1.1
-    - node_js: "0.10"
-      env: UNDERSCORE=1.7 BACKBONE=1.0
-    - node_js: "0.10"
-      env: UNDERSCORE=1.6 BACKBONE=1.0
-    - node_js: "0.10"
-      env: UNDERSCORE=1.4.4 BACKBONE=1.1.0
-    - node_js: "0.10"
-      env: UNDERSCORE=1.5 BACKBONE=1.1
-    - node_js: "0.10"
-      env: LODASH=2.4 BACKBONE=1.1
-    - node_js: "0.10"
-      env: LODASH=3.0 BACKBONE=1.1
-    - node_js: "0.10"
-      env: LODASH=3.1 BACKBONE=1.0
-env: MAINRUN=true
+env:
+  global: MAINRUN=true
+  matrix:
+    - UNDERSCORE=1.4.4 BACKBONE=1.0
+    - UNDERSCORE=1.5 BACKBONE=1.0
+    - UNDERSCORE=1.7 BACKBONE=1.1
+    - UNDERSCORE=1.7 BACKBONE=1.0
+    - UNDERSCORE=1.6 BACKBONE=1.0
+    - UNDERSCORE=1.4.4 BACKBONE=1.1.0
+    - UNDERSCORE=1.5 BACKBONE=1.1
+    - LODASH=2.4 BACKBONE=1.1
+    - LODASH=3.0 BACKBONE=1.1
+    - LODASH=3.1 BACKBONE=1.0
 before_install:
   - npm config set ca ""
 install:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -146,6 +146,11 @@ module.exports = function(grunt) {
       }
     },
 
+    "yaml-validate": {
+      options: {
+        glob: "api/*.yaml"
+      }
+    },
     coveralls: {
       options: {
         src: 'coverage/lcov.info',
@@ -183,20 +188,6 @@ module.exports = function(grunt) {
         files: {
           src: ['test/unit/**.js']
         }
-      }
-    },
-
-    jsDocFiles: {
-     docs: {
-        options: {
-        },
-        files: [{
-          expand: true,
-          cwd: 'api',
-          src: '*.jsdoc',
-          dest: 'jsdoc',
-          ext: '.json'
-        }]
       }
     },
 
@@ -290,7 +281,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('dev', 'Auto-lints while writing code.', ['test', 'watch:marionette']);
 
-  grunt.registerTask('api', 'Build jsdoc api files', ['jsDocFiles']);
+  grunt.registerTask('api', 'test all yaml files', ['yaml-validate']);
 
   grunt.registerTask('build', 'Build all three versions of the library.', ['clean:lib', 'lint', 'mochaTest', 'unwrap', 'preprocess', 'template', 'concat', 'uglify']);
 };

--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -102,6 +102,7 @@
     <script src="test/unit/collection-view.empty-view.spec.js"></script>
     <script src="test/unit/collection-view.item-view-options.spec.js"></script>
     <script src="test/unit/collection-view.reset.spec.js"></script>
+    <script src="test/unit/collection-view.filter.spec.js"></script>
     <script src="test/unit/collection-view.spec.js"></script>
     <script src="test/unit/commands.spec.js"></script>
     <script src="test/unit/composite-view.child-view-container.spec.js"></script>

--- a/api/collection-view.yaml
+++ b/api/collection-view.yaml
@@ -324,3 +324,12 @@ functions:
       @api public
       @param {Marionette.View} view
     
+    filter:
+    description: |
+      ...
+
+      @api public
+      @param {Backbone.Model} model
+      @param {Number} index
+      @param {Backbone.Collection} collection
+

--- a/api/collection-view.yaml
+++ b/api/collection-view.yaml
@@ -306,6 +306,7 @@ functions:
       ...
       
       @api public
+      @returns {Marionette.CollectionView} The current view.
     
     examples:
       

--- a/api/controller.yaml
+++ b/api/controller.yaml
@@ -100,6 +100,8 @@ functions:
       corresponding `onBeforeDestroy` and `onDestroy` method calls. These calls will be passed any arguments `destroy`
       was invoked with.
       
+      @returns {Marionette.Controller} The current Controller.
+      
     examples:
       -
         name: Basic Use

--- a/api/item-view.yaml
+++ b/api/item-view.yaml
@@ -144,8 +144,9 @@ functions:
   destroy:
     description: |
       Destroy the view.
-
+      
       @api public
+      @returns {Marionette.ItemView} The current view.
 
     examples:
       -

--- a/api/layout-view.yaml
+++ b/api/layout-view.yaml
@@ -196,6 +196,7 @@ functions:
       If you are showing a LayoutView within a parent region manager, replacing the LayoutView with another view or LayoutView will destroy the current one. All of this ensures that LayoutViews and the views that they contain are cleaned up correctly.
       
       @api public
+      @returns {Marionette.LayoutView} The current view.
 
     examples:
       -

--- a/api/view.yaml
+++ b/api/view.yaml
@@ -50,6 +50,7 @@ functions:
   
   destroy: |
     @api public
+    @returns {Marionette.View} The current view.
   
   bindUIElements: |
     @api public

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -941,6 +941,7 @@ following are performed:
 * unbind all child views that were rendered
 * remove `this.el` from the DOM
 * call an `onDestroy` event on the view, if one is provided
+* the `CollectionView` is returned
 
 By providing an `onDestroy` event in your view definition, you can
 run custom code for your view that is fired after your view has been

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -28,6 +28,7 @@ will provide features such as `onShow` callbacks, etc. Please see
   * [CollectionView's `reorderOnSort`](#collectionviews-reorderonsort)
 * [CollectionView's `emptyView`](#collectionviews-emptyview)
   * [CollectionView's `getEmptyView`](#collectionviews-getemptyview)
+  * [CollectionView's `isEmpty`](#collectionviews-isempty)
   * [CollectionView's `emptyViewOptions`](#collectionviews-emptyviewoptions)
 * [Callback Methods](#callback-methods)
   * [onBeforeRender callback](#onbeforerender-callback)
@@ -69,9 +70,9 @@ a Backbone view object definition, not an instance. It can be any
 `Backbone.View` or be derived from `Marionette.ItemView`.
 
 ```js
-var MyChildView = Backbone.Marionette.ItemView.extend({});
+var MyChildView = Marionette.ItemView.extend({});
 
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   childView: MyChildView
 });
 ```
@@ -84,7 +85,7 @@ Alternatively, you can specify a `childView` in the options for
 the constructor:
 
 ```js
-var MyCollectionView = Backbone.Marionette.CollectionView.extend({...});
+var MyCollectionView = Marionette.CollectionView.extend({...});
 
 new MyCollectionView({
   childView: MyChildView
@@ -105,14 +106,14 @@ var FooBar = Backbone.Model.extend({
   }
 });
 
-var FooView = Backbone.Marionette.ItemView.extend({
+var FooView = Marionette.ItemView.extend({
   template: '#foo-template'
 });
-var BarView = Backbone.Marionette.ItemView.extend({
+var BarView = Marionette.ItemView.extend({
   template: '#bar-template'
 });
 
-var MyCollectionView = Backbone.Marionette.CollectionView.extend({
+var MyCollectionView = Marionette.CollectionView.extend({
   getChildView: function(item) {
     // Choose which view class to render,
     // depending on the properties of the item model
@@ -149,13 +150,13 @@ literal. This will be passed to the constructor of your childView as part
 of the `options`.
 
 ```js
-var ChildView = Backbone.Marionette.ItemView.extend({
+var ChildView = Marionette.ItemView.extend({
   initialize: function(options) {
     console.log(options.foo); // => "bar"
   }
 });
 
-var CollectionView = Backbone.Marionette.CollectionView.extend({
+var CollectionView = Marionette.CollectionView.extend({
   childView: ChildView,
 
   childViewOptions: {
@@ -171,7 +172,7 @@ the function should you need access to it when calculating
 of the object will be copied to the `childView` instance's options.
 
 ```js
-var CollectionView = Backbone.Marionette.CollectionView.extend({
+var CollectionView = Marionette.CollectionView.extend({
   childViewOptions: function(model, index) {
     // do some calculations based on the model
     return {
@@ -284,10 +285,10 @@ buildChildView: function(child, ChildViewClass, childViewOptions){
 The `addChild` method is responsible for rendering the `childViews` and adding them to the HTML for the `collectionView` instance. It is also responsible for triggering the events per `ChildView`. In most cases you should not override this method. However if you do want to short circuit this method, it can be accomplished via the following.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   addChild: function(child, ChildView, index){
     if (child.shouldBeShown()) {
-      Backbone.Marionette.CollectionView.prototype.addChild.apply(this, arguments);
+      Marionette.CollectionView.prototype.addChild.apply(this, arguments);
     }
   }
 });
@@ -313,11 +314,11 @@ the list of childViews, you can specify an `emptyView` attribute on your
 collection view.
 
 ```js
-var NoChildrenView = Backbone.Marionette.ItemView.extend({
+var NoChildrenView = Marionette.ItemView.extend({
   template: "#show-no-children-message-template"
 });
 
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   // ...
 
   emptyView: NoChildrenView
@@ -329,23 +330,23 @@ Backbone.Marionette.CollectionView.extend({
 If you need the `emptyView`'s class chosen dynamically, specify `getEmptyView`:
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   // ...
 
   getEmptyView: function() {
     // custom logic
     return NoChildrenView;
   }
+});
 ```
 
-This will render the `emptyView` and display the message that needs to
-be displayed when there are no children.
+### CollectionView's `isEmpty`
 
 If you want to control when the empty view is rendered, you can override
 `isEmpty`:
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   isEmpty: function(collection) {
     // some logic to calculate if the view should be rendered as empty
     return someBoolean;
@@ -360,13 +361,13 @@ Similar to `childView` and `childViewOptions`, there is an `emptyViewOptions` pr
 If `emptyViewOptions` aren't provided the CollectionView will default to passing the `childViewOptions` to the `emptyView`.
 
 ```js
-var EmptyView = Backbone.Marionette.ItemView({
+var EmptyView = Marionette.ItemView({
   initialize: function(options){
     console.log(options.foo); // => "bar"
   }
 });
 
-var CollectionView = Backbone.Marionette.CollectionView({
+var CollectionView = Marionette.CollectionView({
   emptyView: EmptyView,
 
   emptyViewOptions: {
@@ -388,7 +389,7 @@ A `onBeforeRender` callback will be called just prior to rendering
 the collection view.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onBeforeRender: function(){
     // do stuff here
   }
@@ -402,7 +403,7 @@ You can implement this in your view to provide custom code for dealing
 with the view's `el` after it has been rendered:
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onRender: function(){
     // do stuff here
   }
@@ -415,7 +416,7 @@ If `reorderOnSort` is set to `true`, `onBeforeReorder` will be called just
 prior to reordering the collection view.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onBeforeReorder: function(){
     // do stuff here
   }
@@ -428,7 +429,7 @@ If `reorderOnSort` is set to `true`, after the view has been reordered,
 a `onReorder` method will be called.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onReorder: function(){
     // do stuff here
   }
@@ -440,7 +441,7 @@ Backbone.Marionette.CollectionView.extend({
 This method is called just before destroying the view.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onBeforeDestroy: function(){
     // do stuff here
   }
@@ -452,7 +453,7 @@ Backbone.Marionette.CollectionView.extend({
 This method is called just after destroying the view.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onDestroy: function(){
     // do stuff here
   }
@@ -466,7 +467,7 @@ instance is about to be added to the collection view. It provides access to
 the view instance for the child that was added.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onBeforeAddChild: function(childView){
     // work with the childView instance, here
   }
@@ -480,7 +481,7 @@ instance has been added to the collection view. It provides access to
 the view instance for the child that was added.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onAddChild: function(childView){
     // work with the childView instance, here
   }
@@ -494,7 +495,7 @@ instance is about to be removed from the `collectionView`. It provides access to
 the view instance for the child that was removed.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onBeforeRemoveChild: function(childView){
     // work with the childView instance, here
   }
@@ -508,7 +509,7 @@ instance has been deleted or removed from the
 collection.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onRemoveChild: function(childView){
     // work with the childView instance, here
   }
@@ -530,7 +531,7 @@ Triggers just prior to the view being rendered. Also triggered as
 "collection:before:render" / `onCollectionBeforeRender`.
 
 ```js
-var MyView = Backbone.Marionette.CollectionView.extend({...});
+var MyView = Marionette.CollectionView.extend({...});
 
 var myView = new MyView();
 
@@ -549,7 +550,7 @@ and allows parent views and other parts of the application to
 know that the view was rendered.
 
 ```js
-var MyView = Backbone.Marionette.CollectionView.extend({...});
+var MyView = Marionette.CollectionView.extend({...});
 
 var myView = new MyView();
 
@@ -570,7 +571,7 @@ When `reorderOnSort` is set to `true`, these events are fired
 respectfully just prior/just after the reordering of the collection.
 
 ```js
-var MyView = Backbone.Marionette.CollectionView.extend({...});
+var MyView = Marionette.CollectionView.extend({...});
 
 var myCol = new Backbone.Collection({ comparator: ... })
 var myView = new MyView({ reorderOnSort: true });
@@ -595,7 +596,7 @@ Triggered just before destroying the view. A "before:destroy:collection" /
 `onBeforeDestroyCollection` event will also be fired
 
 ```js
-var MyView = Backbone.Marionette.CollectionView.extend({...});
+var MyView = Marionette.CollectionView.extend({...});
 
 var myView = new MyView();
 
@@ -612,7 +613,7 @@ Triggered just after destroying the view, both with corresponding
 method calls.
 
 ```js
-var MyView = Backbone.Marionette.CollectionView.extend({...});
+var MyView = Marionette.CollectionView.extend({...});
 
 var myView = new MyView();
 
@@ -741,7 +742,7 @@ children in the collection and renders them individually as an
 `childView`.
 
 ```js
-var MyCollectionView = Backbone.Marionette.CollectionView.extend({...});
+var MyCollectionView = Marionette.CollectionView.extend({...});
 
 // all of the children views will now be rendered.
 new MyCollectionView().render();
@@ -778,7 +779,7 @@ view definition. This method takes three parameters and has no return
 value.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
 
 	// The default implementation:
   attachHtml: function(collectionView, childView, index){
@@ -949,7 +950,7 @@ destroyed and cleaned up. This lets you handle any additional clean up
 code without having to override the `destroy` method.
 
 ```js
-Backbone.Marionette.CollectionView.extend({
+Marionette.CollectionView.extend({
   onDestroy: function() {
     // custom cleanup or destroying code, here
   }

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -245,7 +245,7 @@ var ChildView = new Marionette.ItemView.extend({
   showMessage: function () {
     console.log('The button was clicked.');
 
-    this.trigger('show:message');
+    this.triggerMethod('show:message');
   }
 });
 

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -786,12 +786,15 @@ Backbone.Marionette.CollectionView.extend({
       // buffering happens on reset events and initial renders
       // in order to reduce the number of inserts into the
       // document, which are expensive.
-      collectionView.elBuffer.appendChild(childView.el);
+      collectionView._bufferedChildren.splice(index, 0, childView);
     }
     else {
-      // If we've already rendered the main collection, just
-      // append the new children directly into the element.
-      collectionView.$el.append(childView.el);
+      // If we've already rendered the main collection, append
+      // the new child into the correct order if we need to. Otherwise
+      // append to the end.
+      if (!collectionView._insertBefore(childView, index)){
+        collectionView._insertAfter(childView);
+      }
     }
   },
 

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -58,6 +58,7 @@ will provide features such as `onShow` callbacks, etc. Please see
 * [CollectionView's attachHtml](#collectionviews-attachhtml)
 * [CollectionView's resortView](#collectionviews-resortview)
 * [CollectionView's viewComparator](#collectionviews-viewcomparator)
+* [CollectionView's `filter`](#collectionviews-filter)
 * [CollectionView's children](#collectionviews-children)
 * [CollectionView destroy](#collectionview-destroy)
 
@@ -301,6 +302,9 @@ is activated, when you sort your `Collection`, there will be no re-rendering, on
 will be reordered. This can be a problem if your `ChildView`s use their collection's index
 in their rendering. In this case, you cannot use this option as you need to re-render each
 `ChildView`.
+
+If you combine this option with a [filter](#collectionviews-filter) that changes the views that are
+to be displayed, `reorderOnSort` will be bypassed to render new children and remove those that are rejected by the filter.
 
 ## CollectionView's `emptyView`
 
@@ -847,6 +851,51 @@ CollectionView allows for a custom `viewComparator` option if you want your Coll
 ```
 
 The `viewComparator` can take any of the acceptable `Backbone.Collection` [comparator formats](http://backbonejs.org/#Collection-comparator) -- a sortBy (pass a function that takes a single argument), as a sort (pass a comparator function that expects two arguments), or as a string indicating the attribute to sort by.
+
+## CollectionView's `filter`
+
+CollectionView allows for a custom `filter` option if you want to prevent some of the
+underlying `collection`'s models from being rendered as child views.
+The filter function takes a model from the collection and returns a truthy value if the child should be rendered,
+and a falsey value if it should not.
+
+```js
+  var cv = new Marionette.CollectionView({
+    childView: SomeChildView,
+    emptyView: SomeEmptyView,
+    collection: new Backbone.Collection([
+      { value: 1 },
+      { value: 2 },
+      { value: 3 },
+      { value: 4 }
+    ]),
+
+    // Only show views with even values
+    filter: function (child, index, collection) {
+      return child.get('value') % 2 === 0;
+    }
+  });
+
+  // renders the views with values '2' and '4'
+  cv.render();
+
+  // change the filter
+  cv.filter = function (child, index, collection) {
+    return child.get('value') % 2 !== 0;
+  };
+
+  // renders the views with values '1' and '3'
+  cv.render();
+
+  // remove the filter
+  // note that using `delete cv.filter` will cause the prototype's filter to be used
+  // which may be undesirable
+  cv.filter = null;
+
+  // renders all views
+  cv.render();
+```
+
 
 ## CollectionView's children
 

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -290,6 +290,9 @@ one, the same it will destroy a view.
 All of this ensures that layoutViews and the views that they
 contain are cleaned up correctly.
 
+When calling `destroy` on a layoutView, the layoutView will be returned. This can be useful for
+chaining.
+
 ## Custom Region Class
 
 If you have the need to replace the `Region` with a region class of

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -27,6 +27,7 @@ will provide features such as `onShow` callbacks, etc. Please see
 
 * [Basic Usage](#basic-usage)
 * [Region Options](#region-options)
+* [LayoutView.childEvents](#layoutview-childevents)
 * [Specifying Regions As A Function](#specifying-regions-as-a-function)
 * [Overriding the default RegionManager](#overriding-the-default-regionmanager)
 * [Region Availability](#region-availability)
@@ -101,6 +102,74 @@ new Marionette.LayoutView({
  }
 })
 ```
+
+### LayoutView childEvents
+
+You can specify a `childEvents` hash or method which allows you to capture all
+bubbling `childEvents` without having to manually set bindings.
+
+The keys of the hash can either be a function or a string
+that is the name of a method on the layout view.
+
+The function is called in the context of the view. The first parameter is
+the child view, which emitted the event, the remainder are the arguments
+associated with the event.
+
+```js
+// childEvents can be specified as a hash...
+var MyLayoutView = Marionette.LayoutView.extend({
+
+  // This callback will be called whenever a child is rendered or emits a `render` event
+  childEvents: {
+    render: function(childView) {
+      console.log("a childView has been rendered");
+    }
+  }
+});
+
+// ...or as a function that returns a hash.
+var MyLayoutView = Marionette.LayoutView.extend({
+
+  childEvents: function() {
+    return {
+      render: this.onChildRender
+    }
+  },
+
+  onChildRender: function(childView) {
+  }
+});
+```
+
+This also works for custom events that you might fire on your child views.
+
+```js
+  // The child view fires a custom event, `show:message`
+  var ChildView = new Marionette.ItemView.extend({
+    events: {
+      'click .button': 'showMessage'
+    },
+
+    showMessage: function (e) {
+      console.log('The button was clicked.');
+      this.triggerMethod('show:message', msg);
+    }
+  });
+
+  // The parent uses childEvents to catch that custom event on the child view
+  var ParentView = new Marionette.LayoutView.extend({
+    childEvents: {
+      'show:message': function (childView, msg) {
+        console.log('The show:message event bubbled up to the parent.');
+      }
+    },
+
+    onChildviewShowMessage: function (childView, msg) {
+      console.log('The show:message event bubbled up to the parent.');
+    }
+  });
+```
+
 
 ### Specifying Regions As A Function
 

--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -76,7 +76,7 @@ instance.
 
 Invoking the `destroy` method will trigger a "before:destroy" event and corresponding
 `onBeforeDestroy` method call. These calls will be passed any arguments `destroy`
-was invoked with.
+was invoked with. Invoking `destroy` will return the object, this can be useful for chaining.
 
 ```js
 // define a object with an onDestroy method

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -107,6 +107,7 @@ are performed:
 * unbind all DOM events
 * remove `this.el` from the DOM
 * unbind all `listenTo` events
+* returns the view.
 
 By providing an `onDestroy` method in your view definition, you can
 run custom code for your view that is fired after your view has been

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "mocha": "1.19.0",
     "sinon": "1.10.3",
     "sinon-chai": "2.5.0",
-    "unwrap": "0.1.0"
+    "unwrap": "0.1.0",
+    "grunt-yaml-validate": "~0.1.1"
   }
 }

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -30,6 +30,8 @@ Marionette.Behavior = Marionette.Object.extend({
   // Overrides Object#destroy to prevent additional events from being triggered.
   destroy: function() {
     this.stopListening();
+
+    return this;
   },
 
   proxyViewProperties: function (view) {

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -527,7 +527,7 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Handle cleanup and other destroying needs for the collection of views
   destroy: function() {
-    if (this.isDestroyed) { return; }
+    if (this.isDestroyed) { return this; }
 
     this.triggerMethod('before:destroy:collection');
     this.destroyChildren();

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -92,17 +92,17 @@ Marionette.CollectionView = Marionette.View.extend({
   // Handle a child added to the collection
   _onCollectionAdd: function(child, collection, opts) {
     var index;
-
-    this.destroyEmptyView();
-    var ChildView = this.getChildView(child);
-
     if (opts.at !== undefined) {
       index = opts.at;
     } else {
-      index = this._sortedModels().indexOf(child);
+      index = this._filteredSortedModels().indexOf(child);
     }
 
-    this.addChild(child, ChildView, index);
+    if (this._shouldAddChild(child, index)) {
+      this.destroyEmptyView();
+      var ChildView = this.getChildView(child);
+      this.addChild(child, ChildView, index);
+    }
   },
 
   // get the child view by model it holds, and remove it
@@ -134,17 +134,28 @@ Marionette.CollectionView = Marionette.View.extend({
   // all the collectionView
   reorder: function () {
     var children = this.children;
-
-    // get the DOM nodes in the same order as the models
-    var els = _.map(this._sortedModels(), function (model) {
-      return children.findByModel(model).el;
+    var models = this._filteredSortedModels();
+    var modelsChanged = _.find(models, function (model) {
+      return !children.findByModel(model);
     });
 
-    // since append moves elements that are already in the DOM,
-    // appending the elements will effectively reorder them
-    this.triggerMethod('before:reorder');
-    this.$el.append(els);
-    this.triggerMethod('reorder');
+    // If the models we're displaying have changed due to filtering
+    // We need to add and/or remove child views
+    // So render as normal
+    if (modelsChanged) {
+      this.render();
+    } else {
+      // get the DOM nodes in the same order as the models
+      var els = _.map(models, function (model) {
+        return children.findByModel(model).el;
+      });
+
+      // since append moves elements that are already in the DOM,
+      // appending the elements will effectively reorder them
+      this.triggerMethod('before:reorder');
+      this.$el.append(els);
+      this.triggerMethod('reorder');
+    }
   },
 
   // Render view after sorting. Override this method to
@@ -162,7 +173,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // Internal method. This checks for any changes in the order of the collection.
   // If the index of any view doesn't match, it will render.
   _sortViews: function() {
-    var models = this._sortedModels();
+    var models = this._filteredSortedModels();
 
     // check for any changes in sort order of views
     var orderChanged = _.find(models, function(item, index){
@@ -193,6 +204,11 @@ Marionette.CollectionView = Marionette.View.extend({
       this.showCollection();
       this.endBuffering();
       this.triggerMethod('render:collection', this);
+
+      // If we have shown children and none have passed the filter, show the empty view
+      if (this.children.isEmpty()) {
+        this.showEmptyView();
+      }
     }
   },
 
@@ -200,7 +216,7 @@ Marionette.CollectionView = Marionette.View.extend({
   showCollection: function() {
     var ChildView;
 
-    var models = this._sortedModels();
+    var models = this._filteredSortedModels();
 
     _.each(models, function(child, index) {
       ChildView = this.getChildView(child);
@@ -209,7 +225,7 @@ Marionette.CollectionView = Marionette.View.extend({
   },
 
   // Allow the collection to be sorted by a custom view comparator
-  _sortedModels: function() {
+  _filteredSortedModels: function() {
     var models;
     var viewComparator = this.getViewComparator();
 
@@ -221,6 +237,13 @@ Marionette.CollectionView = Marionette.View.extend({
       }
     } else {
       models = this.collection.models;
+    }
+
+    // Filter after sorting in case the filter uses the index
+    if (this.getOption('filter')) {
+      models = _.filter(models, function (model, index) {
+        return this._shouldAddChild(model, index);
+      }, this);
     }
 
     return models;
@@ -520,6 +543,18 @@ Marionette.CollectionView = Marionette.View.extend({
     this.children.each(this.removeChildView, this);
     this.checkEmpty();
     return childViews;
+  },
+
+  // Return true if the given child should be shown
+  // Return false otherwise
+  // The filter will be passed (child, index, collection)
+  // Where
+  //  'child' is the given model
+  //  'index' is the index of that model in the collection
+  //  'collection' is the collection referenced by this CollectionView
+  _shouldAddChild: function (child, index) {
+    var filter = this.getOption('filter');
+    return !_.isFunction(filter) || filter.call(this, child, index, this.collection);
   },
 
   // Set up the child view event forwarding. Uses a "childview:"

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -115,7 +115,13 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // }
   // ```
   attachElContent: function(html) {
-    this.$el.html(html);
+    if (this.noElement === true) {
+      var newEl = $(html);
+      this.$el.replaceWith(newEl);
+      this.setElement();
+    } else {
+      this.$el.html(html);
+    }
 
     return this;
   },

--- a/src/item-view.js
+++ b/src/item-view.js
@@ -81,6 +81,13 @@ Marionette.ItemView = Marionette.View.extend({
       });
     }
 
+    if (!template && this.noElement === true) {
+      throw new Marionette.Error({
+        name: 'UndefinedTemplateAndNoElementError',
+        message: 'Cannot render the template since it is null or undefined, and no element has been specified.'
+      });
+    }
+
     // Add in entity data and template helpers
     var data = this.mixinTemplateHelpers(this.serializeData());
 
@@ -104,7 +111,13 @@ Marionette.ItemView = Marionette.View.extend({
   // }
   // ```
   attachElContent: function(html) {
-    this.$el.html(html);
+      if (this.noElement === true) {
+        var newEl = $(html);
+        this.$el.replaceWith(newEl);
+        this.setElement();
+      } else {
+        this.$el.html(html);
+      }
 
     return this;
   }

--- a/src/layout-view.js
+++ b/src/layout-view.js
@@ -14,6 +14,10 @@ Marionette.LayoutView = Marionette.ItemView.extend({
     destroyImmediate: false
   },
 
+  // used as the prefix for child view events
+  // that are forwarded through the layoutview
+  childViewEventPrefix: 'childview',
+
   // Ensure the regions are available when the `initialize` method
   // is called.
   constructor: function(options) {

--- a/src/object.js
+++ b/src/object.js
@@ -24,6 +24,8 @@ _.extend(Marionette.Object.prototype, Backbone.Events, {
     this.triggerMethod('before:destroy');
     this.triggerMethod('destroy');
     this.stopListening();
+
+    return this;
   },
 
   // Import the `triggerMethod` to trigger events with corresponding

--- a/src/view.js
+++ b/src/view.js
@@ -148,7 +148,7 @@ Marionette.View = Backbone.View.extend({
   // for you. You can specify an `onDestroy` method in your view to
   // add custom code that is called after the view is destroyed.
   destroy: function() {
-    if (this.isDestroyed) { return; }
+    if (this.isDestroyed) { return this; }
 
     var args = _.toArray(arguments);
 

--- a/src/view.js
+++ b/src/view.js
@@ -18,7 +18,7 @@ Marionette.View = Backbone.View.extend({
     // at some point however this may be removed
     this.options = _.extend({}, _.result(this, 'options'), options);
 
-    if (this.options && ('el' in this.options ? this.options.el === false : this.el === false)) {
+    if (this.getOption('el') === false) {
       this.noElement = true;
     }
 

--- a/src/view.js
+++ b/src/view.js
@@ -5,6 +5,7 @@
 // The core view class that other Marionette views extend from.
 Marionette.View = Backbone.View.extend({
   isDestroyed: false,
+  noElement: false,
 
   constructor: function(options) {
     _.bindAll(this, 'render');
@@ -16,6 +17,10 @@ Marionette.View = Backbone.View.extend({
     // of this.options
     // at some point however this may be removed
     this.options = _.extend({}, _.result(this, 'options'), options);
+
+    if (this.options && ('el' in this.options ? this.options.el === false : this.el === false)) {
+      this.noElement = true;
+    }
 
     this._behaviors = Marionette.Behaviors(this);
 

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -777,6 +777,7 @@ describe('Behaviors', function() {
     });
 
     it('should return the behavior', function() {
+      expect(this.behavior.destroy).to.have.returned(this.behavior);
     });
   });
 });

--- a/test/unit/collection-view.filter.spec.js
+++ b/test/unit/collection-view.filter.spec.js
@@ -1,0 +1,404 @@
+describe("collection view - filter", function() {
+  'use strict';
+
+  beforeEach(function() {
+    var spec = this;
+
+    this.passModel = new Backbone.Model({foo: true});
+    this.failModel = new Backbone.Model({foo: false});
+    this.collection = new Backbone.Collection();
+
+    this.EmptyView = Backbone.Marionette.ItemView.extend({
+      template: function() {
+        return 'empty';
+      }
+    });
+
+    this.ChildView = Backbone.Marionette.ItemView.extend({
+      template: function(data) {
+        return data.foo;
+      }
+    });
+
+    this.filter = this.sinon.spy(function(child) {
+      return child.get('foo');
+    });
+
+    this.inverseFilter = this.sinon.spy(function(child) {
+      return !spec.filter(child);
+    });
+
+    this.CollectionView = Backbone.Marionette.CollectionView.extend({
+      emptyView: this.EmptyView,
+      childView: this.ChildView,
+      filter: this.filter,
+      collection: this.collection,
+      onBeforeRemoveChild: this.sinon.stub(),
+      onRemoveChild: this.sinon.stub()
+    });
+  });
+
+  describe("_shouldAddChild", function() {
+    it("returns the result of the filter", function() {
+      var collectionView = new this.CollectionView();
+      expect(collectionView._shouldAddChild(this.passModel)).to.be.true;
+      expect(collectionView._shouldAddChild(this.failModel)).to.be.false;
+    });
+
+    it("will prefer to use the filter supplied at construction", function() {
+      var collectionView = new this.CollectionView({
+        filter: this.inverseFilter
+      });
+      expect(collectionView._shouldAddChild(this.passModel)).to.be.false;
+      expect(collectionView._shouldAddChild(this.failModel)).to.be.true;
+    });
+
+    it("always returns true when no filter is supplied", function() {
+      var collectionView = new Backbone.Marionette.CollectionView();
+      expect(collectionView._shouldAddChild(this.passModel)).to.be.true;
+      expect(collectionView._shouldAddChild(this.failModel)).to.be.true;
+    });
+  });
+
+  describe("when rendering a collection where some models pass the filter", function() {
+    beforeEach(function() {
+      this.collection.add(this.passModel);
+      this.collection.add(this.failModel);
+      this.collectionView = new this.CollectionView();
+      this.collectionView.render();
+    });
+
+    it('should add children for models accepted by the filter', function() {
+      expect(this.collectionView.children.findByModel(this.passModel)).to.exist;
+    });
+
+    it('should not add children for models rejected by the filter', function() {
+      expect(this.collectionView.children.findByModel(this.failModel)).not.to.exist;
+    });
+
+    it('should call the filter method for each model', function() {
+      expect(this.filter).to.have.been.calledTwice
+        .and.calledOn(this.collectionView)
+        .and.calledWith(this.passModel, 0, this.collection)
+        .and.calledWith(this.failModel, 1, this.collection);
+    });
+
+    it('should contain the view that passed the filter in the DOM', function() {
+      expect(this.collectionView.$el).to.contain.$text('true');
+    });
+
+    it('children.length corresponds to the number of children displayed', function() {
+      expect(this.collectionView.children.length).to.equal(1);
+    });
+
+    describe("when a model that fails the filter is removed from the collection", function() {
+      beforeEach(function() {
+        this.collection.remove(this.failModel);
+      });
+
+      it('should not execute onBeforeRemoveChild', function() {
+        expect(this.collectionView.onBeforeRemoveChild).not.to.have.been.called;
+      });
+
+      it('should not execute onRemoveChild', function() {
+        expect(this.collectionView.onRemoveChild).not.to.have.been.called;
+      });
+
+      it('children.length corresponds to the number of children displayed', function() {
+        expect(this.collectionView.children.length).to.equal(1);
+      });
+    });
+
+    describe("when resetting the collection with some of the models passing the filter", function() {
+      beforeEach(function() {
+        this.filter.reset();
+        this.newPassModel = this.passModel.clone();
+        this.newFailModel = this.failModel.clone();
+        this.collection.reset([this.newFailModel, this.newPassModel]);
+      });
+
+      it('should add children for models accepted by the filter', function() {
+        expect(this.collectionView.children.findByModel(this.newPassModel)).to.exist;
+      });
+
+      it('should not add children for models rejected by the filter', function() {
+        expect(this.collectionView.children.findByModel(this.newFailModel)).not.to.exist;
+      });
+
+      it('should call the filter method for each model', function() {
+        expect(this.filter).to.have.been.calledTwice
+          .and.calledOn(this.collectionView)
+          .and.calledWith(this.newFailModel, 0, this.collection)
+          .and.calledWith(this.newPassModel, 1, this.collection);
+      });
+
+      it('should contain the view that passed the filter in the DOM', function() {
+        expect(this.collectionView.$el).to.contain.$text('true');
+      });
+
+      it('children.length corresponds to the number of children displayed', function() {
+        expect(this.collectionView.children.length).to.equal(1);
+      });
+    });
+
+    describe("when resetting the collection with none of the models passing the filter", function() {
+      beforeEach(function() {
+        this.filter.reset();
+        this.newFailModel = this.failModel.clone();
+        this.sinon.spy(this.collectionView, 'showEmptyView');
+        this.collection.reset([this.newFailModel]);
+      });
+
+      it('should not add children for models rejected by the filter', function() {
+        expect(this.collectionView.children.findByModel(this.newFailModel)).not.to.exist;
+      });
+
+      it('should show the empty view', function() {
+        expect(this.collectionView.showEmptyView).to.have.been.calledOnce
+          .and.calledOn(this.collectionView);
+      });
+
+      it('should contain the empty view in the DOM', function() {
+        expect(this.collectionView.$el).to.contain.$text('empty');
+      });
+    });
+
+    describe("changing the filter", function() {
+      beforeEach(function() {
+        this.collectionView.filter = this.inverseFilter;
+      });
+
+      it("uses the new filter on the next render", function() {
+        this.collectionView.render();
+        expect(this.collectionView.children.findByModel(this.passModel)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.failModel)).to.exist;
+      });
+    });
+
+    describe("removing the filter", function() {
+      beforeEach(function() {
+        this.collectionView.filter = null;
+      });
+
+      it("shows all views on the next render", function() {
+        this.collectionView.render();
+        expect(this.collectionView.children.findByModel(this.passModel)).to.exist;
+        expect(this.collectionView.children.findByModel(this.failModel)).to.exist;
+      });
+    });
+  });
+
+  describe("when rendering a collection where no models pass the filter", function() {
+    beforeEach(function() {
+      this.collection.add(this.failModel);
+      this.collectionView = new this.CollectionView();
+      this.sinon.spy(this.collectionView, 'showEmptyView');
+      this.collectionView.render();
+    });
+
+    it('should show the empty view', function() {
+      expect(this.collectionView.showEmptyView).to.have.been.calledOnce
+        .and.calledOn(this.collectionView);
+    });
+
+    it('should contain the empty view in the DOM', function() {
+      expect(this.collectionView.$el).to.contain.$text('empty');
+    });
+  });
+
+  describe("manipulating the collection after rendering with an empty collection", function() {
+    beforeEach(function() {
+      this.collectionView = new this.CollectionView();
+      this.collectionView.render();
+      this.sinon.spy(this.collectionView, 'destroyEmptyView');
+    });
+
+    describe('when a model is added to the collection but rejected by the filter', function() {
+      beforeEach(function() {
+        this.collection.add(this.failModel);
+      });
+
+      it('should contain the empty view in the DOM', function() {
+        expect(this.collectionView.$el).to.contain.$text('empty');
+      });
+
+      it('should not destroy the empty view', function() {
+        expect(this.collectionView.destroyEmptyView).not.to.have.been.called;
+      });
+    });
+
+    describe('when a model is added to the collection and is accepted by the filter', function() {
+      beforeEach(function() {
+        this.collection.add(this.passModel);
+      });
+
+      it('should contain the empty view in the DOM', function() {
+        expect(this.collectionView.$el).to.contain.$text('true');
+      });
+
+      it('should destroy the empty view', function() {
+        expect(this.collectionView.destroyEmptyView).to.have.been.calledOnce
+          .and.calledOn(this.collectionView);
+      });
+    });
+  });
+
+  describe("combined with a sort", function() {
+    beforeEach(function() {
+      this.collection.comparator = 'bar';
+      this.model1 = new Backbone.Model({foo: true, bar: 1});
+      this.model2 = new Backbone.Model({foo: false, bar: 2});
+      this.model3 = new Backbone.Model({foo: true, bar: 3});
+      this.model4 = new Backbone.Model({foo: false, bar: 4});
+      this.collection.reset([this.model2, this.model4, this.model3, this.model1]);
+
+      this.ChildView = Marionette.ItemView.extend({
+        template: function(data) {
+          return data.bar;
+        }
+      });
+      this.collectionView = new this.CollectionView({childView: this.ChildView});
+    });
+
+    describe("when the filter does not change between sorts", function() {
+      beforeEach(function() {
+        this.collectionView.render();
+        this.collection.comparator = function(model) {
+          return -model.get('bar');
+        };
+        this.collection.sort();
+      });
+
+      it("only renders views that pass the filter", function() {
+        expect(this.collectionView.children.findByModel(this.model1)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model2)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model3)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model4)).not.to.exist;
+      });
+
+      it("renders the views in the correct order", function() {
+        expect(this.collectionView.$el).to.contain.$text('31');
+      });
+    });
+
+    describe("when the filter changes between sorts", function() {
+      beforeEach(function() {
+        this.collectionView.render();
+        this.collectionView.filter = this.inverseFilter;
+        this.collection.sort();
+      });
+
+      it("only renders views that pass the filter", function() {
+        expect(this.collectionView.children.findByModel(this.model1)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model2)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model3)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model4)).to.exist;
+      });
+
+      it("renders the views in the correct order", function() {
+        expect(this.collectionView.$el).to.contain.$text('24');
+      });
+    });
+
+    describe("when the filter changes between sorts and the collection hasn't changed order", function() {
+      beforeEach(function() {
+        this.collection.sort();
+        this.collectionView.render();
+        this.collectionView.filter = this.inverseFilter;
+        this.collection.sort();
+      });
+
+      it("only renders views that pass the filter", function() {
+        expect(this.collectionView.children.findByModel(this.model1)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model2)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model3)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model4)).to.exist;
+      });
+
+      it("renders the views in the correct order", function() {
+        expect(this.collectionView.$el).to.contain.$text('24');
+      });
+    });
+  });
+
+  describe("combined with a reorder", function() {
+    beforeEach(function() {
+      this.collection.comparator = 'bar';
+      this.model1 = new Backbone.Model({foo: true, bar: 1});
+      this.model2 = new Backbone.Model({foo: false, bar: 2});
+      this.model3 = new Backbone.Model({foo: true, bar: 3});
+      this.model4 = new Backbone.Model({foo: false, bar: 4});
+      this.collection.reset([this.model2, this.model4, this.model3, this.model1]);
+
+      this.ChildView = Marionette.ItemView.extend({
+        template: function(data) {
+          return data.bar;
+        }
+      });
+      this.collectionView = new this.CollectionView({
+        childView: this.ChildView,
+        reorderOnSort: true
+      });
+    });
+
+    describe("when the filter does not change between sorts", function() {
+      beforeEach(function() {
+        this.collectionView.render();
+        this.collection.comparator = function(model) {
+          return -model.get('bar');
+        };
+        this.collection.sort();
+      });
+
+      it("only renders views that pass the filter", function() {
+        expect(this.collectionView.children.findByModel(this.model1)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model2)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model3)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model4)).not.to.exist;
+      });
+
+      it("renders the views in the correct order", function() {
+        expect(this.collectionView.$el).to.contain.$text('31');
+      });
+    });
+
+    describe("when the filter changes between sorts", function() {
+      beforeEach(function() {
+        this.collectionView.render();
+        this.collectionView.filter = this.inverseFilter;
+        this.collection.sort();
+      });
+
+      it("only renders views that pass the filter", function() {
+        expect(this.collectionView.children.findByModel(this.model1)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model2)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model3)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model4)).to.exist;
+      });
+
+      it("renders the views in the correct order", function() {
+        expect(this.collectionView.$el).to.contain.$text('24');
+      });
+    });
+
+    describe("when the filter changes between sorts and the collection hasn't changed order", function() {
+      beforeEach(function() {
+        this.collection.sort();
+        this.collectionView.render();
+        this.collectionView.filter = this.inverseFilter;
+        this.collection.sort();
+      });
+
+      it("only renders views that pass the filter", function() {
+        expect(this.collectionView.children.findByModel(this.model1)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model2)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model3)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model4)).to.exist;
+      });
+
+      it("renders the views in the correct order", function() {
+        expect(this.collectionView.$el).to.contain.$text('24');
+      });
+    });
+  });
+});

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -677,6 +677,20 @@ describe('collection view', function() {
     it('should be marked not rendered', function() {
       expect(this.collectionView).to.have.property('isRendered', false);
     });
+
+    it('should return the CollectionView', function() {
+      expect(this.collectionView.destroy).to.have.returned(this.collectionView);
+    });
+
+    describe('and it has already been destroyed', function() {
+      beforeEach(function() {
+        this.collectionView.destroy();
+      });
+
+      it('should return the CollectionView', function() {
+        expect(this.collectionView.destroy).to.have.returned(this.collectionView);
+      });
+    });
   });
 
   describe('when removing a childView that does not have a "destroy" method', function() {

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -50,6 +50,7 @@ describe('marionette object', function() {
     beforeEach(function() {
       this.object = new Marionette.Object();
 
+      this.sinon.spy(this.object, 'destroy');
       this.beforeDestroyHandler = sinon.spy();
       this.object.on('before:destroy', this.beforeDestroyHandler);
       this.object.destroy();
@@ -57,6 +58,10 @@ describe('marionette object', function() {
 
     it('should hear the before:destroy event', function() {
       expect(this.beforeDestroyHandler).to.have.been.calledOnce;
+    });
+
+    it('should return the object', function() {
+      expect(this.object.destroy).to.have.returned(this.object);
     });
   });
 });

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -46,7 +46,8 @@ describe('base view', function() {
 
       this.view = new Marionette.View();
 
-      this.removeSpy = this.sinon.spy(this.view, 'remove');
+      this.sinon.spy(this.view, 'remove');
+      this.sinon.spy(this.view, 'destroy');
 
       this.onDestroyStub = this.sinon.stub();
       this.view.onDestroy = this.onDestroyStub;
@@ -66,11 +67,25 @@ describe('base view', function() {
     });
 
     it('should remove the view', function() {
-      expect(this.removeSpy).to.have.been.calledOnce;
+      expect(this.view.remove).to.have.been.calledOnce;
     });
 
     it('should set the view isDestroyed to true', function() {
       expect(this.view).to.be.have.property('isDestroyed', true);
+    });
+
+    it('should return the View', function() {
+      expect(this.view.destroy).to.have.returned(this.view);
+    });
+
+    describe('and it has already been destroyed', function() {
+      beforeEach(function() {
+        this.view.destroy();
+      });
+
+      it('should return the View', function() {
+        expect(this.view.destroy).to.have.returned(this.view);
+      });
     });
 
     describe('isDestroyed property', function() {


### PR DESCRIPTION
1. Adds ability to pass `el: false` via View.
2. Handles errors if both `template: false` and `el: false`.
3. Changes `attachElContent` in `ItemView` and `CompositeView` to allow replacing default `$el`.

This is my very naive first attempt at this. I have more than likely not considered some aspects, so please feel free to tell me where I've not looked.

One thing that jumped out at me is that `CompositeView` doesn't handle errors when `template` is false. Is that expected behaviour?

I am new to Marionette, so please help me get this PR up to scratch.