### PR TITLE
(#2297) Apply console context to deprecate warnings

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -145,5 +145,9 @@ var deprecate = Marionette.deprecate = function(message, test) {
   }
 };
 
-deprecate._warn = typeof console !== 'undefined' && (console.warn || console.log) || function() {};
+deprecate._console = typeof console !== 'undefined' ? console : {};
+deprecate._warn = function() {
+  var warn = deprecate._console.warn || deprecate._console.log || function() {};
+  return warn.apply(deprecate._console, arguments);
+};
 deprecate._cache = {};

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -61,8 +61,24 @@ describe('normalizeUIKeys', function() {
 
 describe('Marionette.deprecate', function() {
   beforeEach(function() {
-    this.sinon.stub(Marionette.deprecate, '_warn');
+    this.sinon.spy(Marionette.deprecate, '_warn');
+    this.sinon.stub(Marionette.deprecate, '_console', {
+      warn: this.sinon.stub()
+    });
     Marionette.deprecate._cache = {};
+  });
+
+  describe('Marionette.deprecate._warn', function() {
+    beforeEach(function() {
+      Marionette.deprecate._warn('foo');
+    });
+
+    it('should `console.warn` the message', function() {
+      expect(Marionette.deprecate._console.warn)
+        .to.have.been.calledOnce
+        .and.calledOn(Marionette.deprecate._console)
+        .and.calledWith('foo');
+    });
   });
 
   describe('when calling with a message', function() {


### PR DESCRIPTION
To ensure console compatibility

Had to split out console so I could stub it and test it.