### PR TITLE
Added 'reverse' option for CollectionView and CompositeView that displays items in reverse order.

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -543,7 +543,7 @@ Marionette.CollectionView = Marionette.View.extend({
     var elBuffer = document.createDocumentFragment();
     if (this.getOption('reverse')) {
       _.each(this._bufferedChildren, function(b) {
-        elBuffer.prependChild(b.el);
+        elBuffer.insertBefore(b.el, elBuffer.firstChild);
       });
     } else {
       _.each(this._bufferedChildren, function(b) {

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -541,9 +541,15 @@ Marionette.CollectionView = Marionette.View.extend({
   // Create a fragment buffer from the currently buffered children
   _createBuffer: function() {
     var elBuffer = document.createDocumentFragment();
-    _.each(this._bufferedChildren, function(b) {
-      elBuffer.appendChild(b.el);
-    });
+    if (this.getOption('reverse')) {
+      _.each(this._bufferedChildren, function(b) {
+        elBuffer.prependChild(b.el);
+      });
+    } else {
+      _.each(this._bufferedChildren, function(b) {
+        elBuffer.appendChild(b.el);
+      });
+    }
     return elBuffer;
   },
 
@@ -588,7 +594,11 @@ Marionette.CollectionView = Marionette.View.extend({
 
   // Internal method. Append a view to the end of the $el
   _insertAfter: function(childView) {
-    this.$el.append(childView.el);
+    if (this.getOption('reverse')) {
+      this.$el.prepend(childView.el);
+    } else {
+      this.$el.append(childView.el);
+    }
   },
 
   // Internal method to set up the `children` object for

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -131,7 +131,11 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // childViewContainer
   _insertAfter: function(childView) {
     var $container = this.getChildViewContainer(this, childView);
-    $container.append(childView.el);
+    if (this.getOption('reverse')) {
+      $container.prepend(childView.el);
+    } else {
+      $container.append(childView.el);
+    }
   },
 
   // Internal method. Append reordered childView'.


### PR DESCRIPTION
This patch adds a 'reverse' option for CollectionView's and CompositeView's that displays items in reverse order.

The reasoning behind this is that a reverse ordering is a special case and that filter 
sorting items in Backbone.Collection's into reverse order can take too much time to do leading to a noticeable delay in displaying views.

The patch has been tested.