### PR TITLE
Remove passing view options as a function

### DIFF
--- a/src/abstract-view.js
+++ b/src/abstract-view.js
@@ -13,8 +13,6 @@ Marionette.AbstractView = Backbone.View.extend({
   constructor: function(options) {
     _.bindAll(this, 'render');
 
-    options = Marionette._getValue(options, this);
-
     // this exposes view options to the view initializer
     // this is a backfill since backbone removed the assignment
     // of this.options

--- a/test/unit/abstract-view.spec.js
+++ b/test/unit/abstract-view.spec.js
@@ -174,7 +174,6 @@ describe('base view', function() {
       this.options = {foo: 'bar'};
 
       this.presetsStub = this.sinon.stub().returns(this.presets);
-      this.optionsStub = this.sinon.stub().returns(this.options);
 
       this.View = Marionette.AbstractView.extend();
       this.ViewPresets   = Marionette.AbstractView.extend({options: this.presets});
@@ -183,11 +182,6 @@ describe('base view', function() {
 
     it('should take and store view options', function() {
       this.view = new this.View(this.options);
-      expect(this.view.options).to.deep.equal(this.options);
-    });
-
-    it('should take and store view options as a function', function() {
-      this.view = new this.View(this.optionsStub);
       expect(this.view.options).to.deep.equal(this.options);
     });
 
@@ -216,16 +210,6 @@ describe('base view', function() {
         }
       });
       this.myView = new this.MyView();
-      expect(this.myView.className).to.equal('.some-class');
-    });
-
-    it('should attach the viewOptions to the view if options are passed as a function', function() {
-      var options = function() {
-        return {
-          className: '.some-class'
-        };
-      };
-      this.myView = new Marionette.AbstractView(options);
       expect(this.myView.className).to.equal('.some-class');
     });
   });


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2229

Essentially Marionette.Views allow you to pass in options as a function like:
```js
var optionsFunc = function(){
  return {
    foo: 'bar'
  };
};
var myView = new Marionette.View(optionsFunc);
```

For one thing it is inconsistent with option handling on anything that is not a view: https://github.com/marionettejs/backbone.marionette/blob/master/src/object.js#L7

And another thing.. it is really pretty pointless and probably promotes bad patterns.

Also it was a largely [broken](https://github.com/marionettejs/backbone.marionette/issues/2242) "feature" for most of its existence.

