### PR TITLE
Region.empty doesn't fail to destroy view when called with any options

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -217,7 +217,7 @@ Marionette.Region = Marionette.Object.extend({
   empty: function(options) {
     var view = this.currentView;
 
-    var preventDestroy = Marionette._getValue(options, 'preventDestroy', this);
+    var preventDestroy = options && options.preventDestroy;
     // If there is no view in the region
     // we should not remove anything
     if (!view) { return; }


### PR DESCRIPTION
This is a simple pull request to fix #2611 