### PR TITLE
bugfix region.reset can't set el in some case

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -263,12 +263,11 @@ Marionette.Region = Marionette.Object.extend({
   // clearing out the cached `$el`. The next time a view
   // is shown via this region, the region will re-query the
   // DOM for the region's `el`.
-  
   // When this.$el is Object and this.el is DOM selector string, it doesn't works,
   // because this.$el.selector contains parent's selector,
   // for example 
-  //   this.$el.selector = '#parent #child',
-  //   this.el = '#child', it will be override so that this.el can't be find in DOM...
+  // this.$el.selector = '#parent #child',
+  // this.el = '#child', it will be override so that this.el can't be find in DOM...
   reset: function() {
     this.empty();
 

--- a/src/region.js
+++ b/src/region.js
@@ -265,7 +265,7 @@ Marionette.Region = Marionette.Object.extend({
   // DOM for the region's `el`.
   // When this.$el is Object and this.el is DOM selector string, it doesn't works,
   // because this.$el.selector contains parent's selector,
-  // for example 
+  // for example:
   // this.$el.selector = '#parent #child',
   // this.el = '#child', it will be override so that this.el can't be find in DOM...
   reset: function() {

--- a/src/region.js
+++ b/src/region.js
@@ -263,10 +263,16 @@ Marionette.Region = Marionette.Object.extend({
   // clearing out the cached `$el`. The next time a view
   // is shown via this region, the region will re-query the
   // DOM for the region's `el`.
+  
+  // When this.$el is Object and this.el is DOM selector string, it doesn't works,
+  // because this.$el.selector contains parent's selector,
+  // for example 
+  //   this.$el.selector = '#parent #child',
+  //   this.el = '#child', it will be override so that this.el can't be find in DOM...
   reset: function() {
     this.empty();
 
-    if (this.$el) {
+    if (this.$el && _.isObject(this.el)) {
       this.el = this.$el.selector;
     }
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -310,7 +310,7 @@ describe('collection view', function() {
           foo: 'biz'
         }, {
           foo: 'baz'
-      }]);
+        }]);
       this.collection.comparator = function(model) {
         return model.get('foo');
       };


### PR DESCRIPTION
  // When this.$el is Object and this.el is DOM selector string, it doesn't works,
  // because this.$el.selector contains parent's selector,
  // for example 
  //   this.$el.selector = '#parent #child',
  //   this.el = '#child', it will be override so that this.el can't be find in DOM...