### PR TITLE
Add triggerMethodMany

### DIFF
--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -189,6 +189,21 @@ Marionette.triggerMethodOn(ctx, "foo", bar);
 // will trigger "foo" on ctx
 ```
 
+## Marionette.triggerMethodMany
+
+Invokes `triggerMethod` on many contexts.
+
+This is useful when you want to trigger an event on many different objects.
+
+```js
+var views = getManyViews();
+var context = this;
+Marionette.triggerMethodMany(views, context, "foo", bar);
+// will call `onFoo: function(view, context, bar){...})` for each view
+// will trigger "foo" on each of the views
+```
+
+
 ## Marionette.bindEntityEvents
 
 This method is used to bind a backbone "entity" (e.g. collection/model)

--- a/src/region.js
+++ b/src/region.js
@@ -144,9 +144,7 @@ Marionette.Region = Marionette.Object.extend({
 
   _triggerAttach: function(views, prefix) {
     var eventName = (prefix || '') + 'attach';
-    _.each(views, function(view) {
-      Marionette.triggerMethodOn(view, eventName, view, this);
-    }, this);
+    Marionette.triggerMethodMany(views, this, eventName);
   },
 
   _displayedViews: function(view) {

--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -66,3 +66,18 @@ Marionette.triggerMethodOn = function(context) {
 
   return fnc.apply(context, _.rest(arguments));
 };
+
+// triggerMethodMany invokes triggerMethod on many targets from a source
+// it's useful for standardizing a pattern where we propogate an event from a source
+// to many targets.
+//
+// For each target we want to follow the pattern
+// target.triggerMethod(event, target, source, ...other args)
+// e.g childview.triggerMethod('attach', childView, region, ...args)
+Marionette.triggerMethodMany = function(targets, source, eventName) {
+  var args = _.drop(arguments, 3);
+
+  _.each(targets, function(target) {
+    Marionette.triggerMethodOn.apply(target, [target, eventName, target, source].concat(args));
+  });
+};

--- a/test/unit/trigger-method.spec.js
+++ b/test/unit/trigger-method.spec.js
@@ -183,4 +183,22 @@ describe('trigger event and method name', function() {
       });
     });
   });
+
+  describe('when triggering an event on many other contexts', function() {
+    beforeEach(function() {
+      this.views = _.times(2, function() {
+        var view = new Backbone.View();
+        view.onFoo = this.sinon.stub();
+        return view;
+      }, this);
+
+      this.context = {};
+      Marionette.triggerMethodMany(this.views, this.context, 'foo', 'bar', 'baz');
+    });
+
+    it('should trigger the event', function() {
+      expect(this.views[0].onFoo).to.have.been.calledOnce.and.calledWith(this.views[0], this.context, 'bar', 'baz');
+      expect(this.views[1].onFoo).to.have.been.calledOnce.and.calledWith(this.views[1], this.context, 'bar', 'baz');
+    });
+  });
 });


### PR DESCRIPTION
triggerMethodMany invokes triggerMethod on many targets from a source
it's useful for standardizing a pattern where we propogate an event from a source
to many targets.

For each target we want to follow the pattern
target.triggerMethod(event, target, source, ...other args)
e.g childview.triggerMethod('attach', childView, region, ...args)


@ianmstew i'm adding this now so that hopefully `attach` and `_triggerMethodChild` can be standardized