### PR TITLE
Put Backbone.$.Deferred in a function to enable node dependency

### DIFF
--- a/lib/core/backbone.marionette.js
+++ b/lib/core/backbone.marionette.js
@@ -40,7 +40,9 @@
   };
 
   // Get the Deferred creator for later use
-  Marionette.Deferred = Backbone.$.Deferred;
+  Marionette.Deferred = function() {
+    return Backbone.$.Deferred();
+  };
 
   Marionette.FEATURES = {
   };


### PR DESCRIPTION
I had a problem using Marionette when i use it with `mochify`. I want that only one file require shared depencies like Backbone, jQuery but `mocha` seems to include the deeper nested module and when it come to Martionette it hasnt require `Backbone`, nether `Backbone.$.Deferred`.

cf https://github.com/marionettejs/backbone.marionette/issues/2397