### PR TITLE
Doc links

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -187,7 +187,8 @@ var CollectionView = Marionette.CollectionView.extend({
 
 You can customize the event prefix for events that are forwarded
 through the collection view. To do this, set the `childViewEventPrefix`
-on the collection view.
+on the collection view. For more information on the `childViewEventPrefix` see
+["childview:*" event bubbling from child views](#childview-event-bubbling-from-child-views)
 
 ```js
 var CV = Marionette.CollectionView.extend({

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -698,33 +698,29 @@ var myModel = new MyModel();
 var myCollection = new MyCollection();
 myCollection.add(myModel);
 
+var MyItemView = Backbone.Marionette.ItemView.extend({
+  triggers: {
+    'click button': 'do:something'
+  }
+});
+
 // get the collection view in place
 var colView = new CollectionView({
   collection: myCollection,
-  childView: MyItemView
+  childView: MyItemView,
+
+  onChildviewDoSomething: function() {
+    alert("I said, 'do something!'");
+  }
 });
 colView.render();
-
-// bind to the collection view's events that were bubbled
-// from the child view
-colView.on("childview:do:something", function(childView, msg){
-  alert("I said, '" + msg + "'");
-});
-
-// hack, to get the child view and trigger from it
-var childView = colView.children[myModel.cid];
-childView.trigger("do:something", "do something!");
 ```
 
-The result of this will be an alert box that says
-"I said, 'do something!'".
+Now, whenever the button inside the attached childView is clicked, an alert box
+will appear that says: I said, 'do something!'
 
-Also note that you would not normally grab a reference to
-the child view the way this is showing. I'm merely using
-that hack as a way to demonstrate the event bubbling.
-Normally, you would have your child view listening to DOM
-events or model change events, and then triggering an event
-of its own based on that.
+It's also possible to attach the event manually using the usual
+`view.on('childview:do:something')`.
 
 ### before:render:collection event
 

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -274,4 +274,5 @@ Marionette.CompositeView.extend({
 });
 ```
 
-For more information, see the [Marionette.View](./marionette.view.md) documentation.
+For more information, see the [Marionette.View](./marionette.view.md#viewmodelevents-and-viewcollectionevents)
+documentation.

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -166,7 +166,7 @@ var TableView = Backbone.Marionette.CompositeView.extend({
   // ...
 
   childViewContainer: function(){
-    return "#tbody"
+    return "#my-tbody"
   }
 });
 ```
@@ -183,7 +183,7 @@ function options:
 var myComp = new Marionette.CompositeView({
   // ...,
 
-  childViewContainer: "#tbody"
+  childViewContainer: "#my-tbody"
 });
 ```
 

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -164,6 +164,8 @@ This also works for custom events that you might fire on your child views.
       }
     },
 
+    // Alternatively we can use the trigger notation with childview: as the
+    // prefix
     onChildviewShowMessage: function (childView, msg) {
       console.log('The show:message event bubbled up to the parent.');
     }

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -225,7 +225,8 @@ view.on("something:do:it", function(args){
 view.$(".do-something").trigger("click");
 ```
 
-The result of this is an alert box that says, "I DID IT!"
+The result of this is an alert box that says, "I DID IT!" Triggers can also be
+executed using the 'on{EventName}' attribute.
 
 By default all triggers are stopped with `preventDefault` and
 `stopPropagation` methods. But you can manually configure the triggers using

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -197,7 +197,8 @@ var MyView = Backbone.Marionette.ItemView.extend({
 ## View.triggers
 
 Views can define a set of `triggers` as a hash, which will
-convert a DOM event into a `view.triggerMethod` call.
+convert a DOM event into a
+[`view.triggerMethod`](./marionette.functions.md#marionettetriggermethod) call.
 
 The left side of the hash is a standard Backbone.View DOM
 event configuration, while the right side of the hash is the
@@ -226,7 +227,10 @@ view.$(".do-something").trigger("click");
 
 The result of this is an alert box that says, "I DID IT!"
 
-By default all triggers are stopped with `preventDefault` and `stopPropagation` methods. But you can manually configure the triggers using hash instead of event name. Example below triggers an event and prevents default browser behaviour using `preventDefault` method.
+By default all triggers are stopped with `preventDefault` and
+`stopPropagation` methods. But you can manually configure the triggers using
+hash instead of event name. Example below triggers an event and prevents
+default browser behaviour using `preventDefault` method.
 
 ```js
 Backbone.Marionette.CompositeView.extend({


### PR DESCRIPTION
Added a couple of internal documentation links for #2380 which I'm hoping will make it easier for new users to get the context when they're reading the documentation outside the intended order, especially with trigger handling.