### PR TITLE
allow CompositeView to override how reordered children are appended

### DIFF
--- a/api/collection-view.yaml
+++ b/api/collection-view.yaml
@@ -114,6 +114,15 @@ functions:
       @api private
     
     examples:
+
+  _appendReorderedChildren:
+    description: |
+      ...
+      
+      @api private
+      @param {} children
+
+    examples:
       
   _renderChildren:
     description: |

--- a/api/composite-view.yaml
+++ b/api/composite-view.yaml
@@ -95,6 +95,15 @@ functions:
       @param {} childView
 
     examples:
+
+  _appendReorderedChildren:
+    description: |
+      ...
+      
+      @api private
+      @param {} children
+
+    examples:
       
   getChildViewContainer:
     description: |

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -153,7 +153,7 @@ Marionette.CollectionView = Marionette.View.extend({
       // since append moves elements that are already in the DOM,
       // appending the elements will effectively reorder them
       this.triggerMethod('before:reorder');
-      this.$el.append(els);
+      this._appendReorderedChildren(els);
       this.triggerMethod('reorder');
     }
   },
@@ -188,6 +188,12 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Internal reference to what index a `emptyView` is.
   _emptyViewIndex: -1,
+
+  // Internal method. Separated so that CompositeView can append to the childViewContainer
+  // if necessary
+  _appendReorderedChildren: function(children) {
+    this.$el.append(children);
+  },
 
   // Internal method. Separated so that CompositeView can have
   // more control over events being triggered, around the rendering

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -134,6 +134,14 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     $container.append(childView.el);
   },
 
+  // Internal method. Append reordered childView'.
+  // Overidden from CollectionView to ensure reordered views
+  // are appended to childViewContainer
+  _appendReorderedChildren: function(children) {
+    var $container = this.getChildViewContainer(this);
+    $container.append(children);
+  },
+
   // Internal method to ensure an `$childViewContainer` exists, for the
   // `attachHtml` method to use.
   getChildViewContainer: function(containerView, childView) {

--- a/test/unit/sorted-views.spec.js
+++ b/test/unit/sorted-views.spec.js
@@ -12,7 +12,7 @@ describe('collection/composite view sorting', function() {
 
     this.CompositeView = Marionette.CompositeView.extend({
       childView: this.ChildView,
-      template: this.sinon.stub()
+      template: _.template('<div id="container"></div>')
     });
 
     this.collection = new Backbone.Collection([{foo: 1, bar: 4}, {foo: 2, bar: 3}, {foo: 3, bar: 2}]);
@@ -421,16 +421,31 @@ describe('collection/composite view sorting', function() {
             this.collectionView = new this.CollectionView(_.extend({}, {
               reorderOnSort: true
             }, commonAttrs));
+
+            this.compositeView = new this.CompositeView(_.extend({}, {
+              reorderOnSort: true,
+              childViewContainer: '#container'
+            }, commonAttrs));
           } else if (specOptions.onPrototype) {
             var ReorderedCollectionView = this.CollectionView.extend({
               reorderOnSort: true,
               onReorder: this.sinon.spy(),
               onBeforeReorder: this.sinon.spy()
             });
+
+            var ReorderedCompositeView = this.CompositeView.extend({
+              reorderOnSort: true,
+              childViewContainer: '#container',
+              onReorder: this.sinon.spy(),
+              onBeforeReorder: this.sinon.spy()
+            });
+
             this.collectionView = new ReorderedCollectionView(commonAttrs);
+            this.compositeView = new ReorderedCompositeView(commonAttrs);
           }
 
           this.collectionView.render();
+          this.compositeView.render();
           this.sinon.spy(this.collectionView, 'reorder');
           this.sinon.spy(this.collectionView, 'render');
           this.sinon.spy(this.collectionView, 'trigger');
@@ -441,6 +456,7 @@ describe('collection/composite view sorting', function() {
           if (specOptions.viewComparator) {
             this.collection.comparator = 'foo';
             this.collectionView.options.viewComparator = cmp;
+            this.compositeView.options.viewComparator = cmp;
           } else {
             this.collection.comparator = cmp;
           }
@@ -464,6 +480,10 @@ describe('collection/composite view sorting', function() {
           expect(cv.trigger).to.have.been.calledWith('before:reorder');
           expect(cv.trigger).to.have.been.calledWith('reorder');
           expect(cv.trigger).to.have.been.calledTwice;
+        });
+
+        it('should respect the childViewContainer in a CompositeView', function() {
+          expect(this.compositeView.$('#container')).to.have.$text('321');
         });
       });
     };


### PR DESCRIPTION
Fixes #2367 

Added `_appendReorderedChildren` method to allow `CompositeView` to override where the reordered children are appended.

Added a test around this behaviour which fails without the new fix.