### PR TITLE
Accept ChildView as a function and make getChildView private (issue #1846)

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -19,7 +19,6 @@ will provide features such as `onShow` callbacks, etc. Please see
 ## Documentation Index
 
 * [CollectionView's `childView`](#collectionviews-childview)
-  * [CollectionView's `getChildView`](#collectionviews-getchildview)
   * [CollectionView's `childViewOptions`](#collectionviews-childviewoptions)
   * [CollectionView's `childViewEventPrefix`](#collectionviews-childvieweventprefix)
   * [CollectionView's `childViewEvents`](#collectionviews-childviewevents)
@@ -72,8 +71,7 @@ Backbone.Marionette.CollectionView.extend({
 ```
 
 Child views must be defined before they are referenced by the
-`childView` attribute in a collection view definition. Use `getChildView`
-to lookup the definition as child views are instantiated.
+`childView` attribute in a collection view definition.
 
 Alternatively, you can specify a `childView` in the options for
 the constructor:
@@ -89,9 +87,10 @@ new MyCollectionView({
 If you do not specify a `childView`, an exception will be thrown
 stating that you must specify a `childView`.
 
-### CollectionView's `getChildView`
-The value returned by this method is the `ChildView` class that will be instantiated when a `Model` needs to be initially rendered.
-This method also gives you the ability to customize per `Model` `ChildViews`.
+You can also define `childView` as a function. In this form, the value
+returned by this method is the `ChildView` class that will be instantiated
+when a `Model` needs to be initially rendered. This method also gives you
+the ability to customize per `Model` `ChildViews`.
 
 ```js
 var FooBar = Backbone.Model.extend({
@@ -108,7 +107,7 @@ var BarView = Backbone.Marionette.View.extend({
 });
 
 var MyCollectionView = Backbone.Marionette.CollectionView.extend({
-  getChildView: function(item) {
+  childView: function(item) {
     // Choose which view class to render,
     // depending on the properties of the item model
     if  (item.get('isFoo')) {

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -198,6 +198,11 @@ For more information on this method, see the [CollectionView's documentation](./
 ## CompositeView's `childView` container selection
 
 The `getChildViewContainer` method is passed a second `childView` parameter which, when overridden, allows for a finer tuned container selection by being able to access the `childView` which is about to be appended to the `containerView` returned by `getChildViewContainer`.
+You can also define `childView` as a function, which allows you to choose the view class
+to be rendered at runtime.
+
+For more information see the [CollectionView's documentation](./marionette.collectionview.md#collectionviews-childview).
+
 
 ## Recursive By Default
 

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -39,11 +39,31 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // Retrieve the `childView` to be used when rendering each of
   // the items in the collection. The default is to return
   // `this.childView` or Marionette.CompositeView if no `childView`
-  // has been defined
-  getChildView: function(child) {
-    var childView = this.getOption('childView') || this.constructor;
+  // has been defined. As happens in CollectionView, `childView` can
+  // be a function (which should return a view class).
+  _getChildView: function(child) {
+    var childView = this.getOption('childView');
 
-    return childView;
+    // for CompositeView, if `childView` is not specified, we'll get the same
+    // composite view class rendered for each child in the collection
+    if(!childView){
+      return this.constructor;
+    }
+    // then check if the `childView` is a view class (the common case)
+    else if(childView.prototype instanceof Backbone.View || childView === Backbone.View){
+      return childView;
+    }
+    // finally check if it's a function (which we assume that returns a view class)
+    else if(_.isFunction(childView)){
+      return childView.call(this, child);
+    }
+    else{
+      throw new Marionette.Error({
+        name: 'InvalidChildViewError',
+        message: '"childView" must be a view class or a function that returns a view class'
+      });
+    }
+
   },
 
   // Return the serialized model

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -125,7 +125,7 @@ describe('collection view', function() {
       this.sinon.spy(this.collectionView.$el, 'append');
       this.sinon.spy(this.collectionView, 'startBuffering');
       this.sinon.spy(this.collectionView, 'endBuffering');
-      this.sinon.spy(this.collectionView, 'getChildView');
+      this.sinon.spy(this.collectionView, '_getChildView');
 
       this.collectionView.render();
     });
@@ -230,8 +230,8 @@ describe('collection view', function() {
       expect(this.childViewRender.callCount).to.equal(2);
     });
 
-    it('should call "getChildView" for each item in the collection', function() {
-      expect(this.collectionView.getChildView).to.have.been.calledTwice.
+    it('should call "_getChildView" for each item in the collection', function() {
+      expect(this.collectionView._getChildView).to.have.been.calledTwice.
         and.calledWith(this.collection.models[0]).
         and.calledWith(this.collection.models[1]);
     });
@@ -239,6 +239,37 @@ describe('collection view', function() {
     it('should be marked rendered', function() {
       expect(this.collectionView).to.have.property('isRendered', true);
     });
+  });
+
+  describe('when defining childView as a function that returns a view class', function(){
+    beforeEach(function(){
+      this.collection = new Backbone.Collection([{id: 1, name: 'one'}, {id: 2, name: 'two'}]);
+
+      this.EvenView = Backbone.Marionette.View.extend({
+        tagName: 'span',
+        template: _.template('My name is <%= name %>. I am even.')
+      });
+
+      this.OddView = Backbone.Marionette.View.extend({
+        tagName: 'article',
+        template: _.template('My name is <%= name %>. I am odd.')
+      });
+
+      var suite = this;
+      this.collectionView = new this.MockCollectionView({
+        collection: this.collection,
+        childView: function(child){ 
+          return child.get('id') % 2 === 0 ? suite.EvenView : suite.OddView; 
+        }
+      });
+
+      this.collectionView.render();
+    });
+
+    it('should use the correct view class for each child', function() {
+      expect(this.collectionView.$el).to.have.$html('<article>My name is one. I am odd.</article><span>My name is two. I am even.</span>');
+    });
+
   });
 
   describe('when rendering a collection view and accessing children via the DOM', function() {
@@ -452,7 +483,7 @@ describe('collection view', function() {
         onRenderEmpty: function() {},
 
         render: function() {
-          var ChildView = this.getChildView();
+          var ChildView = this._getChildView();
           this.addChild(suite.model, ChildView, 0);
         }
       });
@@ -962,7 +993,7 @@ describe('collection view', function() {
       this.collectionView.trigger('show');
 
       this.sinon.spy(this.collectionView, 'attachBuffer');
-      this.sinon.spy(this.collectionView, 'getChildView');
+      this.sinon.spy(this.collectionView, '_getChildView');
 
       this.collection.add(this.model2);
       this.view = this.collectionView.children.findByIndex(1);
@@ -992,8 +1023,8 @@ describe('collection view', function() {
       expect(this.ChildView.prototype.onDomRefresh).to.have.been.called;
     });
 
-    it('should call "getChildView" with the new model', function() {
-      expect(this.collectionView.getChildView).to.have.been.calledWith(this.model2);
+    it('should call "_getChildView" with the new model', function() {
+      expect(this.collectionView._getChildView).to.have.been.calledWith(this.model2);
     });
 
     describe('when the childView is added at an existing index', function() {

--- a/test/unit/composite-view.spec.js
+++ b/test/unit/composite-view.spec.js
@@ -836,4 +836,45 @@ describe('composite view', function() {
       expect(this.constructor).to.have.been.calledOnce;
     });
   });
+
+  describe('when defining childView as a function that returns a view class', function() {
+    beforeEach(function() {
+
+      this.m1 = new this.Model({id: 1, name: 'one'});
+      this.m2 = new this.Model({id: 2, name: 'two'});
+      this.m3 = new this.Model({foo: 'bar'});
+      this.collection = new this.Collection([this.m1, this.m2]);
+
+      this.EvenView = Backbone.Marionette.View.extend({
+        tagName: 'span',
+        template: _.template('My name is <%= name %>. I am even.')
+      });
+
+      this.OddView = Backbone.Marionette.View.extend({
+        tagName: 'article',
+        template: _.template('My name is <%= name %>. I am odd.')
+      });
+
+      var suite = this;
+      this.CompositeView = Backbone.Marionette.CompositeView.extend({
+        template: _.template('<header>composite template <%= foo %><div id="cv-container"></div></header>'),
+        childViewContainer: '#cv-container',
+        childView: function(child){ 
+          return child.get('id') % 2 === 0 ? suite.EvenView : suite.OddView; 
+        }
+      });
+
+      this.compositeView = new this.CompositeView({
+        collection: this.collection,
+        model: this.m3
+      });
+
+      this.compositeView.render();
+    });
+
+    it('should use the correct view class for each child', function() {
+      expect(this.compositeView.$el).to.have.$html('<header>composite template bar<div id="cv-container"><article>My name is one. I am odd.</article><span>My name is two. I am even.</span></div></header>');
+    });
+  });
+
 });


### PR DESCRIPTION
#### The problem
The `getChildView` property is unnecessary in `Mn.CollectionView`. We could instead allow the `childView` property to be either a view class or a function that returns a view class. This way the role of `getChildView` (which is that of "a function that returns a view class") could be played directly by `childView`. 

This would make the API more simple and more coherent as other properties also allow this duality ("thing" / "function that returns the thing").

Please read #1846 for more details.

#### The solution
1) Remove getChildView from the public API. It still makes sense as a private method though. It's a good place to have the logic that checks if `childView` is a view class or a "regular function" (which should return a view class).
2) add a `_getChildView` private method that is essentially the same as the old `getChildView`

#### Upgrade effort 
This breaking change is very easy to fix: the property `getChildView` should simply be renamed to `childView`. Everything will work as before. Note that in the tests I essentially had to search-and-replace `getChildView` to `_getChildView`.

Note also that having both `childView` and `getChildView` was not possible anyway. If that happened, the view class in `childView` would never be used (that is, the view class to be used would always be the one returned by `getChildView`).

### The bonus
`Mn.CompositeView` will also benefit from this PR: the new functionality of `childView` also works for `CompositeView`. Besides this, if `childView` is undefined, the recursive feature will be then used, as happens currently. The `_getChildView` method in `CompositeView` takes care of this.