### PR TITLE
Fix underscore compatibility version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ You can read the annotations for all the details of how Marionette works, and ad
 MarionetteJS currently works with the following libraries:
 
 * [jQuery](http://jquery.com) v1.8+
-* [Underscore](http://underscorejs.org) v1.4.4 - 1.6.0
+* [Underscore](http://underscorejs.org) v1.4.4 - 1.8.3
 * [Backbone](http://backbonejs.org) v1.0.0 - 1.1.2 are preferred.
 * [Backbone.Wreqr](https://github.com/marionettejs/backbone.wreqr) Comes automatically with the bundled build.
 * [Backbone.BabySitter](https://github.com/marionettejs/backbone.babysitter) Comes automatically with the bundled build.


### PR DESCRIPTION
In Marionette 2.4.2 the underscore dependency was bumped to be compatible with up to 1.8.3, but the readme file did not get updated.