### PR TITLE
fixes #2578

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -90,6 +90,7 @@ Marionette.CollectionView = Marionette.View.extend({
       this.listenTo(this.collection, 'add', this._onCollectionAdd);
       this.listenTo(this.collection, 'remove', this._onCollectionRemove);
       this.listenTo(this.collection, 'reset', this.render);
+      this.listenTo(this.collection, 'update', this._onCollectionUpdate);
 
       if (this.getOption('sort')) {
         this.listenTo(this.collection, 'sort', this._sortViews);
@@ -97,11 +98,24 @@ Marionette.CollectionView = Marionette.View.extend({
     }
   },
 
+  // Handle a Backbone.Collection#add method finished (called once after a
+  // number of sequential _onCollectionAdd calls)
+  _onCollectionUpdate: function() {
+    this._atIndex = null;
+  },
+
   // Handle a child added to the collection
   _onCollectionAdd: function(child, collection, opts) {
     var index;
     if (opts.at !== undefined) {
-      index = opts.at;
+      if (this._atIndex) {
+        // correct child index if a number of models added to collection at once
+        this._atIndex += 1;
+        index = this._atIndex;
+      } else {
+        index = opts.at;
+        this._atIndex = index;
+      }
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);
     }

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -100,8 +100,8 @@ Marionette.CollectionView = Marionette.View.extend({
   // Handle a child added to the collection
   _onCollectionAdd: function(child, collection, opts) {
     var index;
-    if (opts.index !== undefined && !this.getOption('filter')) {
-      index = opts.index;
+    if ((opts.index !== undefined || opts.at) && !this.getOption('filter')) {
+      index = opts.index || opts.at;
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);
     }

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -101,7 +101,7 @@ Marionette.CollectionView = Marionette.View.extend({
   _onCollectionAdd: function(child, collection, opts) {
     var index;
     if (opts.at !== undefined && !this.getOption('filter')) {
-      index = opts.index || opts.at;
+      index = opts.index || _.indexOf(this._filteredSortedModels(), child);
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);
     }

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -100,7 +100,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // Handle a child added to the collection
   _onCollectionAdd: function(child, collection, opts) {
     var index;
-    if ((opts.index !== undefined || opts.at) && !this.getOption('filter')) {
+    if (opts.at !== undefined && !this.getOption('filter')) {
       index = opts.index || opts.at;
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -100,8 +100,8 @@ Marionette.CollectionView = Marionette.View.extend({
   // Handle a child added to the collection
   _onCollectionAdd: function(child, collection, opts) {
     var index;
-    if (opts.at !== undefined) {
-      index = opts.index !== undefined ? opts.index : collection.indexOf(child);
+    if (opts.index !== undefined && !this._isFilteredOrOrdered()) {
+      index = opts.index;
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);
     }
@@ -259,6 +259,10 @@ Marionette.CollectionView = Marionette.View.extend({
       ChildView = this.getChildView(child);
       this.addChild(child, ChildView, index);
     }, this);
+  },
+
+  _isFilteredOrOrdered: function() {
+    return !!(this.getViewComparator() || this.getOption('filter'));
   },
 
   // Allow the collection to be sorted by a custom view comparator

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -90,7 +90,6 @@ Marionette.CollectionView = Marionette.View.extend({
       this.listenTo(this.collection, 'add', this._onCollectionAdd);
       this.listenTo(this.collection, 'remove', this._onCollectionRemove);
       this.listenTo(this.collection, 'reset', this.render);
-      this.listenTo(this.collection, 'update', this._onCollectionUpdate);
 
       if (this.getOption('sort')) {
         this.listenTo(this.collection, 'sort', this._sortViews);
@@ -98,24 +97,11 @@ Marionette.CollectionView = Marionette.View.extend({
     }
   },
 
-  // Handle a Backbone.Collection#add method finished (called once after a
-  // number of sequential _onCollectionAdd calls)
-  _onCollectionUpdate: function() {
-    this._atIndex = null;
-  },
-
   // Handle a child added to the collection
   _onCollectionAdd: function(child, collection, opts) {
     var index;
     if (opts.at !== undefined) {
-      if (this._atIndex) {
-        // correct child index if a number of models added to collection at once
-        this._atIndex += 1;
-        index = this._atIndex;
-      } else {
-        index = opts.at;
-        this._atIndex = index;
-      }
+      index = opts.index || opts.at;
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);
     }

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -101,7 +101,13 @@ Marionette.CollectionView = Marionette.View.extend({
   _onCollectionAdd: function(child, collection, opts) {
     var index;
     if (opts.at !== undefined && !this.getOption('filter')) {
-      index = opts.index || _.indexOf(this._filteredSortedModels(), child);
+      index = opts.index;
+      if (!index) {
+        // ignore sorting with at options specified
+        index = this.getViewComparator() ?
+                collection.indexOf(child) :
+                _.indexOf(this._filteredSortedModels(), child);
+      }
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);
     }

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -101,7 +101,7 @@ Marionette.CollectionView = Marionette.View.extend({
   _onCollectionAdd: function(child, collection, opts) {
     var index;
     if (opts.at !== undefined) {
-      index = opts.index || opts.at;
+      index = opts.index !== undefined ? opts.index : collection.indexOf(child);
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);
     }

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -100,7 +100,7 @@ Marionette.CollectionView = Marionette.View.extend({
   // Handle a child added to the collection
   _onCollectionAdd: function(child, collection, opts) {
     var index;
-    if (opts.index !== undefined && !this._isFilteredOrOrdered()) {
+    if (opts.index !== undefined && !this.getOption('filter')) {
       index = opts.index;
     } else {
       index = _.indexOf(this._filteredSortedModels(), child);
@@ -259,10 +259,6 @@ Marionette.CollectionView = Marionette.View.extend({
       ChildView = this.getChildView(child);
       this.addChild(child, ChildView, index);
     }, this);
-  },
-
-  _isFilteredOrOrdered: function() {
-    return !!(this.getViewComparator() || this.getOption('filter'));
   },
 
   // Allow the collection to be sorted by a custom view comparator

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -469,8 +469,8 @@ describe('collection view', function() {
 
   describe('when a number of models are added to a non-empty collection with an "at" option', function() {
     beforeEach(function() {
-      this.model1 = new Backbone.Model({foo: '1'});
-      this.model2 = new Backbone.Model({foo: '6'});
+      this.model1 = new Backbone.Model({foo: 1});
+      this.model2 = new Backbone.Model({foo: 6});
       this.collection = new Backbone.Collection([this.model1, this.model2]);
 
       this.collectionView = new this.CollectionView({
@@ -478,18 +478,32 @@ describe('collection view', function() {
       });
       this.collectionView.render();
 
-      this.model3 = new Backbone.Model({foo: '2'});
-      this.model4 = new Backbone.Model({foo: '5'});
+      this.model3 = new Backbone.Model({foo: 2});
+      this.model4 = new Backbone.Model({foo: 5});
       this.collection.add([this.model3, this.model4], {at: 1});
 
-      this.model5 = new Backbone.Model({foo: '3'});
-      this.model6 = new Backbone.Model({foo: '4'});
+      this.model5 = new Backbone.Model({foo: 3});
+      this.model6 = new Backbone.Model({foo: 4});
       this.collection.add([this.model5, this.model6], {at: 2});
     });
 
     it('should add models and render views in right order', function() {
       var order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');
       expect(order).to.deep.equal(['1', '2', '3', '4', '5', '6']);
+    });
+
+    it('should add models and render views in right order for filtered collection', function() {
+      this.collectionView.filter = function(child) {
+        return child.get('foo') > 4;
+      };
+      this.collectionView.render();
+      this.collection.add([new Backbone.Model({foo: 10})], {at: 1});
+      var order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');
+      expect(order).to.deep.equal(['5', '10', '6']);
+      this.collectionView.filter = null;
+      this.collectionView.render();
+      order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');
+      expect(order).to.deep.equal(['1', '10', '2', '3', '4', '5', '6']);
     });
   });
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -467,6 +467,34 @@ describe('collection view', function() {
     });
   });
 
+  describe('when a number of models are added to a non-empty collection with an "at" option', function() {
+    beforeEach(function() {
+      this.model1 = new Backbone.Model({foo: '1'});
+      this.model2 = new Backbone.Model({foo: '2'});
+      this.collection = new Backbone.Collection([this.model1, this.model2]);
+
+      this.collectionView = new this.DeepEqualCollectionView({
+        childView: this.ChildView,
+        collection: this.collection
+      });
+      this.collectionView.render();
+
+      this.childViewRender = this.sinon.stub();
+      this.collectionView.on('childview:render', this.childViewRender);
+
+      this.sinon.spy(this.collectionView, 'attachHtml');
+
+      this.model3 = new Backbone.Model({foo: '3'});
+      this.model4 = new Backbone.Model({foo: '4'});
+      this.collection.add([this.model3, this.model4], {at: 1});
+    });
+
+    it('should add models and render views in right order', function() {
+      var order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');
+      expect(order).to.deep.equal(['1', '3', '4', '2']);
+    });
+  });
+
   describe('when providing a custom render that adds children, without a collection object to use, and removing a child', function() {
     beforeEach(function() {
       var suite = this;

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -489,14 +489,7 @@ describe('collection view', function() {
 
     it('should add models and render views in right order', function() {
       var order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');
-      var backboneVersion = _.map(Backbone.VERSION.split('.'), function(x) {
-        return parseInt(x);
-      });
-      if (backboneVersion[0] >= 1 && backboneVersion[1] >= 2) {
-        expect(order).to.deep.equal(['1', '2', '3', '4', '5', '6']);
-      } else {
-        expect(order).to.deep.equal(['1', '5', '4', '3', '2', '6']);
-      }
+      expect(order).to.deep.equal(['1', '2', '3', '4', '5', '6']);
     });
   });
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -489,7 +489,14 @@ describe('collection view', function() {
 
     it('should add models and render views in right order', function() {
       var order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');
-      expect(order).to.deep.equal(['1', '3', '5', '6', '4', '2']);
+      var backboneVersion = _.map(Backbone.VERSION.split('.'), function(x) {
+        return parseInt(x);
+      });
+      if (backboneVersion[0] >= 1 && backboneVersion[1] >= 2) {
+        expect(order).to.deep.equal(['1', '3', '5', '6', '4', '2']);
+      } else {
+        expect(order).to.deep.equal(['1', '4', '6', '5', '3', '2']);
+      }
     });
   });
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -499,7 +499,7 @@ describe('collection view', function() {
       this.collectionView.render();
       this.collection.add([new Backbone.Model({foo: 10})], {at: 1});
       var order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');
-      expect(order).to.deep.equal(['5', '10', '6']);
+      expect(order).to.deep.equal(['10', '5', '6']);
       this.collectionView.filter = null;
       this.collectionView.render();
       order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -470,7 +470,7 @@ describe('collection view', function() {
   describe('when a number of models are added to a non-empty collection with an "at" option', function() {
     beforeEach(function() {
       this.model1 = new Backbone.Model({foo: '1'});
-      this.model2 = new Backbone.Model({foo: '2'});
+      this.model2 = new Backbone.Model({foo: '6'});
       this.collection = new Backbone.Collection([this.model1, this.model2]);
 
       this.collectionView = new this.CollectionView({
@@ -478,12 +478,12 @@ describe('collection view', function() {
       });
       this.collectionView.render();
 
-      this.model3 = new Backbone.Model({foo: '3'});
-      this.model4 = new Backbone.Model({foo: '4'});
+      this.model3 = new Backbone.Model({foo: '2'});
+      this.model4 = new Backbone.Model({foo: '5'});
       this.collection.add([this.model3, this.model4], {at: 1});
 
-      this.model5 = new Backbone.Model({foo: '5'});
-      this.model6 = new Backbone.Model({foo: '6'});
+      this.model5 = new Backbone.Model({foo: '3'});
+      this.model6 = new Backbone.Model({foo: '4'});
       this.collection.add([this.model5, this.model6], {at: 2});
     });
 
@@ -493,9 +493,9 @@ describe('collection view', function() {
         return parseInt(x);
       });
       if (backboneVersion[0] >= 1 && backboneVersion[1] >= 2) {
-        expect(order).to.deep.equal(['1', '3', '5', '6', '4', '2']);
+        expect(order).to.deep.equal(['1', '2', '3', '4', '5', '6']);
       } else {
-        expect(order).to.deep.equal(['1', '4', '6', '5', '3', '2']);
+        expect(order).to.deep.equal(['1', '5', '4', '3', '2', '6']);
       }
     });
   });

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -473,25 +473,23 @@ describe('collection view', function() {
       this.model2 = new Backbone.Model({foo: '2'});
       this.collection = new Backbone.Collection([this.model1, this.model2]);
 
-      this.collectionView = new this.DeepEqualCollectionView({
-        childView: this.ChildView,
+      this.collectionView = new this.CollectionView({
         collection: this.collection
       });
       this.collectionView.render();
 
-      this.childViewRender = this.sinon.stub();
-      this.collectionView.on('childview:render', this.childViewRender);
-
-      this.sinon.spy(this.collectionView, 'attachHtml');
-
       this.model3 = new Backbone.Model({foo: '3'});
       this.model4 = new Backbone.Model({foo: '4'});
       this.collection.add([this.model3, this.model4], {at: 1});
+
+      this.model5 = new Backbone.Model({foo: '5'});
+      this.model6 = new Backbone.Model({foo: '6'});
+      this.collection.add([this.model5, this.model6], {at: 2});
     });
 
     it('should add models and render views in right order', function() {
       var order = _.pluck(this.collectionView.$el.find('span'), 'innerHTML');
-      expect(order).to.deep.equal(['1', '3', '4', '2']);
+      expect(order).to.deep.equal(['1', '3', '5', '6', '4', '2']);
     });
   });
 


### PR DESCRIPTION
actually, when `Backbone.Collection#add ` method called with a bunch of models, backbone triggers `add` event sequentially for each model, so where are no way to determine inside the `_onCollectionAdd` event handler whether one or many models are added. But backbone triggers `update` event after a number of `add` events, once per `Backbone.Collection#add` call. So I decide to add a "private" `_atIndex` flag to indicate this situation. I've add `_onCollectionUpdate` handler to reset this flag after one or more models have been added.