### PR TITLE
noop triggerMethod when view/behavior/object destroyed

### DIFF
--- a/src/abstract-view.js
+++ b/src/abstract-view.js
@@ -167,6 +167,8 @@ Marionette.AbstractView = Backbone.View.extend({
     this.isDestroyed = true;
     this.triggerMethod.apply(this, ['destroy'].concat(args));
 
+    this.triggerMethod = function() {};
+
     // unbind UI elements
     this.unbindUIElements();
 

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -38,6 +38,7 @@ Marionette.Behavior = Marionette.Object.extend({
   // Stops the behavior from listening to events.
   // Overrides Object#destroy to prevent additional events from being triggered.
   destroy: function() {
+    this.triggerMethod = function() {};
     this.stopListening();
 
     return this;

--- a/src/object.js
+++ b/src/object.js
@@ -24,6 +24,8 @@ _.extend(Marionette.Object.prototype, Backbone.Events, {
     this.triggerMethod('before:destroy');
     this.triggerMethod('destroy');
     Marionette.unproxyRadioHandlers.apply(this);
+
+    this.triggerMethod = function() {};
     this.stopListening();
 
     return this;


### PR DESCRIPTION
Possibly resolves https://github.com/marionettejs/backbone.marionette/issues/2501

This was somewhat of an experiment, but swapping `triggerMethod` to be a noop on destroys prevents it from being an async problem.  I don't know if there is a way to safely entirely replace `Backbone.Events.trigger` but in my book this would make the use-case for `trigger` pretty slim compared to `triggerMethod`

Issues?  There is one failing test, but it is testing that behavior can call `triggerMethod` on its view after it has been destroyed.  @jasonLaster is that an important feature, it seems counter-intuitive to what `view.destroy` should be doing.