### PR TITLE
Don't rerender the entire CompositeView on sorting

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -162,13 +162,11 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Render view after sorting. Override this method to
   // change how the view renders after a `sort` on the collection.
-  // An example of this would be to only `renderChildren` in a `CompositeView`
-  // rather than the full view.
   resortView: function() {
     if (Marionette.getOption(this, 'reorderOnSort')) {
       this.reorder();
     } else {
-      this.render();
+      this._renderChildren();
     }
   },
 


### PR DESCRIPTION
Replaces #2457 and #2411

@marionettejs/marionette-core this just needs eyes, should be good to go