### PR TITLE
fyx tipo in regionManager docs

### DIFF
--- a/api/region-manager.yaml
+++ b/api/region-manager.yaml
@@ -16,17 +16,17 @@ constructor:
   
   examples:
     -
-      name: Creating a RegionMananger with default regions
+      name: Creating a RegionManager with default regions
       example: |
 
         ```js
-        var mananger = new Marionette.RegionManager({
+        var manager = new Marionette.RegionManager({
           regions: {
             "aRegion": "#bar"
           }
         })
 
-        mananger.getRegion("aRegion").show(new MyView);
+        manager.getRegion("aRegion").show(new MyView);
         ```
 
 functions:

--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -56,13 +56,13 @@ rm.removeRegion("foo");
 The RegionManager take an optional `region` option in their constructor. the regions are passed directly into `addRegions` for the region manager instance.
 
 ```js
-var mananger = new Marionette.RegionManager({
+var manager = new Marionette.RegionManager({
   regions: {
     "aRegion": "#bar"
   }
 });
 
-mananger.get('aRegion').show(new MyView);
+manager.get('aRegion').show(new MyView);
 ```
 
 ## RegionManager.addRegion


### PR DESCRIPTION
Spotted this typo in the docs. 

`s/mananger/manager`