### PR TITLE
normalize documentation, change Backbone.Marionette to Marionette

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -12,7 +12,7 @@ description: |
   Lastly, they give you a way to connect Views to the document through its Regions.
   
   ```js
-  var MyApp = new Backbone.Marionette.Application();
+  var MyApp = new Marionette.Application();
   ```
 
 constructor: 

--- a/api/region.yaml
+++ b/api/region.yaml
@@ -40,7 +40,7 @@ examples:
       the layout is shown, it should show its subviews in its regions.
       
       ```js
-      var AppLayoutView = Backbone.Marionette.LayoutView.extend({
+      var AppLayoutView = Marionette.LayoutView.extend({
         template: "#layout-view-template",
         
         regions: {
@@ -83,7 +83,7 @@ constructor: |
   #### 1. `el` as a class property
   
   ```js
-  var SomeRegion = Backbone.Marionette.Region.extend({
+  var SomeRegion = Marionette.Region.extend({
     el: "#some-div",
   });
   
@@ -94,7 +94,7 @@ constructor: |
   #### 2. `el` as a selector:
   
   ```js
-  var mgr = new Backbone.Marionette.Region({
+  var mgr = new Marionette.Region({
     el: "#someElement"
   });
   ```
@@ -102,7 +102,7 @@ constructor: |
   #### `el` as raw DOM node reference:
   
   ```js
-  var mgr = new Backbone.Marionette.Region({
+  var mgr = new Marionette.Region({
     el: document.querySelector("body")
   });
   ```
@@ -110,7 +110,7 @@ constructor: |
   #### `el` as a `jQuery` wrapped DOM node:
   
   ```js
-  var mgr = new Backbone.Marionette.Region({
+  var mgr = new Marionette.Region({
     el: $("body")
   });
 
@@ -152,7 +152,7 @@ properties:
     The `initialize` function is a good place to put custom, post instantiation class logic. 
     
     ```js
-    var SomeRegion = Backbone.Marionette.Region.extend({
+    var SomeRegion = Marionette.Region.extend({
       initialize: function() {
         // do some stuff
       }

--- a/changelog.md
+++ b/changelog.md
@@ -392,7 +392,7 @@ new Marionette.RegionManager({
   * Features
     * Add `onRoute` to the `appRouter`.
     ```js
-      Backbone.Marionette.AppRouter.extend({
+      Marionette.AppRouter.extend({
         onRoute: function(route, params) {
         }
       })

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -399,7 +399,7 @@ The Event Aggregator is available through the `vent` property. `vent` is conveni
 pieces of your application as events occur.
 
 ```js
-var MyApp = new Backbone.Marionette.Application();
+var MyApp = new Marionette.Application();
 
 // Alert the user on the 'minutePassed' event
 MyApp.vent.on("minutePassed", function(someData){
@@ -417,7 +417,7 @@ window.setInterval(function() {
 Request Response is a means for any component to request information from another component without being tightly coupled. An instance of Request Response is available on the Application as the `reqres` property.
 
 ```js
-var MyApp = new Backbone.Marionette.Application();
+var MyApp = new Marionette.Application();
 
 // Set up a handler to return a todoList based on type
 MyApp.reqres.setHandler("todoList", function(type){
@@ -438,7 +438,7 @@ Commands are used to make any component tell another component to perform an act
 Note that the callback of a command is not meant to return a value.
 
 ```js
-var MyApp = new Backbone.Marionette.Application();
+var MyApp = new Marionette.Application();
 
 MyApp.model = new Backbone.Model();
 

--- a/docs/marionette.approuter.md
+++ b/docs/marionette.approuter.md
@@ -18,7 +18,7 @@ Have your routers configured to call the method on your object, directly.
 Configure an AppRouter with `appRoutes`. The route definition is passed on to Backbone's standard routing handlers. This means that you define routes like you normally would.  However, instead of providing a callback method that exists on the router, you provide a callback method that exists on the controller, which you specify for the router instance (see below.)
 
 ```js
-var MyRouter = Backbone.Marionette.AppRouter.extend({
+var MyRouter = Marionette.AppRouter.extend({
   // "someMethod" must exist at controller.someMethod
   appRoutes: {
     "some/route": "someMethod"
@@ -92,7 +92,7 @@ var someController = {
   someMethod: function(){ /*...*/ }
 };
 
-Backbone.Marionette.AppRouter.extend({
+Marionette.AppRouter.extend({
   controller: someController
 });
 ```

--- a/docs/marionette.callbacks.md
+++ b/docs/marionette.callbacks.md
@@ -30,7 +30,7 @@ provided options to the callbacks.
 ## Basic Usage
 
 ```js
-var callbacks = new Backbone.Marionette.Callbacks();
+var callbacks = new Marionette.Callbacks();
 
 callbacks.add(function(options){
   alert("I'm a callback with " + options.value + "!");
@@ -50,7 +50,7 @@ You can optionally specify the context that you want each callback to be
 executed with, when adding a callback:
 
 ```js
-var callbacks = new Backbone.Marionette.Callbacks();
+var callbacks = new Marionette.Callbacks();
 
 callbacks.add(function(options){
   alert("I'm a callback with " + options.value + "!");

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -699,7 +699,7 @@ var myModel = new MyModel();
 var myCollection = new MyCollection();
 myCollection.add(myModel);
 
-var MyItemView = Backbone.Marionette.ItemView.extend({
+var MyItemView = Marionette.ItemView.extend({
   triggers: {
     'click button': 'do:something'
   }

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -27,7 +27,7 @@ You can specify a `modelView` to use for the model. If you don't
 specify one, it will default to the `Marionette.ItemView`.
 
 ```js
-var CompositeView = Backbone.Marionette.CompositeView.extend({
+var CompositeView = Marionette.CompositeView.extend({
   template: "#leaf-branch-template"
 });
 
@@ -83,9 +83,9 @@ Each childView will be rendered using the `childView`'s template. The `Composite
 template is rendered and the childView's templates are added to this.
 
 ```js
-var ChildView = Backbone.Marionette.ItemView.extend({});
+var ChildView = Marionette.ItemView.extend({});
 
-var CompView = Backbone.Marionette.CompositeView.extend({
+var CompView = Marionette.CompositeView.extend({
   childView: ChildView
 });
 ```
@@ -138,12 +138,12 @@ table structure, specify an `childViewContainer` in your composite view,
 like this:
 
 ```js
-var RowView = Backbone.Marionette.ItemView.extend({
+var RowView = Marionette.ItemView.extend({
   tagName: "tr",
   template: "#row-template"
 });
 
-var TableView = Backbone.Marionette.CompositeView.extend({
+var TableView = Marionette.CompositeView.extend({
   childView: RowView,
 
   // specify a jQuery selector to put the `childView` instances into
@@ -162,7 +162,7 @@ function needs to return a jQuery selector string, or a jQuery selector
 object.
 
 ```js
-var TableView = Backbone.Marionette.CompositeView.extend({
+var TableView = Marionette.CompositeView.extend({
   // ...
 
   childViewContainer: function(){
@@ -238,7 +238,7 @@ your view to provide custom code for dealing with the view's
 `el` after it has been rendered:
 
 ```js
-Backbone.Marionette.CompositeView.extend({
+Marionette.CompositeView.extend({
   onRender: function(){
     // do stuff here
   }

--- a/docs/marionette.itemview.md
+++ b/docs/marionette.itemview.md
@@ -47,7 +47,7 @@ You should provide a `template` attribute on the item view, which
 will be either a jQuery selector:
 
 ```js
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   template: "#some-template"
 });
 
@@ -58,7 +58,7 @@ new MyView().render();
 
 ```js
 var my_template_html = '<div><%= args.name %></div>'
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   template : function(serialized_model) {
     var name = serialized_model.name;
     return _.template(my_template_html)({
@@ -173,7 +173,7 @@ triggers the event and a corresponding "on{EventName}" method.
 Triggered before an ItemView is rendered.
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   onBeforeRender: function(){
     // set up final bits just before rendering the view's `el`
   }
@@ -187,7 +187,7 @@ You can implement this in your view to provide custom code for dealing
 with the view's `el` after it has been rendered.
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   onRender: function(){
     // manipulate the `el` here. it's already
     // been rendered, and is full of the view's
@@ -202,7 +202,7 @@ Triggered just prior to destroying the view, when the view's `destroy()`
 method has been called.
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   onBeforeDestroy: function(){
     // manipulate the `el` here. it's already
     // been rendered, and is full of the view's
@@ -216,7 +216,7 @@ Backbone.Marionette.ItemView.extend({
 Triggered just after the view has been destroyed.
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   onDestroy: function(){
     // custom destroying and cleanup goes here
   }
@@ -277,7 +277,7 @@ If you need custom serialization for your data, you can provide a
 object, as if you had called `.toJSON` on a model or collection.
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   serializeData: function(){
     return {
       "some attribute": "some value"
@@ -297,7 +297,7 @@ duplicating the selector, you can simply reference it by
 You can also use the ui hash values from within events and trigger keys using the ```"@ui.elementName"```: syntax
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   tagName: "tr",
 
   ui: {

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -13,7 +13,7 @@ attach multiple region managers to dynamically rendered HTML.
 You can create complex views by nesting layoutView managers within `Regions`.
 
 For a more in-depth discussion on LayoutViews, see the blog post
-[Manage Layouts And Nested Views With Backbone.Marionette](http://lostechies.com/derickbailey/2012/03/22/managing-layouts-and-nested-views-with-backbone-marionette/)
+[Manage Layouts And Nested Views With Marionette](http://lostechies.com/derickbailey/2012/03/22/managing-layouts-and-nested-views-with-backbone-marionette/)
 
 Please see
 [the Marionette.ItemView documentation](./marionette.itemview.md)
@@ -57,7 +57,7 @@ to the layoutView.
 ```
 
 ```js
-var AppLayoutView = Backbone.Marionette.LayoutView.extend({
+var AppLayoutView = Marionette.LayoutView.extend({
   template: "#layout-view-template",
 
   regions: {
@@ -371,7 +371,7 @@ your own implementation, you can specify an alternate class to use
 with the `regionClass` property of the `LayoutView`.
 
 ```js
-var MyLayoutView = Backbone.Marionette.LayoutView.extend({
+var MyLayoutView = Marionette.LayoutView.extend({
   regionClass: SomeCustomRegion
 });
 ```
@@ -379,7 +379,7 @@ var MyLayoutView = Backbone.Marionette.LayoutView.extend({
 You can also specify custom `Region` classes for each `region`:
 
 ```js
-var AppLayoutView = Backbone.Marionette.LayoutView.extend({
+var AppLayoutView = Marionette.LayoutView.extend({
   template: "#layout-view-template",
 
   regionClass: SomeDefaultCustomRegion,

--- a/docs/marionette.module.md
+++ b/docs/marionette.module.md
@@ -31,7 +31,7 @@ A module is defined directly from an Application object. To create a module all
 you need to do is give it a name.
 
 ```js
-var MyApp = new Backbone.Marionette.Application();
+var MyApp = new Marionette.Application();
 
 // Creates a new module named "MyModule"
 var myModule = MyApp.module("MyModule");
@@ -44,7 +44,7 @@ calls to `module` with the same name argument will not create
 a new module, but instead return the already-created instance.
 
 ```js
-var MyApp = new Backbone.Marionette.Application();
+var MyApp = new Marionette.Application();
 
 // Instantiates a new Marionette.Module
 var myModule = MyApp.module("MyModule");
@@ -68,7 +68,7 @@ It will receive 6 parameters, in this order:
 * The module itself
 * The Application object
 * Backbone
-* Backbone.Marionette
+* Marionette
 * jQuery
 * Underscore
 * Any custom arguments
@@ -302,7 +302,7 @@ In this example, the module will exhibit the default behavior and start automati
 with the parent application object's `start` call:
 
 ```js
-MyApp = new Backbone.Marionette.Application();
+MyApp = new Marionette.Application();
 
 MyApp.module("Foo", function(){
   // module code goes here

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -51,7 +51,7 @@ If you specify the same region name twice, the last one in wins.
 You can also add regions via `LayoutView`s:
 
 ```js
-var AppLayoutView = Backbone.Marionette.LayoutView.extend({
+var AppLayoutView = Marionette.LayoutView.extend({
   template: "#layout-view-template",
 
   regions: {
@@ -197,7 +197,7 @@ You can specify an `el` for the region to manage at the time
 that the region is instantiated:
 
 ```js
-var mgr = new Backbone.Marionette.Region({
+var mgr = new Marionette.Region({
   el: "#someElement"
 });
 ```
@@ -205,7 +205,7 @@ var mgr = new Backbone.Marionette.Region({
 The `el` option can also be a raw DOM node reference:
 
 ```js
-var mgr = new Backbone.Marionette.Region({
+var mgr = new Marionette.Region({
   el: document.querySelector("body")
 });
 ```
@@ -213,7 +213,7 @@ var mgr = new Backbone.Marionette.Region({
 Or the `el` can also be a `jQuery` wrapped DOM node:
 
 ```js
-var mgr = new Backbone.Marionette.Region({
+var mgr = new Marionette.Region({
   el: $("body")
 });
 ```
@@ -395,7 +395,7 @@ var myView = new MyView({
   el: $("#existing-view-stuff")
 });
 
-var region = new Backbone.Marionette.Region({
+var region = new Marionette.Region({
   el: "#content",
   currentView: myView
 });
@@ -479,7 +479,7 @@ MyApp.mainRegion.on("empty", function(view, region, options){
   // you also have access to the `options` that were passed to the Region.show call
 });
 
-var MyRegion = Backbone.Marionette.Region.extend({
+var MyRegion = Marionette.Region.extend({
   // ...
 
   onBeforeShow: function(view, region, options) {
@@ -500,7 +500,7 @@ var MyView = Marionette.ItemView.extend({
   }
 });
 
-var MyRegion = Backbone.Marionette.Region.extend({
+var MyRegion = Marionette.Region.extend({
   // ...
 
   onBeforeSwap: function(view, region, options) {
@@ -534,7 +534,7 @@ new region class by specifying the region class as the
 value. In this case, `addRegions` expects the constructor itself, not an instance.
 
 ```js
-var FooterRegion = Backbone.Marionette.Region.extend({
+var FooterRegion = Marionette.Region.extend({
   el: "#footer"
 });
 
@@ -547,7 +547,7 @@ You can also specify a selector for the region by using
 an object literal for the configuration.
 
 ```js
-var FooterRegion = Backbone.Marionette.Region.extend({
+var FooterRegion = Marionette.Region.extend({
   el: "#footer"
 });
 
@@ -572,7 +572,7 @@ need to extend from `Region` as shown above and then use
 that constructor function on your own:
 
 ```js
-var SomeRegion = Backbone.Marionette.Region.extend({
+var SomeRegion = Marionette.Region.extend({
   el: "#some-div",
 
   initialize: function(options){

--- a/docs/marionette.renderer.md
+++ b/docs/marionette.renderer.md
@@ -22,7 +22,7 @@ template using the `data` object as the context.
 ```js
 var template = "#some-template";
 var data = {foo: "bar"};
-var html = Backbone.Marionette.Renderer.render(template, data);
+var html = Marionette.Renderer.render(template, data);
 
 // do something with the HTML here
 ```
@@ -40,7 +40,7 @@ to specify a pre-compiled template function as the `template` setting.
 
 ```js
 var myTemplate = _.template("<div>foo</div>");
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   template: myTemplate
 });
 ```
@@ -64,7 +64,7 @@ If you wish to override the template engine used, change the
 `render` method to work however you want:
 
 ```js
-Backbone.Marionette.Renderer.render = function(template, data){
+Marionette.Renderer.render = function(template, data){
   return $(template).tmpl(data);
 };
 ```
@@ -77,7 +77,7 @@ If you override the `render` method and wish to use the
 fetch the template from the cache in your `render` method:
 
 ```js
-Backbone.Marionette.Renderer.render = function(template, data){
+Marionette.Renderer.render = function(template, data){
   var template = Marionette.TemplateCache.get(template);
   // Do something with the template here
 };
@@ -93,7 +93,7 @@ To do this, just override the `render` method to return your executed
 template with the data.
 
 ```js
-Backbone.Marionette.Renderer.render = function(template, data){
+Marionette.Renderer.render = function(template, data){
   return template(data);
 };
 ```
@@ -104,7 +104,7 @@ Then you can specify the pre-compiled template function as your view's
 ```js
 var myPrecompiledTemplate = _.template("<div>some template</div>");
 
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   template: myPrecompiledTemplate
 });
 ```

--- a/docs/marionette.templatecache.md
+++ b/docs/marionette.templatecache.md
@@ -22,7 +22,7 @@ but you do not have to manually create these instances yourself. `get` will
 return a compiled template function.
 
 ```js
-var template = Backbone.Marionette.TemplateCache.get("#my-template", {some: options});
+var template = Marionette.TemplateCache.get("#my-template", {some: options});
 // use the template
 template({param1:'value1', paramN:'valueN'});
 ```
@@ -41,24 +41,24 @@ If you do not specify any parameters, all items will be cleared
 from the cache:
 
 ```js
-Backbone.Marionette.TemplateCache.get("#my-template");
-Backbone.Marionette.TemplateCache.get("#this-template");
-Backbone.Marionette.TemplateCache.get("#that-template");
+Marionette.TemplateCache.get("#my-template");
+Marionette.TemplateCache.get("#this-template");
+Marionette.TemplateCache.get("#that-template");
 
 // clear all templates from the cache
-Backbone.Marionette.TemplateCache.clear()
+Marionette.TemplateCache.clear()
 ```
 
 If you specify one or more parameters, these parameters are assumed
 to be the `templateId` used for loading / caching:
 
 ```js
-Backbone.Marionette.TemplateCache.get("#my-template");
-Backbone.Marionette.TemplateCache.get("#this-template");
-Backbone.Marionette.TemplateCache.get("#that-template");
+Marionette.TemplateCache.get("#my-template");
+Marionette.TemplateCache.get("#this-template");
+Marionette.TemplateCache.get("#that-template");
 
 // clear 2 of 3 templates from the cache
-Backbone.Marionette.TemplateCache.clear("#my-template", "#this-template")
+Marionette.TemplateCache.clear("#my-template", "#this-template")
 ```
 
 ## Customizing Template Access
@@ -79,7 +79,7 @@ works, you can override the `loadTemplate` method on the
 `TemplateCache` object.
 
 ```js
-Backbone.Marionette.TemplateCache.prototype.loadTemplate = function(templateId, options){
+Marionette.TemplateCache.prototype.loadTemplate = function(templateId, options){
   // load your template here, returning the data needed for the compileTemplate
   // function. For example, you have a function that creates templates based on the
   // value of templateId
@@ -99,7 +99,7 @@ remember that it must return a function which takes an object of parameters and 
 and returns a formatted HTML string.
 
 ```js
-Backbone.Marionette.TemplateCache.prototype.compileTemplate = function(rawTemplate, options) {
+Marionette.TemplateCache.prototype.compileTemplate = function(rawTemplate, options) {
   // use Handlebars.js to compile the template
   return Handlebars.compile(rawTemplate);
 }

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -41,7 +41,7 @@ the `listenTo` method to bind model, collection, or other events from Backbone
 and Marionette objects.
 
 ```js
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   initialize: function(){
     this.listenTo(this.model, "change:foo", this.modelChanged);
     this.listenTo(this.collection, "add", this.modelAdded);
@@ -73,7 +73,7 @@ This event can be used to react to when a view has been shown via a [region](./m
 All `views` that inherit from the base `Marionette.View` class have this functionality, notably `ItemView`, `CollectionView`, `CompositeView`, and `LayoutView`.
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   onShow: function(){
     // react to when a view has been shown
   }
@@ -83,7 +83,7 @@ Backbone.Marionette.ItemView.extend({
 A common use case for the `onShow` method is to use it to add children views.
 
 ```js
-var LayoutView = Backbone.Marionette.LayoutView.extend({
+var LayoutView = Marionette.LayoutView.extend({
    regions: {
      Header: 'header',
      Section: 'section'
@@ -116,7 +116,7 @@ that `destroy` was invoked with. This lets you handle any additional clean
 up code without having to override the `destroy` method.
 
 ```js
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   onDestroy: function(arg1, arg2){
     // custom cleanup or destroying code, here
   }
@@ -163,7 +163,7 @@ This event / callback is useful for
 [jQueryUI](http://jqueryui.com/) or [KendoUI](http://kendoui.com).
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   onDomRefresh: function(){
     // manipulate the `el` here. it's already
     // been rendered, and is full of the view's
@@ -181,7 +181,7 @@ Since Views extend from backbone's view class, you gain the benefits of the [eve
 Some preprocessing sugar is added on top to add the ability to cross utilize the ```ui``` hash.
 
 ```js
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   // ...
 
   ui: {
@@ -205,7 +205,7 @@ event configuration, while the right side of the hash is the
 view event that you want to trigger from the view.
 
 ```js
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   // ...
 
   triggers: {
@@ -234,7 +234,7 @@ hash instead of event name. Example below triggers an event and prevents
 default browser behaviour using `preventDefault` method.
 
 ```js
-Backbone.Marionette.CompositeView.extend({
+Marionette.CompositeView.extend({
   triggers: {
     "click .do-something": {
       event: "something:do:it",
@@ -249,7 +249,7 @@ You can also specify the `triggers` as a function that
 returns a hash of trigger configurations
 
 ```js
-Backbone.Marionette.CompositeView.extend({
+Marionette.CompositeView.extend({
   triggers: function(){
     return {
       "click .that-thing": "that:i:sent:you"
@@ -261,7 +261,7 @@ Backbone.Marionette.CompositeView.extend({
 Trigger keys can be configured to cross utilize the ```ui``` hash.
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   ui: {
      'monkey': '.guybrush'
   },
@@ -286,7 +286,7 @@ includes the following:
 These properties match the `view`, `model`, and `collection` properties of the view that triggered the event.
 
 ```js
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   // ...
 
   triggers: {
@@ -316,7 +316,7 @@ the model or collection, and the right side is the name of the
 method on the view.
 
 ```js
-Backbone.Marionette.CompositeView.extend({
+Marionette.CompositeView.extend({
 
   modelEvents: {
     "change:name": "nameChanged" // equivalent to view.listenTo(view.model, "change:name", view.nameChanged, view)
@@ -349,7 +349,7 @@ Multiple callback functions can be specified by separating them with a
 space.
 
 ```js
-Backbone.Marionette.CompositeView.extend({
+Marionette.CompositeView.extend({
 
   modelEvents: {
     "change:name": "nameChanged thatThing"
@@ -369,7 +369,7 @@ A single function can be declared directly in-line instead of specifying a
 callback via a string method name.
 
 ```js
-Backbone.Marionette.CompositeView.extend({
+Marionette.CompositeView.extend({
 
   modelEvents: {
     "change:name": function(){
@@ -388,7 +388,7 @@ A function can be used to declare the event configuration as long as
 that function returns a hash that fits the above configuration options.
 
 ```js
-Backbone.Marionette.CompositeView.extend({
+Marionette.CompositeView.extend({
 
   modelEvents: function(){
     return { "change:name": "someFunc" };
@@ -472,7 +472,7 @@ to add data not returned from `serializeData`, such as calculated values.
 ```
 
 ```js
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   template: "#my-template",
 
   templateHelpers: function () {
@@ -487,14 +487,14 @@ var MyView = Backbone.Marionette.ItemView.extend({
 });
 
 var model = new Backbone.Model({
-  name: "Backbone.Marionette",
+  name: "Marionette",
   decimal: 1
 });
 var view = new MyView({
   model: model
 });
 
-view.render(); //=> "I 100% think that Backbone.Marionette is the coolest!";
+view.render(); //=> "I 100% think that Marionette is the coolest!";
 ```
 
 The `templateHelpers` can also be provided as a constructor parameter
@@ -538,7 +538,7 @@ function. The function must return an object that can be
 mixed in to the data for the view.
 
 ```js
-Backbone.Marionette.ItemView.extend({
+Marionette.ItemView.extend({
   templateHelpers: function(){
     return {
       foo: function(){ /* ... */ }
@@ -556,7 +556,7 @@ a `getTemplate` function on your views and use this to return the
 template that you need.
 
 ```js
-var MyView = Backbone.Marionette.ItemView.extend({
+var MyView = Marionette.ItemView.extend({
   getTemplate: function(){
     if (this.model.get("foo")){
       return "#some-template";

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 
 ## About Marionette
 
-Backbone.Marionette is a composite application library for Backbone.js that
+Marionette is a composite application library for Backbone.js that
 aims to simplify the construction of large scale JavaScript applications.
 It is a collection of common design and implementation patterns found in
 applications.


### PR DESCRIPTION
After learning there is no difference between using `Backbone.Marionette` and `Marionette` I want to suggest normalizing the documentation to one style: `Marionette`