### PR TITLE
Remove redundant return statement

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -132,8 +132,6 @@ Marionette.Region = Marionette.Object.extend({
 
       this.triggerMethod('show', view, this, options);
       Marionette.triggerMethodOn(view, 'show', view, this, options);
-
-      return this;
     }
 
     return this;


### PR DESCRIPTION
Remove redundant `return` in region's `show` method.