### PR TITLE
Updating the appRoutes object when the appRoute() function is called, in...

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -71,6 +71,8 @@ Marionette.AppRouter = Backbone.Router.extend({
       throw new Marionette.Error('Method "' + methodName + '" was not found on the controller');
     }
 
+    this.appRoutes = this.appRoutes || {};
+    this.appRoutes[route] = methodName;
     this.route(route, methodName, _.bind(method, controller));
   },
 


### PR DESCRIPTION
Just took over #2332

Probably needs tests and docs and things

---
Updating the appRoutes object when the appRoute() function is called, in order that the onRoute function can return the correct path.

---

#### Why: 
The problem - In my version of Marionette.AppRouter I do not define the 'appRoutes' object but I do define 'controller'. I instantiate Marionette.AppRouter (var router = new Router()) and then I call the router.appRoute() method to dynamically associate a route with a controller method. I noticed that if I create an onRoute function within the Router class the path is being returned as undefined, rather than the path I created. I believe this is because the appRoutes object is not being updated when the appRoutes() function is being called dynamically, and therefore the path cannot be found when the route event is fired.

#### What:
 I propose to instantiate the appRoutes object as an empty object if it doesn't already exist, or leave it as is if it does exist. In addition to this I propose to add the new route to the appRoutes object whenever appRoutes() is called.

#### How: 
This solves the problem as the _processOnRoute() function now has access to the routes that were dynamically added and can find the associated path.

Given my lack of knowledge of the inner workings of backbone.marionette I admit there may be a more elegant way of solving this. I also wonder if this will cause problems if someone is using the 'routes' object of their Router rather that 'appRoutes', in other words using methods on the Router rather than using a controller.