### PR TITLE
fixes Issue #2615 by making sure all arguments are passed through Mar…

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -11,7 +11,7 @@ Marionette.Application = Marionette.Object.extend({
     this.submodules = {};
     _.extend(this, options);
     this._initChannel();
-    Marionette.Object.call(this, options);
+    Marionette.Object.apply(this, arguments);
   },
 
   // Command execution, facilitated by Backbone.Wreqr.Commands

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -5,7 +5,7 @@ describe('marionette application', function() {
     beforeEach(function() {
       this.fooOptions = {foo: 'bar'};
       this.appOptions = {baz: 'tah'};
-      this.extraArg = 'qux'
+      this.extraArg = 'qux';
       this.initializeStub = this.sinon.stub(Marionette.Application.prototype, 'initialize');
       this.app = new Marionette.Application(this.appOptions, this.extraArg);
 

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -5,8 +5,9 @@ describe('marionette application', function() {
     beforeEach(function() {
       this.fooOptions = {foo: 'bar'};
       this.appOptions = {baz: 'tah'};
+      this.extraArg = 'qux'
       this.initializeStub = this.sinon.stub(Marionette.Application.prototype, 'initialize');
-      this.app = new Marionette.Application(this.appOptions);
+      this.app = new Marionette.Application(this.appOptions, this.extraArg);
 
       this.triggerSpy = this.sinon.spy(this.app, 'trigger');
       this.initializerStub = this.sinon.stub();
@@ -15,8 +16,8 @@ describe('marionette application', function() {
       this.app.start(this.fooOptions);
     });
 
-    it('should call initialize', function() {
-      expect(this.initializeStub).to.have.been.calledOn(this.app).and.calledWith(this.appOptions);
+    it('should call initialize with all arguments it is initialized with', function() {
+      expect(this.initializeStub).to.have.been.calledOn(this.app).and.calledWith(this.appOptions, this.extraArg);
     });
 
     it('should notify me before the starts', function() {


### PR DESCRIPTION
Fixes #2615 

Uses `apply` instead of `call` inside Marionette.Application's constructor to make sure all arguments are passed up the chain to Marionette.Object, and thus to the `initialize()` method.