### PR TITLE
Update children view._index when reordering

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -146,8 +146,10 @@ Marionette.CollectionView = Marionette.View.extend({
       this.render();
     } else {
       // get the DOM nodes in the same order as the models
-      var els = _.map(models, function(model) {
-        return children.findByModel(model).el;
+      var els = _.map(models, function(model, index) {
+        var childView = children.findByModel(model);
+        childView._index = index;
+        return childView.el;
       });
 
       // since append moves elements that are already in the DOM,


### PR DESCRIPTION
Without this change, the CollectionView will not react upon moving a child view back immediately after it was reordered.

Example: when creating a view for collection [a, b], the views will have indexes [va.0, vb.1]. If we switch the order to [b, a], the views will retain their indexes while changing their position, i.e. [vb.1, va.0]. (The view is correctly reordered.) If we then switch the order again to [a, b], the test in _sortViews() will think that the order has not changed, and the views will remain in positions [vb, va]. 

(Depending on the situation, a call to _updateIndices() might fix this.)