### PR TITLE
Refactor serializeData to no longer use toJSON.

### DIFF
--- a/api/item-view.yaml
+++ b/api/item-view.yaml
@@ -40,9 +40,14 @@ constructor:
 functions:
   serializeData:
     description: |
-      Serialize the model or collection for the view. If a model is found, the view's `serializeModel` is called. If a collection is found, each model in the collection is serialized by calling the view's `serializeCollection` and putting into an `items` array in the resulting data. If both are found, the model is used.
+      Serialize the view's model or collection for rendering the view's template. If a model is found, the view's `serializeModel` is called. If a
+      collection is found, `serializeCollection` will be called. The collection will be available in your template as `items`. If both a model and a
+      collection are found, the model will be used.
 
-      You can override the `serializeData` method in your own view definition, to provide custom serialization for your view's data. These serializations are then passed into the template function if one is set.
+      You can override the `serializeData` method in your own view definition to provide custom serialization for your view's `model` or
+      `collection`.
+
+      Do not override `serializeData` to add additional data to your templates. Use `templateHelpers` for that instead.
 
       @api public
 
@@ -59,10 +64,12 @@ functions:
                 var data = {};
 
                 if (this.collection) {
-                  data = { items: _.partial(this.serializeCollection, this.collection).apply(this, arguments) };
+                  data = {
+                    items: this.serializeCollection()
+                  };
                 }
                 else if (this.model) {
-                  data = _.partial(this.serializeModel, this.model).apply(this, arguments);
+                  data = this.serializeModel();
                 }
 
                 return data;
@@ -73,6 +80,8 @@ functions:
   serializeModel:
     description: |
       Serialize the view's model.
+
+      Do not override `serializeModel` to add additional data to your templates. Use `templateHelpers` for that instead.
 
       @api public
       @param {Backbone.Model} model - The model set on the ItemView to be serialized.
@@ -96,6 +105,8 @@ functions:
   serializeCollection:
     description: |
       Serialize the view's collection.
+
+      Do not override `serializeCollection` to add additional data to your templates. Use `templateHelpers` for that instead.
 
       @api public
       @param {Backbone.Collection} collection - The collection set on the ItemView to be serialized.

--- a/docs/marionette.itemview.md
+++ b/docs/marionette.itemview.md
@@ -225,13 +225,29 @@ Marionette.ItemView.extend({
 
 ## ItemView serializeData
 
-Item views will serialize a model or collection, by default, by
-calling `.toJSON` on either the model or collection. If both a model
-and collection are attached to an item view, the model will be used
-as the data source. The results of the data serialization will be passed to the template
-that is rendered.
+This method is used to convert a View's `model` or `collection`
+into a usable form for a template.
 
-If the serialization is a model, the results are passed in directly:
+Item Views are called such because they process only a single item
+at a time. Consequently, only the `model` **or** the `collection` will
+be serialized. If both exist, only the `model` will be serialized.
+
+By default, models are serialized by cloning the attributes of the model.
+
+Collections are serialized into an object of this form:
+
+```js
+{
+  items: [modelOne, modelTwo]
+}
+``
+
+where each model in the collection will have its attributes cloned.
+
+The result of `serializeData` is included in the data passed to
+the view's template.
+
+Let's take a look at some examples of how serializing data works.
 
 ```js
 var myModel = new MyModel({foo: "bar"});
@@ -272,19 +288,11 @@ MyItemView.render();
 </script>
 ```
 
-If you need custom serialization for your data, you can provide a
-`serializeData` method on your view. It must return a valid JSON
-object, as if you had called `.toJSON` on a model or collection.
+If you need to serialize the View's `model` or `collection` in a custom way,
+then you should override either `serializeModel` or `serializeCollection`.
 
-```js
-Marionette.ItemView.extend({
-  serializeData: function(){
-    return {
-      "some attribute": "some value"
-    }
-  }
-});
-```
+On the other hand, you should not use this method to add arbitrary extra data
+to your template. Instead, use [View.templateHelpers](./marionette.view.md#viewtemplatehelpers).
 
 ## Organizing UI Elements
 

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -402,7 +402,14 @@ This works for both `modelEvents` and `collectionEvents`.
 
 ## View.serializeModel
 
-The `serializeModel` method will serialize a model that is passed in as an argument.
+This method is used internally during a view's rendering phase. It
+will serialize the View's `model` property, adding it to the data
+that is ultimately passed to the template.
+
+If you would like to serialize the View's `model` in a special way,
+then you should override this method. With that said, **do not** override
+this if you're simply adding additional data to your template, like computed
+fields. Use [templateHelpers](#viewtemplatehelpers) instead.
 
 ## View.bindUIElements
 

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -46,17 +46,9 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     return childView;
   },
 
-  // Serialize the model for the view.
-  // You can override the `serializeData` method in your own view
-  // definition, to provide custom serialization for your view's data.
+  // Return the serialized model
   serializeData: function() {
-    var data = {};
-
-    if (this.model) {
-      data = _.partial(this.serializeModel, this.model).apply(this, arguments);
-    }
-
-    return data;
+    return this.serializeModel();
   },
 
   // Renders the model and the collection.
@@ -85,9 +77,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // Render the root template that the children
   // views are appended to
   _renderTemplate: function() {
-    var data = {};
-    data = this.serializeData();
-    data = this.mixinTemplateHelpers(data);
+    var data = this.mixinTemplateHelpers(this.serializeData());
 
     this.triggerMethod('before:render:template');
 

--- a/src/item-view.js
+++ b/src/item-view.js
@@ -12,35 +12,32 @@ Marionette.ItemView = Marionette.View.extend({
     Marionette.View.apply(this, arguments);
   },
 
-  // Serialize the model or collection for the view. If a model is
-  // found, the view's `serializeModel` is called. If a collection is found,
-  // each model in the collection is serialized by calling
-  // the view's `serializeCollection` and put into an `items` array in
-  // the resulting data. If both are found, defaults to the model.
-  // You can override the `serializeData` method in your own view definition,
-  // to provide custom serialization for your view's data.
+  // Serialize the view's model *or* collection, if
+  // it exists, for the template
   serializeData: function() {
-    if (!this.model && !this.collection) {
-      return {};
-    }
+    var data = {};
 
-    var args = [this.model || this.collection];
-    if (arguments.length) {
-      args.push.apply(args, arguments);
-    }
-
+    // If we have a model, we serialize that
     if (this.model) {
-      return this.serializeModel.apply(this, args);
-    } else {
-      return {
-        items: this.serializeCollection.apply(this, args)
+      data = this.serializeModel();
+
+    } else if (this.collection) {
+      // Otherwise, we serialize the collection,
+      // making it available under the `items` property
+
+      data = {
+        items: this.serializeCollection()
       };
     }
+
+    return data;
   },
 
-  // Serialize a collection by serializing each of its models.
-  serializeCollection: function(collection) {
-    return collection.toJSON.apply(collection, _.rest(arguments));
+  // Serialize a collection by cloning each of
+  // its model's attributes
+  serializeCollection: function() {
+    if (!this.collection) { return {}; }
+    return _.pluck(this.collection.invoke('clone'), 'attributes');
   },
 
   // Render the view, defaulting to underscore.js templates.

--- a/src/view.js
+++ b/src/view.js
@@ -32,10 +32,13 @@ Marionette.View = Backbone.View.extend({
     return this.getOption('template');
   },
 
-  // Serialize a model by returning its attributes. Clones
-  // the attributes to allow modification.
-  serializeModel: function(model) {
-    return model.toJSON.apply(model, _.rest(arguments));
+  // Prepares the special `model` property of a view
+  // for being displayed in the template. By default
+  // we simply clone the attributes. Override this if
+  // you need a custom transformation for your view's model
+  serializeModel: function() {
+    if (!this.model) { return {}; }
+    return _.clone(this.model.attributes);
   },
 
   // Mix in template helper methods. Looks for a

--- a/test/unit/item-view.spec.js
+++ b/test/unit/item-view.spec.js
@@ -377,15 +377,11 @@ describe('item view', function() {
     describe('and the view only has a collection', function() {
       beforeEach(function() {
         this.itemView.collection = new Backbone.Collection(this.collectionData);
-        this.itemView.serializeData(1, 2, 3);
+        this.itemView.serializeData();
       });
 
       it('should call serializeCollection', function() {
         expect(this.itemView.serializeCollection).to.have.been.calledOnce;
-      });
-
-      it('and the serialize function should be called with the provided arguments', function() {
-        expect(this.itemView.serializeCollection).to.have.been.calledWith(this.itemView.collection, 1, 2, 3);
       });
 
       it('should not call serializeModel', function() {
@@ -397,15 +393,11 @@ describe('item view', function() {
       beforeEach(function() {
         this.itemView.model = new Backbone.Model(this.modelData);
         this.itemView.collection = new Backbone.Collection(this.collectionData);
-        this.itemView.serializeData(1, 2, 3);
+        this.itemView.serializeData();
       });
 
       it('should call serializeModel', function() {
         expect(this.itemView.serializeModel).to.have.been.calledOnce;
-      });
-
-      it('and the serialize function should be called with the provided arguments', function() {
-        expect(this.itemView.serializeModel).to.have.been.calledWith(this.itemView.model, 1, 2, 3);
       });
 
       it('should not call serializeCollection', function() {

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -273,11 +273,13 @@ describe('base view', function() {
 
     beforeEach(function() {
       model = new Backbone.Model(modelData);
-      view = new Marionette.View();
+      view = new Marionette.View({
+        model: model
+      });
     });
 
     it('should return all attributes', function() {
-      expect(view.serializeModel(model)).to.be.eql(modelData);
+      expect(view.serializeModel()).to.be.eql(modelData);
     });
   });
 


### PR DESCRIPTION
Cherry-picks https://github.com/marionettejs/backbone.marionette/commit/f14b7eb55f7b1bd28243c31e8ec9f74da58aad28 onto next.

Here's what my setup looks like ![](http://f.cl.ly/items/2o0N381M3X3t0H272W39/Image%202015-03-25%20at%2012.04.47%20PM.png)

I'm sorry in advance if this proecess kinda sucks and you've got to squint real hard to double check everything. 

On a meta level, I could just merge these cherry-picks into next w/o a review, but honestly w/ big commits like this one i feel better sharing it.


---
toJSON should only be used for preparing data to be sent to the
server. In addition, serializeData no longer accepts arguments,
distinguishing it further from templateHelpers.

Resolves #1476
