### PR TITLE
Remove unneeded files from bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "test",
     ".editorconfig",
     ".gitignore",
+    ".jscsrc",
     ".jshintrc",
     ".npmignore",
     ".travis.yml",


### PR DESCRIPTION
`.jscsrc` file is useless within the bower package, thus it should be removed from there.