### PR TITLE
Order CollectionView children events to accurately model Region#show

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -352,25 +352,22 @@ Marionette.CollectionView = Marionette.View.extend({
     // Proxy emptyView events
     this.proxyChildEvents(view);
 
-    // trigger the 'before:show' event on `view` if the collection view has already been shown
-    if (this._isShown) {
-      Marionette.triggerMethodOn(view, 'before:show', view);
-    }
+    view.once('render', function() {
+      // trigger the 'before:show' event on `view` if the collection view has already been shown
+      if (this._isShown) {
+        Marionette.triggerMethodOn(view, 'before:show', view);
+      }
 
-    // Store the `emptyView` like a `childView` so we can properly
-    // remove and/or close it later
-    this.children.add(view);
-
-    // Trigger `before:attach` following `render` to avoid adding logic and event triggers
-    // to public method `renderChildView()`.
-    if (canTriggerAttach && this._triggerBeforeAttach) {
-      nestedViews = this._getViewAndNested(view);
-      view.once('render', function() {
+      // Trigger `before:attach` following `render` to avoid adding logic and event triggers
+      // to public method `renderChildView()`.
+      if (canTriggerAttach && this._triggerBeforeAttach) {
+        nestedViews = this._getViewAndNested(view);
         this._triggerMethodMany(nestedViews, this, 'before:attach');
-      }, this);
-    }
+      }
+    }, this);
 
-    // Render it and show it
+    // Store the `emptyView` like a `childView` so we can properly remove and/or close it later
+    this.children.add(view);
     this.renderChildView(view, this._emptyViewIndex);
 
     // Trigger `attach`
@@ -456,23 +453,22 @@ Marionette.CollectionView = Marionette.View.extend({
     // set up the child view event forwarding
     this.proxyChildEvents(view);
 
-    // trigger the 'before:show' event on `view` if the collection view has already been shown
-    if (this._isShown && !this.isBuffering) {
-      Marionette.triggerMethodOn(view, 'before:show', view);
-    }
+    view.once('render', function() {
+      // trigger the 'before:show' event on `view` if the collection view has already been shown
+      if (this._isShown && !this.isBuffering) {
+        Marionette.triggerMethodOn(view, 'before:show', view);
+      }
+
+      // Trigger `before:attach` following `render` to avoid adding logic and event triggers
+      // to public method `renderChildView()`.
+      if (canTriggerAttach && this._triggerBeforeAttach) {
+        nestedViews = this._getViewAndNested(view);
+        this._triggerMethodMany(nestedViews, this, 'before:attach');
+      }
+    }, this);
 
     // Store the child view itself so we can properly remove and/or destroy it later
     this.children.add(view);
-
-    // Trigger `before:attach` following `render` to avoid adding logic and event triggers
-    // to public method `renderChildView()`.
-    if (canTriggerAttach && this._triggerBeforeAttach) {
-      nestedViews = this._getViewAndNested(view);
-      view.once('render', function() {
-        this._triggerMethodMany(nestedViews, this, 'before:attach');
-      }, this);
-    }
-
     this.renderChildView(view, index);
 
     // Trigger `attach`

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -1000,8 +1000,11 @@ describe('collection view', function() {
       var ChildView = this.ChildView.extend({
         constructor: function() {
           ChildView.__super__.constructor.apply(this, arguments);
+          spec.sinon.stub(this, 'onRender');
           spec.sinon.stub(this, 'onBeforeShow');
           spec.sinon.stub(this, 'onShow');
+          spec.sinon.stub(this, 'onBeforeAttach');
+          spec.sinon.stub(this, 'onAttach');
           spec.sinon.stub(this, 'onDomRefresh');
         },
         onRender: function() {},
@@ -1049,6 +1052,29 @@ describe('collection view', function() {
         .and.to.have.been.calledWith(this.childView2);
     });
 
+    it('should call Region#show-like events on the initial child views in proper order', function() {
+      expect(this.childView1.onRender).to.have.been.calledBefore(this.childView1.onBeforeShow);
+      expect(this.childView1.onBeforeShow).to.have.been.calledBefore(this.childView1.onBeforeAttach);
+      expect(this.childView1.onBeforeAttach).to.have.been.calledBefore(this.childView1.onAttach);
+      expect(this.childView1.onAttach).to.have.been.calledBefore(this.childView1.onShow);
+      expect(this.childView1.onShow).to.have.been.called;
+    });
+
+    describe('when collection view is emptied', function() {
+      beforeEach(function() {
+        this.collection.reset();
+        this.emptyView = this.collectionView.children.findByIndex(0);
+      });
+
+      it('should call Region#show-like events on the empty view in proper order', function() {
+        expect(this.emptyView.onRender).to.have.been.calledBefore(this.emptyView.onBeforeShow);
+        expect(this.emptyView.onBeforeShow).to.have.been.calledBefore(this.emptyView.onBeforeAttach);
+        expect(this.emptyView.onBeforeAttach).to.have.been.calledBefore(this.emptyView.onAttach);
+        expect(this.emptyView.onAttach).to.have.been.calledBefore(this.emptyView.onShow);
+        expect(this.emptyView.onShow).to.have.been.called;
+      });
+    });
+
     describe('when a child view is added to a collection view, after the collection view has been shown', function() {
       beforeEach(function() {
         this.sinon.spy(this.collectionView, 'attachBuffer');
@@ -1085,6 +1111,14 @@ describe('collection view', function() {
 
       it('should call getChildView with the new model', function() {
         expect(this.collectionView.getChildView).to.have.been.calledWith(this.model3);
+      });
+
+      it('should call Region#show-like events on the added child view in proper order', function() {
+        expect(this.childView3.onRender).to.have.been.calledBefore(this.childView3.onBeforeShow);
+        expect(this.childView3.onBeforeShow).to.have.been.calledBefore(this.childView3.onBeforeAttach);
+        expect(this.childView3.onBeforeAttach).to.have.been.calledBefore(this.childView3.onAttach);
+        expect(this.childView3.onAttach).to.have.been.calledBefore(this.childView3.onShow);
+        expect(this.childView3.onShow).to.have.been.called;
       });
     });
 


### PR DESCRIPTION
Fixes #2633.

While I was in the CollectionView spec, I was able to clean up a bit.  For some reason, the workaround to keep Sinon from exploding on deep equals assertions is not needed, and therefore neither is DeepEqualCollectionView.  It could be that code was only necessary on `next` but came over as part of the retrofit cherry-pick.  Let me know if "cleanup" during a bug fix is best practice or if tidying should go into a separate PR.