### PR TITLE
Propagate CollectionView before:show & call before:show/show with view argument.

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -86,7 +86,7 @@
     <script src="src/region-manager.js"></script>
     <script src="src/behavior.js"></script>
     <script src="src/behaviors.js"></script>
-    <script src="src/view.js"></script>
+    <script src="src/abstract-view.js"></script>
     <script src="src/item-view.js"></script>
     <script src="src/layout-view.js"></script>
     <script src="src/collection-view.js"></script>
@@ -139,7 +139,7 @@
     <script src="test/unit/trigger-method.spec.js"></script>
     <script src="test/unit/unbind-entity-events.spec.js"></script>
     <script src="test/unit/view.entity-events.spec.js"></script>
-    <script src="test/unit/view.spec.js"></script>
+    <script src="test/unit/abstract-view.spec.js"></script>
     <script src="test/unit/view.triggers.spec.js"></script>
     <script src="test/unit/view.ui-bindings.spec.js"></script>
     <script src="test/unit/view.ui-event-and-triggers.spec.js"></script>

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -28,6 +28,7 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
 
     Marionette.AbstractView.apply(this, arguments);
 
+    this.on('before:show', this._onBeforeShowCalled);
     this.on('show', this._onShowCalled);
 
     this.initRenderBuffer();
@@ -47,32 +48,23 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
 
   endBuffering: function() {
     this.isBuffering = false;
-    this._triggerBeforeShowBufferedChildren();
+    if (this._isShown) {
+      this._triggerShowMultiple(this._bufferedChildren, 'before:');
+    }
 
     this.attachBuffer(this);
 
-    this._triggerShowBufferedChildren();
+    if (this._isShown) {
+      this._triggerShowMultiple(this._bufferedChildren);
+    }
     this.initRenderBuffer();
   },
 
-  _triggerBeforeShowBufferedChildren: function() {
-    if (this._isShown) {
-      _.each(this._bufferedChildren, _.partial(this._triggerMethodOnChild, 'before:show'));
-    }
-  },
-
-  _triggerShowBufferedChildren: function() {
-    if (this._isShown) {
-      _.each(this._bufferedChildren, _.partial(this._triggerMethodOnChild, 'show'));
-
-      this.initRenderBuffer();
-    }
-  },
-
-  // Internal method for _.each loops to call `Marionette.triggerMethodOn` on
-  // a child view
-  _triggerMethodOnChild: function(event, childView) {
-    Marionette.triggerMethodOn(childView, event);
+  _triggerShowMultiple: function(views, prefix) {
+    var eventName = (prefix || '') + 'show';
+    _.each(views, function(view) {
+      Marionette.triggerMethodOn(view, eventName, view);
+    }, this);
   },
 
   // Configured the initial events that the collection view
@@ -112,9 +104,16 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     this.checkEmpty();
   },
 
-  // Override from `Marionette.AbstractView` to trigger show on child views
+  _onBeforeShowCalled: function() {
+    this.children.each(function(childView) {
+      Marionette.triggerMethodOn(childView, 'before:show', childView);
+    });
+  },
+
   _onShowCalled: function() {
-    this.children.each(_.partial(this._triggerMethodOnChild, 'show'));
+    this.children.each(function(childView) {
+      Marionette.triggerMethodOn(childView, 'show', childView);
+    });
   },
 
   // Render children views. Override this method to
@@ -317,7 +316,7 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     // trigger the 'before:show' event on `view` if the collection view
     // has already been shown
     if (this._isShown) {
-      Marionette.triggerMethodOn(view, 'before:show');
+      Marionette.triggerMethodOn(view, 'before:show', view);
     }
 
     // Store the `emptyView` like a `childView` so we can properly
@@ -330,7 +329,7 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     // call the 'show' method if the collection view
     // has already been shown
     if (this._isShown) {
-      Marionette.triggerMethodOn(view, 'show');
+      Marionette.triggerMethodOn(view, 'show', view);
     }
   },
 
@@ -404,7 +403,7 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     // trigger the 'before:show' event on `view` if the collection view
     // has already been shown
     if (this._isShown && !this.isBuffering) {
-      Marionette.triggerMethodOn(view, 'before:show');
+      Marionette.triggerMethodOn(view, 'before:show', view);
     }
 
     // Store the child view itself so we can properly
@@ -413,7 +412,7 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     this.renderChildView(view, index);
 
     if (this._isShown && !this.isBuffering) {
-      Marionette.triggerMethodOn(view, 'show');
+      Marionette.triggerMethodOn(view, 'show', view);
     }
 
     this.triggerMethod('add:child', view);

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -5,8 +5,18 @@ describe('collection view', function() {
     // Shared View Definitions
     // -----------------------
 
+    var spec = this;
+
     this.ChildView = Backbone.Marionette.ItemView.extend({
       tagName: 'span',
+      // Stub methods in contructor to ensure calls are counted from the moment the parent
+      // CollectionView instantiates it.
+      constructor: function(options) {
+        Marionette.ItemView.prototype.constructor.call(this, options);
+        this.onBeforeShow = spec.sinon.stub();
+        this.onShow = spec.sinon.stub();
+        this.onDomRefresh = spec.sinon.stub();
+      },
       render: function() {
         this.$el.html(this.model.get('foo'));
         this.trigger('render');
@@ -18,7 +28,14 @@ describe('collection view', function() {
       // The ItemView's destroy method tries to destroy the
       // RegionManager, which, from the above, does not exist.
       destroy: Marionette.AbstractView.prototype.destroy,
-      onRender: function() {}
+      onRender: function() {},
+      onBeforeShow: function() {},
+      onShow: function() {},
+      onDomRefresh: function() {},
+    });
+
+    this.CollectionView = Backbone.Marionette.CollectionView.extend({
+      childView: this.ChildView
     });
 
     this.MockCollectionView = Backbone.Marionette.CollectionView.extend({
@@ -974,22 +991,7 @@ describe('collection view', function() {
 
   describe('when a child view is added to a collection view, after the collection view has been shown', function() {
     beforeEach(function() {
-      this.ChildView = Backbone.Marionette.ItemView.extend({
-        onBeforeShow: function() {},
-        onShow: function() {},
-        onDomRefresh: function() {},
-        onRender: function() {},
-        template: _.template('<%= foo %>')
-      });
-
-      this.CollectionView = Backbone.Marionette.CollectionView.extend({
-        childView: this.ChildView,
-        onShow: function() {}
-      });
-
-      this.sinon.spy(this.ChildView.prototype, 'onBeforeShow');
-      this.sinon.spy(this.ChildView.prototype, 'onShow');
-      this.sinon.spy(this.ChildView.prototype, 'onDomRefresh');
+      this.setFixtures($('<div id="fixture-container"></div>'));
 
       this.model1 = new Backbone.Model({foo: 1});
       this.model2 = new Backbone.Model({foo: 2});
@@ -997,44 +999,41 @@ describe('collection view', function() {
       this.collectionView = new this.CollectionView({
         collection: this.collection
       });
-      $('body').append(this.collectionView.el);
+      $('#fixture-container').append(this.collectionView.el);
 
       this.collectionView.render();
-      this.collectionView.onShow();
       this.collectionView.trigger('show');
 
       this.sinon.spy(this.collectionView, 'attachBuffer');
       this.sinon.spy(this.collectionView, 'getChildView');
 
       this.collection.add(this.model2);
-      this.view = this.collectionView.children.findByIndex(1);
+      this.childView2 = this.collectionView.children.findByIndex(1);
     });
 
     it('should not use the render buffer', function() {
       expect(this.collectionView.attachBuffer).not.to.have.been.called;
     });
 
-    it('should call the "onBeforeShow" method of the child view', function() {
-      expect(this.ChildView.prototype.onBeforeShow).to.have.been.called;
+    it('should call onBeforeShow of the added child view', function() {
+      expect(this.childView2.onBeforeShow).to.have.been.calledOnce;
+      expect(this.childView2.onBeforeShow).to.have.been.calledOn(this.childView2);
+      expect(this.childView2.onBeforeShow).to.have.been.calledWith(this.childView2);
     });
 
-    it('should call the childs "onBeforeShow" method with itself as the context', function() {
-      expect(this.ChildView.prototype.onBeforeShow).to.have.been.calledOn(this.view);
+    it('should call onShow of the added child view', function() {
+      expect(this.childView2.onShow).to.have.been.calledOnce;
+      expect(this.childView2.onShow).to.have.been.calledOn(this.childView2);
+      expect(this.childView2.onShow).to.have.been.calledWith(this.childView2);
     });
 
-    it('should call the "onShow" method of the child view', function() {
-      expect(this.ChildView.prototype.onShow).to.have.been.called;
+    it('should call onDomRefresh of the added child view', function() {
+      expect(this.childView2.onDomRefresh).to.have.been.calledOnce;
+      expect(this.childView2.onDomRefresh).to.have.been.calledOn(this.childView2);
+      expect(this.childView2.onDomRefresh).to.have.been.calledWithExactly(); // no args
     });
 
-    it('should call the childs "onShow" method with itself as the context', function() {
-      expect(this.ChildView.prototype.onShow).to.have.been.calledOn(this.view);
-    });
-
-    it('should call the childs "onDomRefresh" method with itself as the context', function() {
-      expect(this.ChildView.prototype.onDomRefresh).to.have.been.called;
-    });
-
-    it('should call "getChildView" with the new model', function() {
+    it('should call getChildView with the new model', function() {
       expect(this.collectionView.getChildView).to.have.been.calledWith(this.model2);
     });
 
@@ -1323,6 +1322,40 @@ describe('collection view', function() {
 
     it('should return the child view for the model', function() {
       expect(this.childView.$el).to.contain.$text('bar');
+    });
+  });
+
+  describe('when a collection view has been rendered but not shown', function() {
+    beforeEach(function() {
+      this.collection = new Backbone.Collection([{foo: 1}, {foo: 2}]);
+      this.collectionView = new this.CollectionView({
+        collection: this.collection
+      });
+
+      this.collectionView.render();
+      this.collectionView.trigger('before:show');
+      this.collectionView.trigger('show');
+
+      this.childView1 = this.collectionView.children.findByIndex(0);
+      this.childView2 = this.collectionView.children.findByIndex(1);
+    });
+
+    it('onBeforeShow should propagate to each child view', function() {
+      expect(this.childView1.onBeforeShow).to.have.been.calledOnce;
+      expect(this.childView1.onBeforeShow).to.have.been.calledOn(this.childView1);
+      expect(this.childView1.onBeforeShow).to.have.been.calledWith(this.childView1);
+      expect(this.childView2.onBeforeShow).to.have.been.calledOnce;
+      expect(this.childView2.onBeforeShow).to.have.been.calledOn(this.childView2);
+      expect(this.childView2.onBeforeShow).to.have.been.calledWith(this.childView2);
+    });
+
+    it('onShow should propagate to each child view', function() {
+      expect(this.childView1.onShow).to.have.been.calledOnce;
+      expect(this.childView1.onShow).to.have.been.calledOn(this.childView1);
+      expect(this.childView1.onShow).to.have.been.calledWith(this.childView1);
+      expect(this.childView2.onShow).to.have.been.calledOnce;
+      expect(this.childView2.onShow).to.have.been.calledOn(this.childView2);
+      expect(this.childView2.onShow).to.have.been.calledWith(this.childView2);
     });
   });
 });


### PR DESCRIPTION
Fixes #2428, continuation of #2434.

Improvements:
* Relying on `Marionette.triggerMethodOn` directly, where convenient (removed _triggerMethodOnChild)
* Added call count, context, and parameter checks to spec.
* Spec no longer attaches to `<body>`, preferring to use a detached nodes and then `setFixtures()` when necessary
* Retro-improved earlier spec code surrounding `before:show` and `show` checks (when adding a new childView to an already shown collectionView).
* Fixed pre-existing issue #2462 where `onBeforeShow` and `onShow` are not called with the view argument in the same manner that `Region#show` calls them