### PR TITLE
(#2437) CollectionView filter shows empty view on remove

### DIFF
--- a/api/collection-view.yaml
+++ b/api/collection-view.yaml
@@ -251,6 +251,7 @@ functions:
       
       @api public
       @param {Marionette.Collection} collection
+      @param {Object} options
     
     examples:
       

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -353,7 +353,7 @@ If you want to control when the empty view is rendered, you can override
 
 ```js
 Marionette.CollectionView.extend({
-  isEmpty: function(collection) {
+  isEmpty: function(collection, options) {
     // some logic to calculate if the view should be rendered as empty
     return someBoolean;
   }

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -204,36 +204,32 @@ Marionette.CollectionView = Marionette.View.extend({
     this.destroyEmptyView();
     this.destroyChildren({checkEmpty: false});
 
-    if (this.isEmpty(this.collection)) {
+    var models = this._filteredSortedModels();
+    if (this.isEmpty(this.collection, {processedModels: models})) {
       this.showEmptyView();
     } else {
       this.triggerMethod('before:render:collection', this);
       this.startBuffering();
-      this.showCollection();
+      this.showCollection(models);
       this.endBuffering();
       this.triggerMethod('render:collection', this);
-
-      // If we have shown children and none have passed the filter, show the empty view
-      if (this.children.isEmpty()) {
-        this.showEmptyView();
-      }
     }
   },
 
   // Internal method to loop through collection and show each child view.
-  showCollection: function() {
-    var ChildView;
-
-    var models = this._filteredSortedModels();
-
+  showCollection: function(models) {
     _.each(models, function(child, index) {
-      ChildView = this.getChildView(child);
+      var ChildView = this.getChildView(child);
       this.addChild(child, ChildView, index);
     }, this);
   },
 
   // Allow the collection to be sorted by a custom view comparator
   _filteredSortedModels: function() {
+    if (!this.collection) {
+      return [];
+    }
+
     var models;
     var viewComparator = this.getViewComparator();
 
@@ -248,12 +244,18 @@ Marionette.CollectionView = Marionette.View.extend({
     }
 
     // Filter after sorting in case the filter uses the index
+    models = this._filterModels(models);
+
+    return models;
+  },
+
+  // Filter an array of models, if a filter exists
+  _filterModels: function(models) {
     if (this.getOption('filter')) {
       models = _.filter(models, function(model, index) {
         return this._shouldAddChild(model, index);
       }, this);
     }
-
     return models;
   },
 
@@ -460,8 +462,16 @@ Marionette.CollectionView = Marionette.View.extend({
   },
 
   // check if the collection is empty
-  isEmpty: function() {
-    return !this.collection || this.collection.length === 0;
+  // or optionally whether an array of pre-processed models is empty
+  isEmpty: function(collection, options) {
+    var models;
+    if (_.result(options, 'processedModels')) {
+      models = options.processedModels;
+    } else {
+      models = this.collection ? this.collection.models : [];
+      models = this._filterModels(models);
+    }
+    return models.length === 0;
   },
 
   // If empty, show the empty view

--- a/test/unit/collection-view.empty-view.spec.js
+++ b/test/unit/collection-view.empty-view.spec.js
@@ -330,6 +330,26 @@ describe('collectionview - emptyView', function() {
         expect(this.isEmptyStub).to.have.been.calledWith(this.collection);
       });
     });
+
+    describe('with a filter', function() {
+      beforeEach(function() {
+        this.collection.reset([{foo: true}, {foo: false}]);
+      });
+
+      it('returns false if any of the models pass the filter', function() {
+        this.collectionView.filter = function(model) {
+          return model.get('foo');
+        };
+        expect(this.collectionView.isEmpty()).to.be.false;
+      });
+
+      it('returns true if none of the models pass the filter', function() {
+        this.collectionView.filter = function() {
+          return false;
+        };
+        expect(this.collectionView.isEmpty()).to.be.true;
+      });
+    });
   });
 
   describe('when rendering and an "emptyViewOptions" is provided', function() {

--- a/test/unit/collection-view.filter.spec.js
+++ b/test/unit/collection-view.filter.spec.js
@@ -34,7 +34,9 @@ describe('collection view - filter', function() {
       filter: this.filter,
       collection: this.collection,
       onBeforeRemoveChild: this.sinon.stub(),
-      onRemoveChild: this.sinon.stub()
+      onRemoveChild: this.sinon.stub(),
+      onBeforeRenderCollection: this.sinon.stub(),
+      onRenderCollection: this.sinon.stub()
     });
   });
 
@@ -65,6 +67,7 @@ describe('collection view - filter', function() {
       this.collection.add(this.passModel);
       this.collection.add(this.failModel);
       this.collectionView = new this.CollectionView();
+      this.sinon.spy(this.collectionView, 'removeChildView');
       this.collectionView.render();
     });
 
@@ -109,6 +112,23 @@ describe('collection view - filter', function() {
       });
     });
 
+    describe('when all models passing the filter are removed from the collection', function() {
+      beforeEach(function() {
+        this.passView = this.collectionView.children.first();
+        this.collection.remove(this.passModel);
+      });
+
+      it('should remove the child view', function() {
+        expect(this.collectionView.removeChildView).to.have.been.calledOnce
+          .and.calledOn(this.collectionView)
+          .and.calledWith(this.passView);
+      });
+
+      it('should show the EmptyView', function() {
+        expect(this.collectionView.$el).to.contain.$text('empty');
+      });
+    });
+
     describe('when resetting the collection with some of the models passing the filter', function() {
       beforeEach(function() {
         this.filter.reset();
@@ -146,6 +166,8 @@ describe('collection view - filter', function() {
         this.filter.reset();
         this.newFailModel = this.failModel.clone();
         this.sinon.spy(this.collectionView, 'showEmptyView');
+        this.collectionView.onBeforeRenderCollection.reset();
+        this.collectionView.onRenderCollection.reset();
         this.collection.reset([this.newFailModel]);
       });
 
@@ -160,6 +182,14 @@ describe('collection view - filter', function() {
 
       it('should contain the empty view in the DOM', function() {
         expect(this.collectionView.$el).to.contain.$text('empty');
+      });
+
+      it('should not call onBeforeRenderCollection', function() {
+        expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
+      });
+
+      it('should not call onRenderCollection', function() {
+        expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
       });
     });
 
@@ -203,6 +233,14 @@ describe('collection view - filter', function() {
 
     it('should contain the empty view in the DOM', function() {
       expect(this.collectionView.$el).to.contain.$text('empty');
+    });
+
+    it('should not call onBeforeRenderCollection', function() {
+      expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
+    });
+
+    it('should not call onRenderCollection', function() {
+      expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
     });
   });
 


### PR DESCRIPTION
Opening against `next`, from #2445:

As per #2437, currently, the CollectionView doesn't consider the filter when checking for emptiness.

In order to prevent two complete filter operations when rendering (once for checking emptiness, and once when displaying models), this implementation has an option to skip checking based on filtering (see comments).

This should land in 2.4.2 and is dependent on other bugfixes meant to land in 2.4.2 (primarily the `checkEmpty` with `destroyChildren`)