### PR TITLE
onBeforeAttach and onAttach for CollectionView child views (continued)

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -1,4 +1,4 @@
-/* jshint maxstatements: 14 */
+/* jshint maxstatements: 15 */
 
 // Collection View
 // ---------------
@@ -22,15 +22,17 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
   // option to pass `{comparator: compFunction()}` to allow the `CollectionView`
   // to use a custom sort order for the collection.
   constructor: function(options) {
-
     this.once('render', this._initialEvents);
     this._initChildViewStorage();
 
     Marionette.AbstractView.apply(this, arguments);
 
-    this.on('before:show', this._onBeforeShowCalled);
-    this.on('show', this._onShowCalled);
-
+    this.on({
+      'before:show':   this._onBeforeShowCalled,
+      'show':          this._onShowCalled,
+      'before:attach': this._onBeforeAttachCalled,
+      'attach':        this._onAttachCalled
+    });
     this.initRenderBuffer();
   },
 
@@ -47,24 +49,31 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
   },
 
   endBuffering: function() {
+    // Only trigger attach if already shown and attached, otherwise Region#show() handles this.
+    var canTriggerAttach = this._isShown && Marionette.isNodeAttached(this.el);
+    var nestedViews;
+
     this.isBuffering = false;
+
     if (this._isShown) {
-      this._triggerShowMultiple(this._bufferedChildren, 'before:');
+      Marionette.triggerMethodMany(this._bufferedChildren, this, 'before:show');
+    }
+    if (canTriggerAttach && this._triggerBeforeAttach) {
+      nestedViews = this._getNestedViews();
+      Marionette.triggerMethodMany(nestedViews, this, 'before:attach');
     }
 
     this.attachBuffer(this);
 
-    if (this._isShown) {
-      this._triggerShowMultiple(this._bufferedChildren);
+    if (canTriggerAttach && this._triggerAttach) {
+      nestedViews = this._getNestedViews();
+      Marionette.triggerMethodMany(nestedViews, this, 'attach');
     }
-    this.initRenderBuffer();
-  },
+    if (this._isShown) {
+      Marionette.triggerMethodMany(this._bufferedChildren, this, 'show');
+    }
 
-  _triggerShowMultiple: function(views, prefix) {
-    var eventName = (prefix || '') + 'show';
-    _.each(views, function(view) {
-      Marionette.triggerMethodOn(view, eventName, view);
-    }, this);
+    this.initRenderBuffer();
   },
 
   // Configured the initial events that the collection view
@@ -106,6 +115,9 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
   },
 
   _onBeforeShowCalled: function() {
+    // Reset attach event flags at the top of the Region#show() event lifecycle; if the Region's
+    // show() options permit onBeforeAttach/onAttach events, these flags will be set true again.
+    this._triggerBeforeAttach = this._triggerAttach = false;
     this.children.each(function(childView) {
       Marionette.triggerMethodOn(childView, 'before:show', childView);
     });
@@ -115,6 +127,16 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     this.children.each(function(childView) {
       Marionette.triggerMethodOn(childView, 'show', childView);
     });
+  },
+
+  // If during Region#show() onBeforeAttach was fired, continue firing it for child views
+  _onBeforeAttachCalled: function() {
+    this._triggerBeforeAttach = true;
+  },
+
+  // If during Region#show() onAttach was fired, continue firing it for child views
+  _onAttachCalled: function() {
+    this._triggerAttach = true;
   },
 
   // Render children views. Override this method to
@@ -264,13 +286,22 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     var EmptyView = this.getEmptyView();
 
     if (EmptyView && !this._showingEmptyView) {
-      this.triggerMethod('before:render:empty');
-
       this._showingEmptyView = true;
-      var model = new Backbone.Model();
-      this.addEmptyView(model, EmptyView);
 
-      this.triggerMethod('render:empty');
+      var model = new Backbone.Model();
+      var emptyViewOptions =
+        this.getOption('emptyViewOptions') || this.getOption('childViewOptions');
+      if (_.isFunction(emptyViewOptions)) {
+        emptyViewOptions = emptyViewOptions.call(this, model, this._emptyViewIndex);
+      }
+
+      var view = this.buildChildView(model, EmptyView, emptyViewOptions);
+
+      this.triggerMethod('before:render:empty', view);
+      this._addChildView(view, 0);
+      this.triggerMethod('render:empty', view);
+
+      view._parent = this;
     }
   },
 
@@ -293,54 +324,12 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     return this.getOption('emptyView');
   },
 
-  // Render and show the emptyView. Similar to addChild method
-  // but "add:child" events are not fired, and the event from
-  // emptyView are not forwarded
-  addEmptyView: function(child, EmptyView) {
-
-    // get the emptyViewOptions, falling back to childViewOptions
-    var emptyViewOptions = this.getOption('emptyViewOptions') ||
-                          this.getOption('childViewOptions');
-
-    if (_.isFunction(emptyViewOptions)) {
-      emptyViewOptions = emptyViewOptions.call(this, child, this._emptyViewIndex);
-    }
-
-    // build the empty view
-    var view = this.buildChildView(child, EmptyView, emptyViewOptions);
-
-    view._parent = this;
-
-    // Proxy emptyView events
-    this.proxyChildEvents(view);
-
-    // trigger the 'before:show' event on `view` if the collection view
-    // has already been shown
-    if (this._isShown) {
-      Marionette.triggerMethodOn(view, 'before:show', view);
-    }
-
-    // Store the `emptyView` like a `childView` so we can properly
-    // remove and/or close it later
-    this.children.add(view);
-
-    // Render it and show it
-    this.renderChildView(view, this._emptyViewIndex);
-
-    // call the 'show' method if the collection view
-    // has already been shown
-    if (this._isShown) {
-      Marionette.triggerMethodOn(view, 'show', view);
-    }
-  },
-
   // Retrieve the `childView` class, either from `this.options.childView`
   // or from the `childView` in the object definition. The "options"
   // takes precedence.
   // The `childView` property can be either a view class or a function that
   // returns a view class. If it is a function, it will receive the model that
   // will be passed to the view instance (created from the returned view class)
-
   _getChildView: function(child) {
     var childView = this.getOption('childView');
 
@@ -378,7 +367,9 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     // increment indices of views after this one
     this._updateIndices(view, true, index);
 
+    this.triggerMethod('before:add:child', view);
     this._addChildView(view, index);
+    this.triggerMethod('add:child', view);
 
     view._parent = this;
 
@@ -408,32 +399,41 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
   // Internal Method. Add the view to children and render it at
   // the given index.
   _addChildView: function(view, index) {
+    // Only trigger attach if already shown, attached, and not buffering, otherwise endBuffer() or
+    // Region#show() handles this.
+    var canTriggerAttach = this._isShown && !this.isBuffering && Marionette.isNodeAttached(this.el);
+    var triggerBeforeAttach = canTriggerAttach && this._triggerBeforeAttach;
+    var triggerAttach = canTriggerAttach && this._triggerAttach;
+
     // set up the child view event forwarding
     this.proxyChildEvents(view);
 
-    this.triggerMethod('before:add:child', view);
-
-    // trigger the 'before:show' event on `view` if the collection view
-    // has already been shown
+    // trigger the 'before:show' event on `view` if the collection view has already been shown
     if (this._isShown && !this.isBuffering) {
       Marionette.triggerMethodOn(view, 'before:show', view);
     }
 
-    // Store the child view itself so we can properly
-    // remove and/or destroy it later
+    // Store the child view itself so we can properly remove and/or destroy it later
     this.children.add(view);
-    this.renderChildView(view, index);
 
+    this._renderChildView(view, index, triggerBeforeAttach);
+
+    if (triggerAttach) {
+      var nestedViews = [view].concat(view._getNestedViews());
+      Marionette.triggerMethodMany(nestedViews, this, 'attach');
+    }
     if (this._isShown && !this.isBuffering) {
       Marionette.triggerMethodOn(view, 'show', view);
     }
-
-    this.triggerMethod('add:child', view);
   },
 
   // render the child view
-  renderChildView: function(view, index) {
+  _renderChildView: function(view, index, triggerBeforeAttach) {
     view.render();
+    if (triggerBeforeAttach) {
+      var nestedViews = [view].concat(view._getNestedViews());
+      Marionette.triggerMethodMany(nestedViews, this, 'before:attach');
+    }
     this.attachHtml(this, view, index);
     return view;
   },

--- a/test/unit/on-attach.spec.js
+++ b/test/unit/on-attach.spec.js
@@ -14,6 +14,28 @@ describe('onAttach', function() {
       onAttach: function() {},
       onBeforeAttach: function() {}
     });
+
+    var spec = this;
+    this.EmptyView = Marionette.View.extend({
+      template: false,
+      constructor: function(options) {
+        Marionette.View.prototype.constructor.call(this, options);
+        this.onAttach = spec.sinon.stub();
+        this.onBeforeAttach = spec.sinon.stub();
+      }
+    });
+    this.ChildView = Marionette.View.extend({
+      template: false,
+      constructor: function(options) {
+        Marionette.View.prototype.constructor.call(this, options);
+        this.onAttach = spec.sinon.stub();
+        this.onBeforeAttach = spec.sinon.stub();
+      }
+    });
+    this.BasicCollectionView = Marionette.CollectionView.extend({
+      childView: this.ChildView,
+      emptyView: this.EmptyView
+    });
   });
 
   describe('when showing a region that is not attached to the document', function() {
@@ -746,6 +768,212 @@ describe('onAttach', function() {
       it('should trigger onBeforeAttach & onAttach on the footerView a single time', function() {
         expect(this.footerView.onBeforeAttach).to.have.been.calledOnce;
         expect(this.footerView.onAttach).to.have.been.calledOnce;
+      });
+    });
+  });
+
+  describe('when showing an empty CollectionView', function() {
+    beforeEach(function() {
+      this.collection = new Backbone.Collection();
+      this.collectionView = new this.BasicCollectionView({
+        collection: this.collection
+      });
+      this.region.show(this.collectionView);
+      this.childView = this.collectionView.children.findByIndex(0);
+    });
+
+    it('should trigger onBeforeAttach and onAttach on the emptyView a single time', function() {
+      expect(this.childView).to.be.an.instanceof(this.EmptyView);
+      expect(this.childView.onBeforeAttach).to.have.been.calledOnce;
+      expect(this.childView.onBeforeAttach).to.have.been.calledOn(this.childView);
+      expect(this.childView.onBeforeAttach).to.have.been.calledWith(this.childView);
+      expect(this.childView.onAttach).to.have.been.calledOnce;
+      expect(this.childView.onAttach).to.have.been.calledOn(this.childView);
+      expect(this.childView.onAttach).to.have.been.calledWith(this.childView);
+    });
+
+    describe('when adding a new element to the collection', function() {
+      beforeEach(function() {
+        this.collection.add({id: 1});
+        this.childView = this.collectionView.children.findByIndex(0);
+      });
+      it('should trigger onBeforeAttach and onAttach on the childView a single time', function() {
+        expect(this.childView).to.be.an.instanceof(this.ChildView);
+        expect(this.childView.onBeforeAttach).to.have.been.calledOnce;
+        expect(this.childView.onBeforeAttach).to.have.been.calledOn(this.childView);
+        expect(this.childView.onBeforeAttach).to.have.been.calledWith(this.childView);
+        expect(this.childView.onAttach).to.have.been.calledOnce;
+        expect(this.childView.onAttach).to.have.been.calledOn(this.childView);
+        expect(this.childView.onAttach).to.have.been.calledWith(this.childView);
+      });
+    });
+  });
+
+  describe('when showing an empty CollectionView with triggerBeforeAttach and triggerAttach set to false on the region', function() {
+    beforeEach(function() {
+      this.collection = new Backbone.Collection();
+      this.collectionView = new this.BasicCollectionView({
+        collection: this.collection
+      });
+      this.region.triggerAttach = false;
+      this.region.triggerBeforeAttach = false;
+      this.region.show(this.collectionView);
+      this.childView = this.collectionView.children.findByIndex(0);
+    });
+
+    it('should not trigger onAttach or onBeforeAttach on the emptyView a single time', function() {
+      expect(this.childView).to.be.an.instanceof(this.EmptyView);
+      expect(this.childView.onBeforeAttach).to.not.have.been.calledOnce;
+      expect(this.childView.onBeforeAttach).to.not.have.been.calledOn(this.childView);
+      expect(this.childView.onBeforeAttach).to.not.have.been.calledWith(this.childView);
+      expect(this.childView.onAttach).to.not.have.been.calledOnce;
+      expect(this.childView.onAttach).to.not.have.been.calledOn(this.childView);
+      expect(this.childView.onAttach).to.not.have.been.calledWith(this.childView);
+    });
+
+    describe('when adding a new element to the collection', function() {
+      beforeEach(function() {
+        this.collection.add({id: 1});
+        this.childView = this.collectionView.children.findByIndex(0);
+      });
+      it('should not trigger onBeforeAttach or onAttach on the childView a single time', function() {
+        expect(this.childView).to.be.an.instanceof(this.ChildView);
+        expect(this.childView.onBeforeAttach).to.not.have.been.calledOnce;
+        expect(this.childView.onBeforeAttach).to.not.have.been.calledOn(this.childView);
+        expect(this.childView.onBeforeAttach).to.not.have.been.calledWith(this.childView);
+        expect(this.childView.onAttach).to.not.have.been.calledOnce;
+        expect(this.childView.onAttach).to.not.have.been.calledOn(this.childView);
+        expect(this.childView.onAttach).to.not.have.been.calledWith(this.childView);
+      });
+    });
+  });
+
+  describe('when showing a non-empty CollectionView', function() {
+    beforeEach(function() {
+      this.collection = new Backbone.Collection([{id: 1}, {id: 2}]);
+      this.collectionView = new this.BasicCollectionView({
+        collection: this.collection
+      });
+      this.region.show(this.collectionView);
+      this.childView1 = this.collectionView.children.findByIndex(0);
+      this.childView2 = this.collectionView.children.findByIndex(1);
+    });
+
+    it('should trigger onBeforeAttach and onAttach on each of its childViews a single time', function() {
+      expect(this.childView1.onBeforeAttach).to.have.been.calledOnce;
+      expect(this.childView1.onBeforeAttach).to.have.been.calledOn(this.childView1);
+      expect(this.childView1.onBeforeAttach).to.have.been.calledWith(this.childView1);
+      expect(this.childView1.onAttach).to.have.been.calledOnce;
+      expect(this.childView1.onAttach).to.have.been.calledOn(this.childView1);
+      expect(this.childView1.onAttach).to.have.been.calledWith(this.childView1);
+      expect(this.childView2.onBeforeAttach).to.have.been.calledOnce;
+      expect(this.childView2.onBeforeAttach).to.have.been.calledOn(this.childView2);
+      expect(this.childView2.onBeforeAttach).to.have.been.calledWith(this.childView2);
+      expect(this.childView2.onAttach).to.have.been.calledOnce;
+      expect(this.childView2.onAttach).to.have.been.calledOn(this.childView2);
+      expect(this.childView2.onAttach).to.have.been.calledWith(this.childView2);
+    });
+
+    describe('when re-rendering the CollectionView', function() {
+      beforeEach(function() {
+        this.collectionView.render();
+      });
+
+      it('should trigger onBeforeAttach and onAttach on each of its childViews a single time', function() {
+        expect(this.childView1.onBeforeAttach).to.have.been.calledOnce;
+        expect(this.childView1.onBeforeAttach).to.have.been.calledOn(this.childView1);
+        expect(this.childView1.onBeforeAttach).to.have.been.calledWith(this.childView1);
+        expect(this.childView1.onAttach).to.have.been.calledOnce;
+        expect(this.childView1.onAttach).to.have.been.calledOn(this.childView1);
+        expect(this.childView1.onAttach).to.have.been.calledWith(this.childView1);
+        expect(this.childView2.onBeforeAttach).to.have.been.calledOnce;
+        expect(this.childView2.onBeforeAttach).to.have.been.calledOn(this.childView2);
+        expect(this.childView2.onBeforeAttach).to.have.been.calledWith(this.childView2);
+        expect(this.childView2.onAttach).to.have.been.calledOnce;
+        expect(this.childView2.onAttach).to.have.been.calledOn(this.childView2);
+        expect(this.childView2.onAttach).to.have.been.calledWith(this.childView2);
+      });
+    });
+
+    describe('when emptying the collection', function() {
+      beforeEach(function() {
+        this.collection.reset();
+        this.childView = this.collectionView.children.findByIndex(0);
+      });
+      it('should trigger onBeforeAttach and onAttach on the emptyView a single time', function() {
+        expect(this.childView).to.be.an.instanceof(this.EmptyView);
+        expect(this.childView.onBeforeAttach).to.have.been.calledOnce;
+        expect(this.childView.onBeforeAttach).to.have.been.calledOn(this.childView);
+        expect(this.childView.onBeforeAttach).to.have.been.calledWith(this.childView);
+        expect(this.childView.onAttach).to.have.been.calledOnce;
+        expect(this.childView.onAttach).to.have.been.calledOn(this.childView);
+        expect(this.childView.onAttach).to.have.been.calledWith(this.childView);
+      });
+    });
+  });
+
+  describe('when showing a non-empty CollectionView with triggerBeforeAttach and triggerAttach set to false on the region', function() {
+    beforeEach(function() {
+      this.collection = new Backbone.Collection([{id: 1}, {id: 2}]);
+      this.collectionView = new this.BasicCollectionView({
+        collection: this.collection
+      });
+      this.region.triggerAttach = false;
+      this.region.triggerBeforeAttach = false;
+      this.region.show(this.collectionView);
+      this.childView1 = this.collectionView.children.findByIndex(0);
+      this.childView2 = this.collectionView.children.findByIndex(1);
+    });
+
+    it('should not trigger onBeforeAttach or onAttach on each of its childViews a single time', function() {
+      expect(this.childView1.onBeforeAttach).to.not.have.been.calledOnce;
+      expect(this.childView1.onBeforeAttach).to.not.have.been.calledOn(this.childView1);
+      expect(this.childView1.onBeforeAttach).to.not.have.been.calledWith(this.childView1);
+      expect(this.childView1.onAttach).to.not.have.been.calledOnce;
+      expect(this.childView1.onAttach).to.not.have.been.calledOn(this.childView1);
+      expect(this.childView1.onAttach).to.not.have.been.calledWith(this.childView1);
+      expect(this.childView2.onBeforeAttach).to.not.have.been.calledOnce;
+      expect(this.childView2.onBeforeAttach).to.not.have.been.calledOn(this.childView2);
+      expect(this.childView2.onBeforeAttach).to.not.have.been.calledWith(this.childView2);
+      expect(this.childView2.onAttach).to.not.have.been.calledOnce;
+      expect(this.childView2.onAttach).to.not.have.been.calledOn(this.childView2);
+      expect(this.childView2.onAttach).to.not.have.been.calledWith(this.childView2);
+    });
+
+    describe('when re-rendering the CollectionView', function() {
+      beforeEach(function() {
+        this.collectionView.render();
+      });
+
+      it('should not trigger onBeforeAttach or onAttach on each of its childViews a single time', function() {
+        expect(this.childView1.onBeforeAttach).to.not.have.been.calledOnce;
+        expect(this.childView1.onBeforeAttach).to.not.have.been.calledOn(this.childView1);
+        expect(this.childView1.onBeforeAttach).to.not.have.been.calledWith(this.childView1);
+        expect(this.childView1.onAttach).to.not.have.been.calledOnce;
+        expect(this.childView1.onAttach).to.not.have.been.calledOn(this.childView1);
+        expect(this.childView1.onAttach).to.not.have.been.calledWith(this.childView1);
+        expect(this.childView2.onBeforeAttach).to.not.have.been.calledOnce;
+        expect(this.childView2.onBeforeAttach).to.not.have.been.calledOn(this.childView2);
+        expect(this.childView2.onBeforeAttach).to.not.have.been.calledWith(this.childView2);
+        expect(this.childView2.onAttach).to.not.have.been.calledOnce;
+        expect(this.childView2.onAttach).to.not.have.been.calledOn(this.childView2);
+        expect(this.childView2.onAttach).to.not.have.been.calledWith(this.childView2);
+      });
+    });
+
+    describe('when emptying the collection', function() {
+      beforeEach(function() {
+        this.collection.reset();
+        this.childView = this.collectionView.children.findByIndex(0);
+      });
+      it('should not trigger onBeforeAttach or onAttach on the emptyView a single time', function() {
+        expect(this.childView).to.be.an.instanceof(this.EmptyView);
+        expect(this.childView.onBeforeAttach).to.not.have.been.calledOnce;
+        expect(this.childView.onBeforeAttach).to.not.have.been.calledOn(this.childView);
+        expect(this.childView.onBeforeAttach).to.not.have.been.calledWith(this.childView);
+        expect(this.childView.onAttach).to.not.have.been.calledOnce;
+        expect(this.childView.onAttach).to.not.have.been.calledOn(this.childView);
+        expect(this.childView.onAttach).to.not.have.been.calledWith(this.childView);
       });
     });
   });


### PR DESCRIPTION
Continuation of #2441, fixes #2209.

New feature of this PR:

- Solved how to pass down `Region#show()`'s `triggerBeforeAttach` and `triggerAttach` flags. 

Needs the following wrapup, probably 1-2 hours' work, will do in next day or so:

- [x] Make final call on `view.once('render'` to trigger `before:attach` within `_addChildView` and `addEmptyView`.  See https://github.com/marionettejs/backbone.marionette/pull/2441#discussion_r28120859.  @jasonLaster I wouldn't mind talking this one through more.
- [x] Additional specs (will bump coverage to 100%)
  * When collectionView is shown in a region with `triggerBeforeShow == false`
  * When collectionView is shown in a region with `triggerShow == false`
- [x] Implement @paulfalgout's suggestion for triggering `before:attach`
- [x] Final squash