### PR TITLE
Mn.Controller must come after Mn.Object

### DIFF
--- a/src/build/bundled.js
+++ b/src/build/bundled.js
@@ -47,8 +47,8 @@
 
   // @include ../error.js
   // @include ../callbacks.js
-  // @include ../controller.js
   // @include ../object.js
+  // @include ../controller.js
   // @include ../region.js
   // @include ../region-manager.js
 

--- a/src/build/core.js
+++ b/src/build/core.js
@@ -41,8 +41,8 @@
 
   // @include ../error.js
   // @include ../callbacks.js
-  // @include ../controller.js
   // @include ../object.js
+  // @include ../controller.js
   // @include ../region.js
   // @include ../region-manager.js
 


### PR DESCRIPTION
The current build from minor is broken because `Mn.Controller` comes before `Mn.Object`. But with the recent changes introduced in #2402 `Mn.Controller` now depends on `Mn.Object`.