### PR TITLE
Remove new keyword in front of childEvents example

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -239,7 +239,7 @@ This also works for custom events that you might fire on your child views.
 
 ```js
 // The child view fires a custom event, `show:message`
-var ChildView = new Marionette.ItemView.extend({
+var ChildView = Marionette.ItemView.extend({
   events: {
     'click .button': 'showMessage'
   },
@@ -252,7 +252,7 @@ var ChildView = new Marionette.ItemView.extend({
 });
 
 // The parent uses childEvents to catch that custom event on the child view
-var ParentView = new Marionette.CollectionView.extend({
+var ParentView = Marionette.CollectionView.extend({
   childView: ChildView,
 
   childEvents: {


### PR DESCRIPTION
The example doesn't work with the 'new' keyword. Removing the 'new' keyword allows the instances of the ChildView and ParentView to be created.

No other changes were made.