### PR TITLE
Change show render event ordering

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -89,8 +89,6 @@ Marionette.Region = Marionette.Object.extend({
       // we can not reuse it.
       view.once('destroy', this.empty, this);
 
-      this.renderView(view, options);
-
       view._parent = this;
 
       if (isChangingView) {
@@ -99,6 +97,8 @@ Marionette.Region = Marionette.Object.extend({
 
       this.triggerMethod('before:show', view, this, options);
       Marionette.triggerMethodOn(view, 'before:show', view, this, options);
+
+      this.renderView(view, options);
 
       if (isChangingView) {
         this.triggerMethod('swapOut', this.currentView, this, options);

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -257,8 +257,8 @@ describe('region', function() {
     });
 
     describe('Render and show event ordering', function() {
-      it('triggers the before render event before the before show event', function() {
-        expect(this.viewOnBeforeRenderSpy).to.have.been.calledBefore(this.viewOnBeforeShowSpy);
+      it('triggers the before render event after the before show event', function() {
+        expect(this.viewOnBeforeShowSpy).to.have.been.calledBefore(this.viewOnBeforeRenderSpy);
       });
 
       it('triggers the show event after the render event', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -122,18 +122,17 @@ describe('region', function() {
         onSwapOut: function() {}
       });
 
-      this.MyView = Backbone.View.extend({
+      this.MyView = Marionette.View.extend({
         events: {
           'click': function() {}
         },
-        render: function() {
-          $(this.el).html('some content');
-        },
+        template: _.template('some content'),
         destroy: function() {},
         onBeforeShow: function() {},
         onShow: function() {
           $(this.el).addClass('onShowClass');
-        }
+        },
+        onBeforeRender: function() {},
       });
 
       this.setFixtures('<div id="region"></div>');
@@ -147,9 +146,11 @@ describe('region', function() {
       this.regionBeforeEmptySpy = this.sinon.spy();
 
       this.view = new this.MyView();
+      this.viewOnBeforeRenderSpy = this.sinon.spy(this.view, 'onBeforeRender');
       this.viewRenderSpy = this.sinon.spy(this.view, 'render');
       this.viewOnBeforeShowSpy = this.sinon.spy(this.view, 'onBeforeShow');
       this.viewOnShowSpy = this.sinon.spy(this.view, 'onShow');
+      this.triggerSpy = this.sinon.spy(this.view, 'trigger');
 
       this.myRegion = new this.MyRegion();
       this.regionOnBeforeShowSpy = this.sinon.spy(this.myRegion, 'onBeforeShow');
@@ -253,6 +254,16 @@ describe('region', function() {
 
     it('should pass the shown view, region and options arguments to the view "onBeforeShow"', function() {
       expect(this.viewOnBeforeShowSpy).to.have.been.calledWith(this.view, this.myRegion, this.showOptions);
+    });
+
+    describe('Render and show event ordering', function() {
+      it('triggers the before render event before the before show event', function() {
+        expect(this.viewOnBeforeRenderSpy).to.have.been.calledBefore(this.viewOnBeforeShowSpy);
+      });
+
+      it('triggers the show event after the render event', function() {
+        expect(this.viewRenderSpy).to.have.been.calledBefore(this.viewOnShowSpy);
+      });
     });
 
     it('should trigger a show event for the view', function() {


### PR DESCRIPTION
This is the change I originally proposed, making before:show actually being the first thing to happen when showing a view.

This fails a bunch of tests (I'm sure travis will show the exact ones) related to showing subviews in the `onBeforeShow` hook. Obviously this doesn't work anymore with this change.

What does everyone think of this change, and if it is good, what should I do about those tests?