### PR TITLE
Adding an array-based syntax for Behaviors

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -55,7 +55,8 @@ var MyView = Marionette.ItemView.extend({
 
 Interaction points, such as tooltips and warning messages, are generic concepts. There is no need to recode them within your Views. They are prime for abstraction into a higher level non-coupled concept, which is exactly what Behaviors provide you with.
 
-Here is the syntax for declaring which behaviors get used within a View.
+Here is the syntax for declaring which behaviors get used within a View.  You can pass behaviors either as a set of key-value pairs where the keys are used to
+lookup the behavior class, or as an array.
 The keys in the hash are passed to `getBehaviorClass` which looks up the correct `Behavior` class.
 The options for each Behavior are also passed through to the Behavior during initialization. The options are then stored within each Behavior under `options`.
 

--- a/src/behaviors.js
+++ b/src/behaviors.js
@@ -91,24 +91,30 @@ Marionette.Behaviors = (function(Marionette, _) {
     // Takes care of getting the behavior class
     // given options and a key.
     // If a user passes in options.behaviorClass
-    // default to using that. Otherwise delegate
-    // the lookup to the users `behaviorsLookup` implementation.
+    // default to using that.
+    // If a user passes in a Behavior Class directly, use that
+    // Otherwise delegate the lookup to the users `behaviorsLookup` implementation.
     getBehaviorClass: function(options, key) {
       if (options.behaviorClass) {
         return options.behaviorClass;
+        //treat functions as a Behavior constructor
+      } else if (_.isFunction(options)) {
+        return options;
       }
 
-      // Get behavior class can be either a flat object or a method
+      // behaviorsLookup can be either a flat object or a method
       return Marionette._getValue(Behaviors.behaviorsLookup, this, [options, key])[key];
     },
 
     // Iterate over the behaviors object, for each behavior
     // instantiate it and get its grouped behaviors.
+    // This accepts a list of behaviors in either an object or array form
     parseBehaviors: function(view, behaviors) {
       return _.chain(behaviors).map(function(options, key) {
         var BehaviorClass = Behaviors.getBehaviorClass(options, key);
-
-        var behavior = new BehaviorClass(options, view);
+        //if we're passed a class directly instead of an object
+        var _options = options === BehaviorClass ? {} : options;
+        var behavior = new BehaviorClass(_options, view);
         var nestedBehaviors = Behaviors.parseBehaviors(view, _.result(behavior, 'behaviors'));
 
         return [behavior].concat(nestedBehaviors);

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -39,8 +39,12 @@ describe('Behaviors', function() {
 
   describe('behavior parsing', function() {
     beforeEach(function() {
+      this.Bar = Marionette.Behavior.extend({});
+      this.Baz = Marionette.Behavior.extend({});
       this.behaviors = {
-        foo: this.sinon.spy(Marionette, 'Behavior')
+        foo: this.sinon.spy(Marionette, 'Behavior'),
+        bar: this.sinon.spy(this, 'Bar'),
+        baz: this.sinon.spy(this, 'Baz')
       };
 
       Marionette.Behaviors.behaviorsLookup = this.behaviors;
@@ -106,6 +110,27 @@ describe('Behaviors', function() {
 
       it('should instantiate the behavior', function() {
         expect(this.behaviors.foo).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when behaviors are specified as an array', function() {
+      beforeEach(function() {
+        this.View = Marionette.ItemView.extend({
+          behaviors: [this.behaviors.foo, this.behaviors.bar, {
+            behaviorClass: this.behaviors.baz
+          }]
+        });
+
+        this.view = new this.View();
+      });
+
+      it('should instantiate behaviors passed directly as a class', function() {
+        expect(this.behaviors.foo).to.have.been.calledOnce;
+        expect(this.behaviors.bar).to.have.been.calledOnce;
+      });
+
+      it('should instantiate behaviors passed with behaviorClass', function() {
+        expect(this.behaviors.baz).to.have.been.calledOnce;
       });
     });
   });


### PR DESCRIPTION
Add an array based syntax for attaching Behaviors to Views.  

Would close #2366.