### PR TITLE
Fix inconsistency between addRegion & addRegions

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -22,7 +22,7 @@ Marionette.View = Marionette.AbstractView.extend({
     this._firstRender = true;
     this._initializeRegions(options);
 
-    this.regions = {};
+    this.regions = this.regions || {};
 
     Marionette.AbstractView.apply(this, arguments);
   },

--- a/src/view.js
+++ b/src/view.js
@@ -135,10 +135,14 @@ Marionette.View = Marionette.AbstractView.extend({
   },
 
   // Add multiple regions as a {name: definition, name2: def2} object literal or
-  // a function evaluation to such literal
-  addRegions: function(regions, defaults) {
+  // a function that evaluates to such literal
+  addRegions: function(regions) {
+    return this._addRegions(regions, arguments);
+  },
+
+  _addRegions: function(regions, parameters) {
     // Enable regions to be a function
-    regions = Marionette._getValue(regions, this, arguments);
+    regions = Marionette._getValue(regions, this, parameters);
 
     // Normalize region selectors hash to allow
     // a user to use the @ui. syntax.
@@ -201,8 +205,8 @@ Marionette.View = Marionette.AbstractView.extend({
   _initializeRegions: function(options) {
     this._initRegionManager();
 
-    this.addRegions(this.regions);
-    this.addRegions(this.getOption.call(options, 'regions'));
+    this._addRegions(this.regions, [options]);
+    this._addRegions(this.getOption.call(options, 'regions'), [options]);
   },
 
   // internal method to build regions

--- a/src/view.js
+++ b/src/view.js
@@ -129,7 +129,7 @@ Marionette.View = Marionette.AbstractView.extend({
   addRegion: function(name, definition) {
     var regions = {};
     regions[name] = definition;
-    return this._buildRegions(regions)[name];
+    return this.addRegions(regions)[name];
   },
 
   // Add multiple regions as a {name: definition, name2: def2} object literal

--- a/test/unit/view.dynamic-regions.spec.js
+++ b/test/unit/view.dynamic-regions.spec.js
@@ -53,7 +53,6 @@ describe('itemView - dynamic regions', function() {
     });
 
     it('adds the regions definitions to the regions property', function(){
-      console.log(this.view.regions);
       expect(this.view.regions.fooRegion).to.equal(this.fooSelector);
       expect(this.view.regions.barRegion).to.deep.equal({
         selector: this.barSelector, regionClass: this.BarRegion

--- a/test/unit/view.dynamic-regions.spec.js
+++ b/test/unit/view.dynamic-regions.spec.js
@@ -52,7 +52,7 @@ describe('itemView - dynamic regions', function() {
       expect(this.view.getRegion('barRegion').el).to.deep.equal(this.barRegion.el);
     });
 
-    it('adds the regions definitions to the regions property', function(){
+    it('adds the regions definitions to the regions property', function() {
       expect(this.view.regions.fooRegion).to.equal(this.fooSelector);
       expect(this.view.regions.barRegion).to.deep.equal({
         selector: this.barSelector, regionClass: this.BarRegion

--- a/test/unit/view.dynamic-regions.spec.js
+++ b/test/unit/view.dynamic-regions.spec.js
@@ -52,6 +52,14 @@ describe('itemView - dynamic regions', function() {
       expect(this.view.getRegion('barRegion').el).to.deep.equal(this.barRegion.el);
     });
 
+    it('adds the regions definitions to the regions property', function(){
+      console.log(this.view.regions);
+      expect(this.view.regions.fooRegion).to.equal(this.fooSelector);
+      expect(this.view.regions.barRegion).to.deep.equal({
+        selector: this.barSelector, regionClass: this.BarRegion
+      });
+    });
+
     it('uses the custom regionClass', function() {
       expect(this.view.getRegion('barRegion')).to.be.an.instanceof(this.BarRegion);
     });
@@ -85,6 +93,10 @@ describe('itemView - dynamic regions', function() {
 
     it('should add the region to the layoutView', function() {
       expect(this.layoutView.foo).to.equal(this.region);
+    });
+
+    it('should add the region definition to the regions property', function() {
+      expect(this.layoutView.regions.foo).to.equal('#foo');
     });
 
     it('should set the parent of the region to the layoutView', function() {


### PR DESCRIPTION
`addRegion` now behaves like `addRegions` and adds the new region to internal `this.regions`.