### PR TITLE
Simplify Travis Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - "0.12"
-  - "0.11"
-  - "0.10"
 env:
   global: MAINRUN=true
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,25 @@ sudo: false
 language: node_js
 node_js:
   - "0.12"
-env:
-  global: MAINRUN=true
-  matrix:
-    - UNDERSCORE=1.4.4 BACKBONE=1.0
-    - UNDERSCORE=1.5 BACKBONE=1.0
-    - UNDERSCORE=1.7 BACKBONE=1.1
-    - UNDERSCORE=1.7 BACKBONE=1.0
-    - UNDERSCORE=1.6 BACKBONE=1.0
-    - UNDERSCORE=1.4.4 BACKBONE=1.1.0
-    - UNDERSCORE=1.5 BACKBONE=1.1
-    - UNDERSCORE=1.7 BACKBONE=1.2
-    - UNDERSCORE=1.8 BACKBONE=1.2
-    - LODASH=2.4 BACKBONE=1.1
-    - LODASH=3.0 BACKBONE=1.1
-    - LODASH=3.1 BACKBONE=1.0
+matrix:
+  include:
+    - node_js: "0.10"
+      env: UNDERSCORE=1.4.4 BACKBONE=1.0
+    - node_js: "io.js"
+      env: UNDERSCORE=1.5 BACKBONE=1.0
+    - env: UNDERSCORE=1.7 BACKBONE=1.1
+    - env: UNDERSCORE=1.7 BACKBONE=1.0
+    - env: UNDERSCORE=1.6 BACKBONE=1.0
+    - env: UNDERSCORE=1.4.4 BACKBONE=1.1.0
+    - env: UNDERSCORE=1.5 BACKBONE=1.1
+    - env: UNDERSCORE=1.7 BACKBONE=1.2
+    - node_js: "0.10"
+      env: UNDERSCORE=1.8 BACKBONE=1.2
+    - env: LODASH=2.4 BACKBONE=1.1
+    - env: LODASH=3.0 BACKBONE=1.1
+    - node_js: "io.js"
+      env: LODASH=3.1 BACKBONE=1.0
+env: MAINRUN=true
 before_install:
   - npm config set ca ""
 install:


### PR DESCRIPTION
Fixes #2609 

There doesn't seem to be any reason to run travis on multiple versions of node as `Marionette` runs primarily on the browser. Currently we're running **36** different travis VMs per commit. This brings it down to **12**.