### PR TITLE
fix for #2615 ensuring all arguments from a Mn.Application instantiat…

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -7,7 +7,7 @@ Marionette.Application = Marionette.Object.extend({
 
   constructor: function(options) {
     _.extend(this, options);
-    Marionette.Object.call(this, options);
+    Marionette.Object.apply(this, arguments);
   },
 
   // kick off all of the application's processes.

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -4,11 +4,17 @@ describe('marionette application', function() {
   describe('when instantiating an app with options specified', function() {
     beforeEach(function() {
       this.fooOption = 'bar';
-      this.app = new Marionette.Application({fooOption: this.fooOption});
+      this.appOptions = {fooOption: this.fooOption};
+      this.initializeStub = this.sinon.stub(Marionette.Application.prototype, 'initialize');
+      this.app = new Marionette.Application(this.appOptions, 'fooArg');
     });
 
     it('should merge those options into the app', function() {
       expect(this.app.fooOption).to.equal(this.fooOption);
+    });
+
+    it('should pass all arguments to the initialize method', function() {
+      expect(this.initializeStub).to.have.been.calledOn(this.app).and.calledWith(this.appOptions, 'fooArg');
     });
   });
 


### PR DESCRIPTION
Fix for #2616 

Ensuring all arguments are passed from Mn.Application instantiation to its .initialize().