### PR TITLE
Fix region.empty({preventDestroy: false}) bug

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -207,7 +207,8 @@ Marionette.Region = Marionette.Object.extend({
   empty: function(options) {
     var view = this.currentView;
 
-    var preventDestroy = Marionette._getValue(options, 'preventDestroy', this);
+    var emptyOptions = options || {};
+    var preventDestroy  = !!emptyOptions.preventDestroy;
     // If there is no view in the region
     // we should not remove anything
     if (!view) { return; }

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -679,7 +679,7 @@ describe('region', function() {
     });
   });
 
-  describe('when preventing destroy on empty', function() {
+  describe('when passing "preventDestroy" option to empty', function() {
     beforeEach(function() {
       this.MyRegion = Backbone.Marionette.Region.extend({
         el: '#region'
@@ -698,15 +698,28 @@ describe('region', function() {
       this.view = new this.MyView();
       this.sinon.spy(this.view, 'destroy');
       this.myRegion.show(this.view);
-      this.myRegion.empty({preventDestroy: true});
     });
 
-    it('should not destroy view', function() {
-      expect(this.view.destroy).to.have.been.not.called;
+    describe('preventDestroy: true', function() {
+      beforeEach(function() {
+        this.myRegion.empty({preventDestroy: true});
+      });
+      it('should not destroy view', function() {
+        expect(this.view.destroy).to.have.been.not.called;
+      });
+
+      it('should clear region contents', function() {
+        expect(this.myRegion.$el.html()).to.eql('');
+      });
     });
 
-    it('should clear region contents', function() {
-      expect(this.myRegion.$el.html()).to.eql('');
+    describe('preventDestroy: false', function() {
+      beforeEach(function() {
+        this.myRegion.empty({preventDestroy: false});
+      });
+      it('should destroy view', function() {
+        expect(this.view.destroy).to.have.been.called;
+      });
     });
   });
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -679,7 +679,7 @@ describe('region', function() {
     });
   });
 
-  describe('when passing "preventDestroy" option to empty', function() {
+  describe('when passing options to empty', function() {
     beforeEach(function() {
       this.MyRegion = Backbone.Marionette.Region.extend({
         el: '#region'
@@ -716,6 +716,14 @@ describe('region', function() {
     describe('preventDestroy: false', function() {
       beforeEach(function() {
         this.myRegion.empty({preventDestroy: false});
+      });
+      it('should destroy view', function() {
+        expect(this.view.destroy).to.have.been.called;
+      });
+    });
+    describe('preventDestroy undefined', function() {
+      beforeEach(function() {
+        this.myRegion.empty({});
       });
       it('should destroy view', function() {
         expect(this.view.destroy).to.have.been.called;


### PR DESCRIPTION
I'm submitting a new pull request for this against the patch branch, as directed in #2613.  Fixes #2611.