### PR TITLE
Remove redundant throw error in ItemView._renderTemplate

### DIFF
--- a/src/item-view.js
+++ b/src/item-view.js
@@ -64,21 +64,12 @@ Marionette.ItemView = Marionette.View.extend({
 
   // Internal method to render the template with the serialized data
   // and template helpers via the `Marionette.Renderer` object.
-  // Throws an `UndefinedTemplateError` error if the template is
-  // any falsely value but literal `false`.
   _renderTemplate: function() {
     var template = this.getTemplate();
 
     // Allow template-less item views
     if (template === false) {
       return;
-    }
-
-    if (!template) {
-      throw new Marionette.Error({
-        name: 'UndefinedTemplateError',
-        message: 'Cannot render the template since it is null or undefined.'
-      });
     }
 
     // Add in entity data and template helpers

--- a/test/unit/item-view.spec.js
+++ b/test/unit/item-view.spec.js
@@ -17,7 +17,7 @@ describe('item view', function() {
     });
 
     it('should throw an exception because there was no valid template', function() {
-      expect(this.view.render).to.throw('Cannot render the template since it is null or undefined.');
+      expect(this.view.render).to.throw('Cannot render the template since its false, null or undefined.');
     });
   });
 


### PR DESCRIPTION
In `ItemView._renderTemplate` the `template` property is checked. If it is undefined or null, an error is thrown. But in `Renderer.render` (which is called immediately after) that same check is done. The only thing that changes is error name: `'UndefinedTemplateError'` in the first case, and `'TemplateNotFoundError'` in the second. 

This check can be removed from `_renderTemplate`. The method would be a little cleaner without it.