### PR TITLE
Reset region when destroying

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -282,6 +282,13 @@ Marionette.Region = Marionette.Object.extend({
 
     delete this.$el;
     return this;
+  },
+
+  // Handle cleanup and other destroying needs for the region
+  destroy: function() {
+    this.reset();
+
+    return Marionette.Object.prototype.destroy.apply(this, arguments);
   }
 
 },

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -995,6 +995,29 @@ describe('region', function() {
     });
   });
 
+  describe('when destroying a region', function() {
+    beforeEach(function() {
+      this.setFixtures('<div id="region"></div>');
+
+      this.region = new Backbone.Marionette.Region({
+        el: '#region'
+      });
+
+      this.sinon.spy(this.region, 'reset');
+
+      this.sinon.spy(this.region, 'destroy');
+      this.region.destroy();
+    });
+
+    it('should reset the region', function() {
+      expect(this.region.reset).to.have.been.called;
+    });
+
+    it('should return the region', function() {
+      expect(this.region.destroy).to.have.returned(this.region);
+    });
+  });
+
   describe('when destroying a view in a region', function() {
     beforeEach(function() {
       this.setFixtures('<div id="region"></div>');


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2379

This makes sense.  I think it was just an oversight when making `Region` extend `Object` as previous to that you could not `destroy` a `Region`