### PR TITLE
add checkEmpty flag to destroyChildren in CollectionView

### DIFF
--- a/api/collection-view.yaml
+++ b/api/collection-view.yaml
@@ -324,6 +324,7 @@ functions:
       ...
       
       @api public
+      @param {Object} options
     
     examples:
       

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -30,6 +30,7 @@ will provide features such as `onShow` callbacks, etc. Please see
   * [CollectionView's `getEmptyView`](#collectionviews-getemptyview)
   * [CollectionView's `isEmpty`](#collectionviews-isempty)
   * [CollectionView's `emptyViewOptions`](#collectionviews-emptyviewoptions)
+  * [CollectionView's `destroyChildren`](#collectionviews-destroychildren)
 * [Callback Methods](#callback-methods)
   * [onBeforeRender callback](#onbeforerender-callback)
   * [onRender callback](#onrender-callback)
@@ -375,6 +376,16 @@ var CollectionView = Marionette.CollectionView({
     foo: "bar"
   }
 });
+```
+
+### CollectionView's `destroyChildren`
+
+`CollectionView` provides a `destroyChildren` method that will only destroy it's childViews. This can be useful when you would like to empty your view but keep the data in the `collection`. This method takes an optional `checkEmpty` parameter, by default it is set to `true`, if `false` it will disable the call to `checkEmpty` and `destroyChildren` will not show the `emptyView`.
+
+```js
+myView.destroyChildren(); // will show emptyView
+myView.destroyChildren({checkEmpty: false}); // will not show emptyView
+
 ```
 
 ## Callback Methods

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -200,7 +200,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // process
   _renderChildren: function() {
     this.destroyEmptyView();
-    this.destroyChildren();
+    this.destroyChildren({checkEmpty: false});
 
     if (this.isEmpty(this.collection)) {
       this.showEmptyView();
@@ -538,7 +538,7 @@ Marionette.CollectionView = Marionette.View.extend({
     if (this.isDestroyed) { return this; }
 
     this.triggerMethod('before:destroy:collection');
-    this.destroyChildren();
+    this.destroyChildren({checkEmpty: false});
     this.triggerMethod('destroy:collection');
 
     return Marionette.View.prototype.destroy.apply(this, arguments);
@@ -546,10 +546,20 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Destroy the child views that this collection view
   // is holding on to, if any
-  destroyChildren: function() {
+  destroyChildren: function(options) {
+    var destroyOptions = options || {};
+    var shouldCheckEmpty = true;
     var childViews = this.children.map(_.identity);
+
+    if (!_.isUndefined(destroyOptions.checkEmpty)) {
+      shouldCheckEmpty = destroyOptions.checkEmpty;
+    }
+
     this.children.each(this.removeChildView, this);
-    this.checkEmpty();
+
+    if (shouldCheckEmpty) {
+      this.checkEmpty();
+    }
     return childViews;
   },
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -582,6 +582,7 @@ describe('collection view', function() {
       this.sinon.spy(this.collectionView, 'onDestroy');
       this.sinon.spy(this.collectionView, 'onBeforeDestroy');
       this.sinon.spy(this.collectionView, 'trigger');
+      this.sinon.spy(this.collectionView, 'checkEmpty');
 
       this.collectionView.bind('destroy:collection', this.destroyHandler);
 
@@ -674,6 +675,10 @@ describe('collection view', function() {
       expect(this.collectionView).to.have.property('isRendered', false);
     });
 
+    it('should not call checkEmpty', function() {
+      expect(this.collectionView.checkEmpty).to.have.not.been.called;
+    });
+
     it('should return the CollectionView', function() {
       expect(this.collectionView.destroy).to.have.returned(this.collectionView);
     });
@@ -732,6 +737,7 @@ describe('collection view', function() {
       this.childrenViews = this.collectionView.children.map(_.identity);
 
       this.sinon.spy(this.collectionView, 'destroyChildren');
+      this.sinon.spy(this.collectionView, 'checkEmpty');
       this.collectionView.destroyChildren();
     });
 
@@ -742,6 +748,24 @@ describe('collection view', function() {
 
     it('should return the child views', function() {
       expect(this.collectionView.destroyChildren).to.have.returned(this.childrenViews);
+    });
+
+    it('should call checkEmpty', function() {
+      expect(this.collectionView.checkEmpty).to.have.been.calledOnce;
+    });
+
+    describe('with the checkEmpty flag set as false', function() {
+      it('should not call checkEmpty', function() {
+        this.collectionView.destroyChildren({checkEmpty: false});
+        expect(this.collectionView.checkEmpty).to.have.been.calledOnce;
+      });
+    });
+
+    describe('with the checkEmpty flag set as true', function() {
+      it('should call checkEmpty', function() {
+        this.collectionView.destroyChildren({checkEmpty: true});
+        expect(this.collectionView.checkEmpty).to.have.been.calledTwice;
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #2313 

I've added a `checkEmpty` flag to `destroyChildren` to maintain BC for `CompositeView` where users may actually want to destroy the children and show an emptyView. The only places where the flag is passed are: `renderChildren` and `destroy` as it makes no sense to `checkEmpty` in those 2 places.

ping @cmaher 