### PR TITLE
Typo on Behavior docs page fixed

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -224,7 +224,7 @@ Marionette.Behavior.extend({
 ```
 
 ### Grouped Behaviors
-Then `behaviors` key allows a `Behavior` to group multiple behaviors together.
+The `behaviors` key allows a `Behavior` to group multiple behaviors together.
 
 ```js
   Marionette.Behavior.extend({


### PR DESCRIPTION
Fixed a small typo on the documentation page about `Marionette.Behavior`