### PR TITLE
Fix typo in marionette.module.md

### DIFF
--- a/docs/marionette.module.md
+++ b/docs/marionette.module.md
@@ -132,7 +132,7 @@ Sometimes a module definition can become quite long. You can split
 apart the definition by making subsequent calls to the `module`
 function.
 
-This can used to split the definition of your module
+This can be used to split the definition of your module
 across multiple files.
 
 ```js


### PR DESCRIPTION
Only made 1 typo fix:
1) Add missing word 'be' in marionette.module.md

No other changes were made.