### PR TITLE
Support empty view on removal from filtered CollectionView

### DIFF
--- a/api/collection-view.yaml
+++ b/api/collection-view.yaml
@@ -251,6 +251,7 @@ functions:
       
       @api public
       @param {Marionette.Collection} collection
+      @param {Object} options
     
     examples:
       

--- a/api/item-view.yaml
+++ b/api/item-view.yaml
@@ -40,9 +40,14 @@ constructor:
 functions:
   serializeData:
     description: |
-      Serialize the model or collection for the view. If a model is found, the view's `serializeModel` is called. If a collection is found, each model in the collection is serialized by calling the view's `serializeCollection` and putting into an `items` array in the resulting data. If both are found, the model is used.
+      Serialize the view's model or collection for rendering the view's template. If a model is found, the view's `serializeModel` is called. If a
+      collection is found, `serializeCollection` will be called. The collection will be available in your template as `items`. If both a model and a
+      collection are found, the model will be used.
 
-      You can override the `serializeData` method in your own view definition, to provide custom serialization for your view's data. These serializations are then passed into the template function if one is set.
+      You can override the `serializeData` method in your own view definition to provide custom serialization for your view's `model` or
+      `collection`.
+
+      Do not override `serializeData` to add additional data to your templates. Use `templateHelpers` for that instead.
 
       @api public
 
@@ -59,10 +64,12 @@ functions:
                 var data = {};
 
                 if (this.collection) {
-                  data = { items: _.partial(this.serializeCollection, this.collection).apply(this, arguments) };
+                  data = {
+                    items: this.serializeCollection()
+                  };
                 }
                 else if (this.model) {
-                  data = _.partial(this.serializeModel, this.model).apply(this, arguments);
+                  data = this.serializeModel();
                 }
 
                 return data;
@@ -73,6 +80,8 @@ functions:
   serializeModel:
     description: |
       Serialize the view's model.
+
+      Do not override `serializeModel` to add additional data to your templates. Use `templateHelpers` for that instead.
 
       @api public
       @param {Backbone.Model} model - The model set on the ItemView to be serialized.
@@ -96,6 +105,8 @@ functions:
   serializeCollection:
     description: |
       Serialize the view's collection.
+
+      Do not override `serializeCollection` to add additional data to your templates. Use `templateHelpers` for that instead.
 
       @api public
       @param {Backbone.Collection} collection - The collection set on the ItemView to be serialized.

--- a/api/region.yaml
+++ b/api/region.yaml
@@ -255,6 +255,15 @@ functions:
     @param {Marionette.View} view
     @param {Object} options
 
+  renderView: |
+    Utility function to allow overriding of logic that determines whether the shown view should `render`. It will
+    always `render` by default.
+    
+    @api public
+    @param {Marionette.View} view
+    @param {Object} options
+    @returns {void}
+
   _ensureElement: |
     Ensure that `this.el` and `this.$el` is set. If 
     

--- a/api/region.yaml
+++ b/api/region.yaml
@@ -264,6 +264,15 @@ functions:
     @param {Object} options
     @returns {void}
 
+  shouldDestroyView: |
+    Utility function to allow overriding of logic that determines whether the old view should be destroyed. It will
+    always `destroy` by default unless the `preventDestroy` option is `true`.
+    
+    @api public
+    @param {Marionette.View} view
+    @param {Object} options
+    @returns {Boolean} should the view be destroyed
+
   _ensureElement: |
     Ensure that `this.el` and `this.$el` is set. If 
     

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -353,7 +353,7 @@ If you want to control when the empty view is rendered, you can override
 
 ```js
 Marionette.CollectionView.extend({
-  isEmpty: function(collection) {
+  isEmpty: function(collection, options) {
     // some logic to calculate if the view should be rendered as empty
     return someBoolean;
   }

--- a/docs/marionette.itemview.md
+++ b/docs/marionette.itemview.md
@@ -225,13 +225,29 @@ Marionette.ItemView.extend({
 
 ## ItemView serializeData
 
-Item views will serialize a model or collection, by default, by
-calling `.toJSON` on either the model or collection. If both a model
-and collection are attached to an item view, the model will be used
-as the data source. The results of the data serialization will be passed to the template
-that is rendered.
+This method is used to convert a View's `model` or `collection`
+into a usable form for a template.
 
-If the serialization is a model, the results are passed in directly:
+Item Views are called such because they process only a single item
+at a time. Consequently, only the `model` **or** the `collection` will
+be serialized. If both exist, only the `model` will be serialized.
+
+By default, models are serialized by cloning the attributes of the model.
+
+Collections are serialized into an object of this form:
+
+```js
+{
+  items: [modelOne, modelTwo]
+}
+``
+
+where each model in the collection will have its attributes cloned.
+
+The result of `serializeData` is included in the data passed to
+the view's template.
+
+Let's take a look at some examples of how serializing data works.
 
 ```js
 var myModel = new MyModel({foo: "bar"});
@@ -272,19 +288,11 @@ MyItemView.render();
 </script>
 ```
 
-If you need custom serialization for your data, you can provide a
-`serializeData` method on your view. It must return a valid JSON
-object, as if you had called `.toJSON` on a model or collection.
+If you need to serialize the View's `model` or `collection` in a custom way,
+then you should override either `serializeModel` or `serializeCollection`.
 
-```js
-Marionette.ItemView.extend({
-  serializeData: function(){
-    return {
-      "some attribute": "some value"
-    }
-  }
-});
-```
+On the other hand, you should not use this method to add arbitrary extra data
+to your template. Instead, use [View.templateHelpers](./marionette.view.md#viewtemplatehelpers).
 
 ## Organizing UI Elements
 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -314,10 +314,20 @@ In order to add conditional logic when rendering a view you can override the `re
 ```js
 
 var CachingRegion = Marionette.Region.extend({
-  shouldDestroyView(view, options) { return false; },
-  renderView(view, options) {
+  shouldDestroyView: function(view, options) { return false; },
+  renderView: function(view, options) {
     if (!view.isRendered) { view.render(); }
   }
+});
+```
+
+#### `shouldDestroyView`
+
+In order to add conditional logic around whether the current view should be destroyed when showing a new one you can override the `shouldDestroyView` method. This is particularly useful as an alternative to the `preventDestroy` option when you wish to prevent destroy on all views that are shown in the region.
+
+```js
+var CachingRegion = Marionette.Region.extend({
+  shouldDestroyView: function(view, options) { return false; }
 });
 ```
 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -307,6 +307,20 @@ myRegion.triggerBeforeAttach = false;
 myRegion.show(myView, {triggerBeforeAttach: true});
 ```
 
+#### `renderView`
+
+In order to add conditional logic when rendering a view you can override the `renderView` method. This could be useful if you don't want the region to re-render views that aren't destroyed. By default this method will call `view.render`.
+
+```js
+
+var CachingRegion = Marionette.Region.extend({
+  shouldDestroyView(view, options) { return false; },
+  renderView(view, options) {
+    if (!view.isRendered) { view.render(); }
+  }
+});
+```
+
 ### Checking whether a region is showing a view
 
 If you wish to check whether a region has a view, you can use the `hasView`

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -402,7 +402,14 @@ This works for both `modelEvents` and `collectionEvents`.
 
 ## View.serializeModel
 
-The `serializeModel` method will serialize a model that is passed in as an argument.
+This method is used internally during a view's rendering phase. It
+will serialize the View's `model` property, adding it to the data
+that is ultimately passed to the template.
+
+If you would like to serialize the View's `model` in a special way,
+then you should override this method. With that said, **do not** override
+this if you're simply adding additional data to your template, like computed
+fields. Use [templateHelpers](#viewtemplatehelpers) instead.
 
 ## View.bindUIElements
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -146,8 +146,10 @@ Marionette.CollectionView = Marionette.View.extend({
       this.render();
     } else {
       // get the DOM nodes in the same order as the models
-      var els = _.map(models, function(model) {
-        return children.findByModel(model).el;
+      var els = _.map(models, function(model, index) {
+        var view = children.findByModel(model);
+        view._index = index;
+        return view.el;
       });
 
       // since append moves elements that are already in the DOM,

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -204,36 +204,32 @@ Marionette.CollectionView = Marionette.View.extend({
     this.destroyEmptyView();
     this.destroyChildren({checkEmpty: false});
 
-    if (this.isEmpty(this.collection)) {
+    var models = this._filteredSortedModels();
+    if (this.isEmpty(this.collection, {processedModels: models})) {
       this.showEmptyView();
     } else {
       this.triggerMethod('before:render:collection', this);
       this.startBuffering();
-      this.showCollection();
+      this.showCollection(models);
       this.endBuffering();
       this.triggerMethod('render:collection', this);
-
-      // If we have shown children and none have passed the filter, show the empty view
-      if (this.children.isEmpty()) {
-        this.showEmptyView();
-      }
     }
   },
 
   // Internal method to loop through collection and show each child view.
-  showCollection: function() {
-    var ChildView;
-
-    var models = this._filteredSortedModels();
-
+  showCollection: function(models) {
     _.each(models, function(child, index) {
-      ChildView = this.getChildView(child);
+      var ChildView = this.getChildView(child);
       this.addChild(child, ChildView, index);
     }, this);
   },
 
   // Allow the collection to be sorted by a custom view comparator
   _filteredSortedModels: function() {
+    if (!this.collection) {
+      return [];
+    }
+
     var models;
     var viewComparator = this.getViewComparator();
 
@@ -248,12 +244,18 @@ Marionette.CollectionView = Marionette.View.extend({
     }
 
     // Filter after sorting in case the filter uses the index
+    models = this._filterModels(models);
+
+    return models;
+  },
+
+  // Filter an array of models, if a filter exists
+  _filterModels: function(models) {
     if (this.getOption('filter')) {
       models = _.filter(models, function(model, index) {
         return this._shouldAddChild(model, index);
       }, this);
     }
-
     return models;
   },
 
@@ -460,8 +462,16 @@ Marionette.CollectionView = Marionette.View.extend({
   },
 
   // check if the collection is empty
-  isEmpty: function() {
-    return !this.collection || this.collection.length === 0;
+  // or optionally whether an array of pre-processed models is empty
+  isEmpty: function(collection, options) {
+    var models;
+    if (_.result(options, 'processedModels')) {
+      models = options.processedModels;
+    } else {
+      models = this.collection ? this.collection.models : [];
+      models = this._filterModels(models);
+    }
+    return models.length === 0;
   },
 
   // If empty, show the empty view

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -46,17 +46,9 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     return childView;
   },
 
-  // Serialize the model for the view.
-  // You can override the `serializeData` method in your own view
-  // definition, to provide custom serialization for your view's data.
+  // Return the serialized model
   serializeData: function() {
-    var data = {};
-
-    if (this.model) {
-      data = _.partial(this.serializeModel, this.model).apply(this, arguments);
-    }
-
-    return data;
+    return this.serializeModel();
   },
 
   // Renders the model and the collection.
@@ -85,9 +77,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // Render the root template that the children
   // views are appended to
   _renderTemplate: function() {
-    var data = {};
-    data = this.serializeData();
-    data = this.mixinTemplateHelpers(data);
+    var data = this.mixinTemplateHelpers(this.serializeData());
 
     this.triggerMethod('before:render:template');
 

--- a/src/item-view.js
+++ b/src/item-view.js
@@ -12,35 +12,32 @@ Marionette.ItemView = Marionette.View.extend({
     Marionette.View.apply(this, arguments);
   },
 
-  // Serialize the model or collection for the view. If a model is
-  // found, the view's `serializeModel` is called. If a collection is found,
-  // each model in the collection is serialized by calling
-  // the view's `serializeCollection` and put into an `items` array in
-  // the resulting data. If both are found, defaults to the model.
-  // You can override the `serializeData` method in your own view definition,
-  // to provide custom serialization for your view's data.
+  // Serialize the view's model *or* collection, if
+  // it exists, for the template
   serializeData: function() {
-    if (!this.model && !this.collection) {
-      return {};
-    }
+    var data = {};
 
-    var args = [this.model || this.collection];
-    if (arguments.length) {
-      args.push.apply(args, arguments);
-    }
-
+    // If we have a model, we serialize that
     if (this.model) {
-      return this.serializeModel.apply(this, args);
-    } else {
-      return {
-        items: this.serializeCollection.apply(this, args)
+      data = this.serializeModel();
+
+    } else if (this.collection) {
+      // Otherwise, we serialize the collection,
+      // making it available under the `items` property
+
+      data = {
+        items: this.serializeCollection()
       };
     }
+
+    return data;
   },
 
-  // Serialize a collection by serializing each of its models.
-  serializeCollection: function(collection) {
-    return collection.toJSON.apply(collection, _.rest(arguments));
+  // Serialize a collection by cloning each of
+  // its model's attributes
+  serializeCollection: function() {
+    if (!this.collection) { return {}; }
+    return _.pluck(this.collection.invoke('clone'), 'attributes');
   },
 
   // Render the view, defaulting to underscore.js templates.

--- a/src/region.js
+++ b/src/region.js
@@ -46,7 +46,6 @@ Marionette.Region = Marionette.Object.extend({
 
     var showOptions     = options || {};
     var isDifferentView = view !== this.currentView;
-    var preventDestroy  = !!showOptions.preventDestroy;
     var forceShow       = !!showOptions.forceShow;
 
     // We are only changing the view if there is a current view to change to begin with
@@ -54,7 +53,7 @@ Marionette.Region = Marionette.Object.extend({
 
     // Only destroy the current view if we don't want to `preventDestroy` and if
     // the view given in the first argument is different than `currentView`
-    var _shouldDestroyView = isDifferentView && !preventDestroy;
+    var _shouldDestroyView = this.shouldDestroyView(view, options);
 
     // Only show the view given in the first argument if it is different than
     // the current view or if we want to re-show the view. Note that if
@@ -138,6 +137,14 @@ Marionette.Region = Marionette.Object.extend({
     }
 
     return this;
+  },
+
+  shouldDestroyView: function(view, options) {
+    var showOptions     = options || {};
+    var isDifferentView = view !== this.currentView;
+    var preventDestroy  = !!showOptions.preventDestroy;
+
+    return isDifferentView && !preventDestroy;
   },
 
   renderView: function(view, options) {

--- a/src/region.js
+++ b/src/region.js
@@ -87,7 +87,8 @@ Marionette.Region = Marionette.Object.extend({
       // to the currentView since once a view has been destroyed
       // we can not reuse it.
       view.once('destroy', this.empty, this);
-      view.render();
+
+      this.renderView(view, options);
 
       view._parent = this;
 
@@ -137,6 +138,10 @@ Marionette.Region = Marionette.Object.extend({
     }
 
     return this;
+  },
+
+  renderView: function(view, options) {
+    view.render();
   },
 
   triggerBeforeAttach: true,

--- a/src/view.js
+++ b/src/view.js
@@ -32,10 +32,13 @@ Marionette.View = Backbone.View.extend({
     return this.getOption('template');
   },
 
-  // Serialize a model by returning its attributes. Clones
-  // the attributes to allow modification.
-  serializeModel: function(model) {
-    return model.toJSON.apply(model, _.rest(arguments));
+  // Prepares the special `model` property of a view
+  // for being displayed in the template. By default
+  // we simply clone the attributes. Override this if
+  // you need a custom transformation for your view's model
+  serializeModel: function() {
+    if (!this.model) { return {}; }
+    return _.clone(this.model.attributes);
   },
 
   // Mix in template helper methods. Looks for a

--- a/test/unit/collection-view.empty-view.spec.js
+++ b/test/unit/collection-view.empty-view.spec.js
@@ -330,6 +330,26 @@ describe('collectionview - emptyView', function() {
         expect(this.isEmptyStub).to.have.been.calledWith(this.collection);
       });
     });
+
+    describe('with a filter', function() {
+      beforeEach(function() {
+        this.collection.reset([{foo: true}, {foo: false}]);
+      });
+
+      it('returns false if any of the models pass the filter', function() {
+        this.collectionView.filter = function(model) {
+          return model.get('foo');
+        };
+        expect(this.collectionView.isEmpty()).to.be.false;
+      });
+
+      it('returns false if none of the models pass the filter', function() {
+        this.collectionView.filter = function() {
+          return false;
+        };
+        expect(this.collectionView.isEmpty()).to.be.true;
+      });
+    });
   });
 
   describe('when rendering and an "emptyViewOptions" is provided', function() {

--- a/test/unit/collection-view.filter.spec.js
+++ b/test/unit/collection-view.filter.spec.js
@@ -34,7 +34,9 @@ describe('collection view - filter', function() {
       filter: this.filter,
       collection: this.collection,
       onBeforeRemoveChild: this.sinon.stub(),
-      onRemoveChild: this.sinon.stub()
+      onRemoveChild: this.sinon.stub(),
+      onBeforeRenderCollection: this.sinon.stub(),
+      onRenderCollection: this.sinon.stub()
     });
   });
 
@@ -65,6 +67,7 @@ describe('collection view - filter', function() {
       this.collection.add(this.passModel);
       this.collection.add(this.failModel);
       this.collectionView = new this.CollectionView();
+      this.sinon.spy(this.collectionView, 'removeChildView');
       this.collectionView.render();
     });
 
@@ -109,6 +112,23 @@ describe('collection view - filter', function() {
       });
     });
 
+    describe('when all models passing the filter are removed from the collection', function() {
+      beforeEach(function() {
+        this.passView = this.collectionView.children.first();
+        this.collection.remove(this.passModel);
+      });
+
+      it('should remove the child view', function() {
+        expect(this.collectionView.removeChildView).to.have.been.calledOnce
+          .and.calledOn(this.collectionView)
+          .and.calledWith(this.passView);
+      });
+
+      it('should show the EmptyView', function() {
+        expect(this.collectionView.$el).to.contain.$text('empty');
+      });
+    });
+
     describe('when resetting the collection with some of the models passing the filter', function() {
       beforeEach(function() {
         this.filter.reset();
@@ -146,6 +166,8 @@ describe('collection view - filter', function() {
         this.filter.reset();
         this.newFailModel = this.failModel.clone();
         this.sinon.spy(this.collectionView, 'showEmptyView');
+        this.collectionView.onBeforeRenderCollection.reset();
+        this.collectionView.onRenderCollection.reset();
         this.collection.reset([this.newFailModel]);
       });
 
@@ -160,6 +182,14 @@ describe('collection view - filter', function() {
 
       it('should contain the empty view in the DOM', function() {
         expect(this.collectionView.$el).to.contain.$text('empty');
+      });
+
+      it('should not call onBeforeRenderCollection', function() {
+        expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
+      });
+
+      it('should not call onRenderCollection', function() {
+        expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
       });
     });
 
@@ -203,6 +233,14 @@ describe('collection view - filter', function() {
 
     it('should contain the empty view in the DOM', function() {
       expect(this.collectionView.$el).to.contain.$text('empty');
+    });
+
+    it('should not call onBeforeRenderCollection', function() {
+      expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
+    });
+
+    it('should not call onRenderCollection', function() {
+      expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
     });
   });
 

--- a/test/unit/item-view.spec.js
+++ b/test/unit/item-view.spec.js
@@ -377,15 +377,11 @@ describe('item view', function() {
     describe('and the view only has a collection', function() {
       beforeEach(function() {
         this.itemView.collection = new Backbone.Collection(this.collectionData);
-        this.itemView.serializeData(1, 2, 3);
+        this.itemView.serializeData();
       });
 
       it('should call serializeCollection', function() {
         expect(this.itemView.serializeCollection).to.have.been.calledOnce;
-      });
-
-      it('and the serialize function should be called with the provided arguments', function() {
-        expect(this.itemView.serializeCollection).to.have.been.calledWith(this.itemView.collection, 1, 2, 3);
       });
 
       it('should not call serializeModel', function() {
@@ -397,15 +393,11 @@ describe('item view', function() {
       beforeEach(function() {
         this.itemView.model = new Backbone.Model(this.modelData);
         this.itemView.collection = new Backbone.Collection(this.collectionData);
-        this.itemView.serializeData(1, 2, 3);
+        this.itemView.serializeData();
       });
 
       it('should call serializeModel', function() {
         expect(this.itemView.serializeModel).to.have.been.calledOnce;
-      });
-
-      it('and the serialize function should be called with the provided arguments', function() {
-        expect(this.itemView.serializeModel).to.have.been.calledWith(this.itemView.model, 1, 2, 3);
       });
 
       it('should not call serializeCollection', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -103,9 +103,9 @@ describe('region', function() {
         });
 
         it('should not render the view', function() {
-          sinon.spy(this.myView, 'render');
+          this.sinon.spy(this.myRegion, 'renderView');
           this.myRegion.show(this.myView);
-          expect(this.myView.render).not.to.have.been.called;
+          expect(this.myRegion.renderView).not.to.have.been.called;
         });
       });
     });
@@ -561,6 +561,7 @@ describe('region', function() {
 
       this.sinon.spy(this.view, 'destroy');
       this.sinon.spy(this.myRegion, 'attachHtml');
+      this.sinon.spy(this.myRegion, 'renderView');
       this.sinon.spy(this.view, 'render');
       this.myRegion.show(this.view);
     });
@@ -573,8 +574,8 @@ describe('region', function() {
       expect(this.myRegion.attachHtml).not.to.have.been.calledWith(this.view);
     });
 
-    it('should not call "render" on the view', function() {
-      expect(this.view.render).not.to.have.been.called;
+    it('should not call "renderView"', function() {
+      expect(this.myRegion.renderView).not.to.have.been.called;
     });
   });
 
@@ -601,6 +602,7 @@ describe('region', function() {
 
       this.sinon.spy(this.view, 'destroy');
       this.sinon.spy(this.myRegion, 'attachHtml');
+      this.sinon.spy(this.myRegion, 'renderView');
       this.sinon.spy(this.view, 'render');
       this.myRegion.show(this.view, {forceShow: true});
     });
@@ -613,8 +615,8 @@ describe('region', function() {
       expect(this.myRegion.attachHtml).to.have.been.calledWith(this.view);
     });
 
-    it('should call "render" on the view', function() {
-      expect(this.view.render).to.have.been.called;
+    it('should call "renderView"', function() {
+      expect(this.myRegion.renderView).to.have.been.calledOnce.and.calledWith(this.view, {forceShow: true});
     });
   });
 
@@ -853,10 +855,12 @@ describe('region', function() {
         el: '#foo',
         currentView: this.view
       });
+
+      this.sinon.spy(this.region, 'renderView');
     });
 
     it('should not render the view', function() {
-      expect(this.view.render).not.to.have.been.called;
+      expect(this.region.renderView).not.to.have.been.called;
     });
 
     it('should not `show` the view', function() {
@@ -881,12 +885,13 @@ describe('region', function() {
         el: '#foo'
       });
 
+      this.sinon.spy(this.region, 'renderView');
       this.sinon.spy(this.region, 'attachView');
       this.region.attachView(this.view);
     });
 
     it('should not render the view', function() {
-      expect(this.view.render).not.to.have.been.called;
+      expect(this.region.renderView).not.to.have.been.called;
     });
 
     it('should not `show` the view', function() {
@@ -1049,6 +1054,27 @@ describe('region', function() {
     it('should throw an error', function() {
       var errorMessage = 'The view passed is undefined and therefore invalid. You must pass a view instance to show.';
       expect(this.insertUndefined).to.throw(errorMessage);
+    });
+  });
+
+  describe('when calling "renderView"', function() {
+    beforeEach(function() {
+      this.region = new Backbone.Marionette.Region({
+        el: '#region'
+      });
+
+      this.View = Backbone.Marionette.View.extend({
+        template: _.template('')
+      });
+
+      this.view = new this.View();
+      this.sinon.spy(this.view, 'render');
+
+      this.region.renderView(this.view);
+    });
+
+    it('should call "render" on the view', function() {
+      expect(this.view.render).to.have.been.calledOnce;
     });
   });
 });

--- a/test/unit/sorted-views.spec.js
+++ b/test/unit/sorted-views.spec.js
@@ -453,6 +453,7 @@ describe('collection/composite view sorting', function() {
           var cmp = function(m) {
             return m.get('bar');
           };
+
           if (specOptions.viewComparator) {
             this.collection.comparator = 'foo';
             this.collectionView.options.viewComparator = cmp;
@@ -484,6 +485,26 @@ describe('collection/composite view sorting', function() {
 
         it('should respect the childViewContainer in a CompositeView', function() {
           expect(this.compositeView.$('#container')).to.have.$text('321');
+        });
+
+        describe('and reversing the sort', function() {
+          beforeEach(function() {
+            var cmp = function(m) {
+              return m.get('foo');
+            };
+            if (specOptions.viewComparator) {
+              this.collection.comparator = 'bar';
+              this.collectionView.options.viewComparator = cmp;
+              this.compositeView.options.viewComparator = cmp;
+            } else {
+              this.collection.comparator = cmp;
+            }
+            this.collection.sort();
+          });
+
+          it('should reorder the DOM', function() {
+            expect(this.collectionView.$el).to.have.$text('123');
+          });
         });
       });
     };

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -273,11 +273,13 @@ describe('base view', function() {
 
     beforeEach(function() {
       model = new Backbone.Model(modelData);
-      view = new Marionette.View();
+      view = new Marionette.View({
+        model: model
+      });
     });
 
     it('should return all attributes', function() {
-      expect(view.serializeModel(model)).to.be.eql(modelData);
+      expect(view.serializeModel()).to.be.eql(modelData);
     });
   });
 


### PR DESCRIPTION
As per #2437, currently, the CollectionView doesn't consider the filter when checking for emptiness.

In order to prevent two complete filter operations when rendering (once for checking emptiness, and once when displaying models), this implementation has an option to skip checking based on filtering (see comments).

I wouldn't say this PR is complete, but I wanted to get the rest of the team's opinion, since I can multiple less-than-ideal solutions to this problem.