### PR TITLE
Fix dependencies and build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,8 +26,8 @@ module.exports = function(grunt) {
         ' * Includes BabySitter\n' +
         ' * https://github.com/marionettejs/backbone.babysitter/\n' +
         ' *\n' +
-        ' * Includes Wreqr\n' +
-        ' * https://github.com/marionettejs/backbone.wreqr/\n' +
+        ' * Includes Radio\n' +
+        ' * https://github.com/marionettejs/backbone.radio/\n' +
         ' */\n\n\n'
     },
 
@@ -247,9 +247,9 @@ module.exports = function(grunt) {
         src: './node_modules/backbone.babysitter/lib/backbone.babysitter.js',
         dest: './tmp/backbone.babysitter.bare.js'
       },
-      wreqr: {
-        src: './node_modules/backbone.wreqr/lib/backbone.wreqr.js',
-        dest: './tmp/backbone.wreqr.bare.js'
+      radio: {
+        src: './node_modules/backbone.radio/build/backbone.radio.js',
+        dest: './tmp/backbone.radio.bare.js'
       }
     }
   });

--- a/bower.json
+++ b/bower.json
@@ -37,6 +37,7 @@
     "backbone": "1.0.0 - 1.1.2",
     "underscore": "1.4.4 - 1.6.0",
     "backbone.babysitter": "^0.1.0",
+    "backbone.radio": "^0.9.0",
     "jquery": "^1.8.0 || ^2.0.0"
   }
 }

--- a/component.json
+++ b/component.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "marionettejs/backbone.babysitter": "*",
-    "marionettejs/backbone.wreqr": "*",
+    "marionettejs/backbone.radio": "*",
     "jashkenas/backbone": "*",
     "jashkenas/underscore": "*"
   },

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ We're happy to discuss design patterns and learn how you're using Marionette.
 * Compose your application's visuals at runtime, with the `Region` and `LayoutView` objects
 * Nested views and layouts within visual regions
 * Built-in memory management and zombie-killing in views, regions and layoutViews
-* Event-driven architecture with `Backbone.Wreqr.EventAggregator`
+* Event-driven architecture with `Backbone.Radio`
 * Flexible, "as-needed" architecture allowing you to pick and choose what you need
 * And much, much more
 
@@ -83,7 +83,7 @@ We're happy to discuss design patterns and learn how you're using Marionette.
 + **Explore** application with an inspector magnifying glass
 + **Jump** between the inspector elements and source panel with intelligent links
 
-Download at [Chrome Web Store](https://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka)  
+Download at [Chrome Web Store](https://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka)
 Explore code at  [Github](https://github.com/marionettejs/marionette.inspector)
 
 ## Source Code and Downloads
@@ -123,7 +123,7 @@ MarionetteJS currently works with the following libraries:
 * [jQuery](http://jquery.com) v1.8+
 * [Underscore](http://underscorejs.org) v1.4.4 - 1.6.0
 * [Backbone](http://backbonejs.org) v1.0.0 - 1.1.2 are preferred.
-* [Backbone.Wreqr](https://github.com/marionettejs/backbone.wreqr) Comes automatically with the bundled build.
+* [Backbone.Radio](https://github.com/marionettejs/backbone.radio) Comes automatically with the bundled build.
 * [Backbone.BabySitter](https://github.com/marionettejs/backbone.babysitter) Comes automatically with the bundled build.
 
 Marionette has not been tested against any other versions of these

--- a/src/application.js
+++ b/src/application.js
@@ -8,16 +8,6 @@ Marionette.Application = Marionette.Object.extend({
     Marionette.Object.call(this, options);
   },
 
-  // Command execution, facilitated by Backbone.Wreqr.Commands
-  execute: function() {
-    this.commands.execute.apply(this.commands, arguments);
-  },
-
-  // Request/response, facilitated by Backbone.Wreqr.RequestResponse
-  request: function() {
-    return this.reqres.request.apply(this.reqres, arguments);
-  },
-
   // kick off all of the application's processes.
   // initializes all of the regions that have been added
   // to the app, and runs all of the initializer functions

--- a/src/build/bundled.js
+++ b/src/build/bundled.js
@@ -19,6 +19,9 @@
   /* istanbul ignore next */
   // @include ../../tmp/backbone.babysitter.bare.js
 
+  /* istanbul ignore next */
+  // @include ../../tmp/backbone.radio.bare.js
+
   var previousMarionette = root.Marionette;
   var previousMn = root.Mn;
 
@@ -32,8 +35,7 @@
     return this;
   };
 
-  Backbone.Marionette = Marionette;
-
+  // @include ../features.js
   // @include ../helpers.js
   // @include ../trigger-method.js
   // @include ../dom-refresh.js
@@ -42,7 +44,6 @@
 
   // @include ../error.js
   // @include ../object.js
-  // @include ../controller.js
   // @include ../region.js
   // @include ../region-manager.js
 

--- a/src/build/core.js
+++ b/src/build/core.js
@@ -40,7 +40,6 @@
 
   // @include ../error.js
   // @include ../object.js
-  // @include ../controller.js
   // @include ../region.js
   // @include ../region-manager.js
 


### PR DESCRIPTION
This is a portion of the fixes from https://github.com/marionettejs/backbone.marionette/pull/2485 applied to the bundle.

Currently `next` does not build.  This is because the build files have not been maintained well.
Also Radio was not added to the bundled file, but wreqr was still attempting to be "unwrapped" breaking the build.

I removed the rest of the wreqr related issues and updated them to radio.

So for what is currently in `next` this fixes the build and dependencies so `next` is in a releasable state.  