### PR TITLE
Added options parameter to showChildView()

### DIFF
--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -75,17 +75,17 @@ Once you've rendered the layoutView, you now have direct access
 to all of the specified regions as region managers.
 
 ```js
-layoutView.getRegion('menu').show(new MenuView());
+layoutView.getRegion('menu').show(new MenuView(), options);
 
-layoutView.getRegion('content').show(new MainContentView());
+layoutView.getRegion('content').show(new MainContentView(), options);
 ```
 
 There are also helpful shortcuts for more concise syntax.
 
 ```js
-layoutView.showChildView('menu', new MenuView());
+layoutView.showChildView('menu', new MenuView(), options);
 
-layoutView.showChildView('content', new MainContentView());
+layoutView.showChildView('content', new MainContentView(), options);
 ```
 
 ### Region Options
@@ -294,7 +294,7 @@ var layoutView = new Marionette.LayoutView({
 });
 
 // Lastly, show the LayoutView in the App's mainRegion
-MyApp.rootView.getRegion('main').show(layoutView);
+MyApp.rootView.getRegion('main').show(layoutView, options);
 ```
 
 You can nest LayoutViews as deeply as you want. This provides for a well organized,
@@ -307,7 +307,7 @@ var layout1 = new Layout1();
 var layout2 = new Layout2();
 var layout3 = new Layout3();
 
-MyApp.rootView.getRegion('main').show(layout1);
+MyApp.rootView.getRegion('main').show(layout1, options);
 
 layout1.showChildView('region1', layout2);
 layout2.showChildView('region2', layout3);
@@ -327,7 +327,7 @@ var ParentLayout = Marionette.LayoutView.extend({
   }
 });
 
-myRegion.show(new ParentLayout());
+myRegion.show(new ParentLayout(), options);
 ```
 
 In this example, the doubly-nested view structure will be rendered in a single paint.
@@ -432,7 +432,7 @@ var layoutView = new MyLayoutView();
 // ...
 
 layoutView.addRegion("foo", "#foo");
-layoutView.getRegion('foo').show(new someView());
+layoutView.getRegion('foo').show(new someView(), options);
 ```
 
 addRegions:

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -229,11 +229,13 @@ and `empty` methods to display and shut-down a view:
 var myView = new MyView();
 
 // render and display the view
-MyApp.mainRegion.show(myView);
+MyApp.mainRegion.show(myView, options);
 
 // empties the current view
 MyApp.mainRegion.empty();
 ```
+
+The `options` object is optional. If provided, it will be passed to the [events raised during `show`](#events-raised-during-show) (except for `before:empty` and `empty`). Special properties that change the behavior of `show` include `preventDestroy` and `forceShow`.
 
 #### preventDestroy
 
@@ -504,10 +506,9 @@ MyApp.mainRegion.on("swapOut", function(view, region, options){
   // you also have access to the `options` that were passed to the Region.show call
 });
 
-MyApp.mainRegion.on("empty", function(view, region, options){
+MyApp.mainRegion.on("empty", function(view, region){
   // manipulate the `view` or do something extra
   // with the `region`
-  // you also have access to the `options` that were passed to the Region.show call
 });
 
 var MyRegion = Marionette.Region.extend({
@@ -613,7 +614,7 @@ var SomeRegion = Marionette.Region.extend({
 
 MyApp.someRegion = new SomeRegion();
 
-MyApp.someRegion.show(someView);
+MyApp.someRegion.show(someView, options);
 ```
 
 You can optionally add an `initialize` function to your Region

--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -46,7 +46,7 @@ var regions = rm.addRegions({
   quux: "ul.quux"
 });
 
-regions.get('baz').show(myView);
+regions.get('baz').show(myView, options);
 
 rm.removeRegion("foo");
 ```
@@ -62,7 +62,7 @@ var mananger = new Marionette.RegionManager({
   }
 });
 
-mananger.get('aRegion').show(new MyView);
+mananger.get('aRegion').show(new MyView, options);
 ```
 
 ## RegionManager.addRegion

--- a/src/view.js
+++ b/src/view.js
@@ -160,8 +160,9 @@ Marionette.View = Marionette.AbstractView.extend({
     return this.regionManager.removeRegion(name);
   },
 
-  showChildView: function(regionName, view) {
-    return this.getRegion(regionName).show(view);
+  showChildView: function(regionName, view, options) {
+    var region = this.getRegion(regionName);
+    return region.show.apply(region, _.rest(arguments));
   },
 
   getChildView: function(regionName) {

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -301,6 +301,23 @@ describe('layoutView', function() {
     });
   });
 
+  describe('when using showChildView with options', function() {
+    var options = {myOption: 'some value'};
+
+    beforeEach(function() {
+      this.layoutView = new this.View().render();
+      this.childView = new Backbone.View();
+      this.sinon.spy(this.layoutView.regionOne, 'show');
+      this.layoutView.showChildView('regionOne', this.childView, options);
+    });
+
+    it('passes the options hash to the region', function() {
+      expect(this.layoutView.regionOne.show)
+        .to.have.been.calledOnce
+        .and.calledWith(this.childView, options);
+    });
+  });
+
   describe('when showing a layoutView via a region', function() {
     beforeEach(function() {
       var suite = this;


### PR DESCRIPTION
Fixes #2572.

> ... `showChildView` does not take an `options` hash.

This PR changes `showChildView(view)` to `showChildView(view, options)` to provide consistency with `Marionette.Region.show(view, options)`.

I'm new to writing unit tests, so please let me know if the unit test needs adjusting.