### PR TITLE
Fix module definition when array is provided as additional argument

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -117,7 +117,7 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
       Marionette,
       Backbone.$, _,
       customArgs
-    ]);
+    ], true);
 
     definition.apply(this, args);
   },

--- a/src/module.js
+++ b/src/module.js
@@ -114,7 +114,7 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
     // make flattening consistent
     // in lodash (v3) it's flatten(collection, deep)
     // and in underscore it's flatten(collection, shallow)
-    var deepFlag = !!_.flattenDeep;
+    var deepFlag = !_.flattenDeep;
     var args = _.flatten([
       this,
       this.app,

--- a/src/module.js
+++ b/src/module.js
@@ -110,6 +110,11 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
     if (!definition) { return; }
 
     // build the correct list of arguments for the module definition
+
+    // make flattening consistent
+    // in lodash (v3) it's flatten(collection, deep)
+    // and in underscore it's flatten(collection, shallow)
+    var deepFlag = !!_.flattenDeep;
     var args = _.flatten([
       this,
       this.app,
@@ -117,7 +122,7 @@ _.extend(Marionette.Module.prototype, Backbone.Events, {
       Marionette,
       Backbone.$, _,
       customArgs
-    ], true);
+    ], deepFlag);
 
     definition.apply(this, args);
   },

--- a/test/unit/module.spec.js
+++ b/test/unit/module.spec.js
@@ -25,7 +25,7 @@ describe('application modules', function() {
 
       describe('and the define function is provided', function() {
         beforeEach(function() {
-          this.additionalParam = [1, 2];
+          this.additionalParam = [[1], 2];
           this.module = this.app.module('Mod', this.defineSpy, this.additionalParam);
         });
 

--- a/test/unit/module.spec.js
+++ b/test/unit/module.spec.js
@@ -25,7 +25,7 @@ describe('application modules', function() {
 
       describe('and the define function is provided', function() {
         beforeEach(function() {
-          this.additionalParam = {};
+          this.additionalParam = [1, 2];
           this.module = this.app.module('Mod', this.defineSpy, this.additionalParam);
         });
 


### PR DESCRIPTION
I guess this is not intended behaviour:

if array is provided as additional argument to module definition it gets flattened into separate arguments.

    MyApp.module("MyModule", function(MyModule, MyApp, Backbone, Marionette, $, _, arg1, arg2){
        // arg1 === 1;
        // arg2 === 2;
    }, [1, 2]);