### PR TITLE
Fix bug in metal configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "backbone.babysitter": "^0.1.0",
     "backbone.radio": "^0.9.0",
     "backbone": "1.0.0 - 1.2.1",
-    "backbone-metal": "^0.5.0",
+    "backbone-metal": "^0.6.0",
     "underscore": "1.4.4 - 1.8.3"
   },
   "devDependencies": {

--- a/src/metal.js
+++ b/src/metal.js
@@ -4,11 +4,12 @@
 
 Marionette.Class = Metal.Class.extend({});
 
+var props = _.keys(Metal.Class.prototype);
 function classify(obj) {
   return Marionette.Class.extend(
     _.extend(
       {constructor: obj},
-      _.omit(obj.prototype, _.keys(Metal.Class.prototype))
+      _.omit(obj.prototype, props)
     )
   );
 }

--- a/src/metal.js
+++ b/src/metal.js
@@ -8,7 +8,7 @@ function classify(obj) {
   return Marionette.Class.extend(
     _.extend(
       {constructor: obj},
-      _.omit(obj.prototype, _.keys(Marionette.Class.prototype))
+      _.omit(obj.prototype, _.keys(Metal.Class.prototype))
     )
   );
 }

--- a/src/metal.js
+++ b/src/metal.js
@@ -4,12 +4,12 @@
 
 Marionette.Class = Metal.Class.extend({});
 
-var props = _.keys(Metal.Class.prototype);
 function classify(obj) {
   return Marionette.Class.extend(
-    _.extend(
+    _.defaults(
       {constructor: obj},
-      _.omit(obj.prototype, props)
+      Metal.Class.prototype,
+      obj.prototype
     )
   );
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -9,6 +9,7 @@
     "_"                  : true,
     "Backbone"           : true,
     "Marionette"         : true,
+    "Metal"              : true,
     "slice"              : true,
 
     "jasmine"            : true,

--- a/test/unit/metal.spec.js
+++ b/test/unit/metal.spec.js
@@ -24,4 +24,18 @@ describe('metal', function() {
       expect(new Marionette.View()).to.be.instanceof(Backbone.Metal.Class);
     });
   });
+
+  describe('The Metal implementation', function() {
+    _.each(['Model', 'Collection', 'Router', 'History'], function(klass) {
+      var Klass = Marionette[klass];
+      describe('should be used for ' + klass, function() {
+        _.each(Metal.Class.prototype, function(method, name) {
+          it('for method ' + name, function() {
+            expect(Klass.prototype[name]).to.be.equal(method);
+          });
+        });
+      });
+    });
+
+  });
 });


### PR DESCRIPTION
I was looking over some of the changes and I'm pretty sure this is a mistake (/cc @thejameskyle) as `Marionnette.Class.prototype` will have no keys (as a result of calling `Metal.Class.extend()`)