### PR TITLE
Allow a user to define trigger handlers in options.

### DIFF
--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -22,7 +22,7 @@ Marionette._triggerMethod = (function() {
 
     // get the method name from the event name
     var methodName = 'on' + event.replace(splitter, getEventName);
-    var method = context[methodName];
+    var method = Marionette.getOption(context, methodName);
     var result;
 
     // call the onMethodName if it exists

--- a/test/unit/trigger-method.spec.js
+++ b/test/unit/trigger-method.spec.js
@@ -13,6 +13,17 @@ describe('trigger event and method name', function() {
     this.triggerMethodSpy = this.sinon.spy(this.view, 'triggerMethod');
   });
 
+  describe('triggering an event when passed options', function() {
+    beforeEach(function() {
+      this.view.options.onFoo = this.methodHandler;
+      this.view.triggerMethod('foo');
+    });
+
+    it('should trigger the event', function() {
+      expect(this.methodHandler).to.have.been.calledOnce;
+    });
+  });
+
   describe('when triggering an event', function() {
     beforeEach(function() {
       this.view.onFoo = this.methodHandler;


### PR DESCRIPTION
For example

```js
new myView({
  onRender: function(){}
})
```

As compared to prior to this a user having to define these methods on
the actual prototype chain such as

```js
var MyView = Mn.ItemView.extend({
  onRender: function(){}
})
```