### PR TITLE
use initRenderBuffer to reset the _bufferedChildren array

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -65,7 +65,7 @@ Marionette.CollectionView = Marionette.View.extend({
     if (this._isShown) {
       _.each(this._bufferedChildren, _.partial(this._triggerMethodOnChild, 'show'));
 
-      this._bufferedChildren = [];
+      this.initRenderBuffer();
     }
   },
 


### PR DESCRIPTION
We are already using `initRenderBuffer` to reset the `_bufferedChildren` array in other parts of CollectionView (`startBuffering`, `endBuffering`). 

We should do it in `_triggerShowBufferedChildren` as well.