### PR TITLE
Don't assume that options is always defined; instead just don't rely on it

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -55,7 +55,7 @@ var MyView = Marionette.ItemView.extend({
 
 Interaction points, such as tooltips and warning messages, are generic concepts. There is no need to recode them within your Views. They are prime candidates for abstraction into a higher level, non-coupled concept, which is exactly what Behaviors provide you with.
 
-Here is the syntax for declaring which behaviors get used within a View.  
+Here is the syntax for declaring which behaviors get used within a View.
 * You can pass behaviors either as a set of key-value pairs where the keys are used to lookup the behavior class, or as an array.
 * The keys in the hash are passed to `getBehaviorClass` which looks up the correct `Behavior` class.
 * The options for each `Behavior` are also passed through to the `Behavior` during initialization.

--- a/src/module.js
+++ b/src/module.js
@@ -10,7 +10,7 @@ Marionette.Module = function(moduleName, app, options) {
   this.options = _.extend({}, this.options, options);
   // Allow for a user to overide the initialize
   // for a given module instance.
-  this.initialize = options.initialize || this.initialize;
+  this.initialize = this.options.initialize || this.initialize;
 
   // Set up an internal store for sub-modules.
   this.submodules = {};


### PR DESCRIPTION
If options is undefined when a module gets instantiated, an error gets thrown:

    Uncaught TypeError: Cannot read property 'initialize' of undefined