### PR TITLE
Remove unused triggerMethod optimization

### DIFF
--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -33,11 +33,7 @@ Marionette._triggerMethod = (function() {
 
     // trigger the event, if a trigger method exists
     if (_.isFunction(context.trigger)) {
-      if (noEventArg + args.length > 1) {
-        context.trigger.apply(context, noEventArg ? args : [event].concat(_.drop(args, 0)));
-      } else {
-        context.trigger(event);
-      }
+      context.trigger.apply(context, noEventArg ? args : [event].concat(_.drop(args, 0)));
     }
 
     return result;


### PR DESCRIPTION
This optimization of `triggerMethod` was previously used in `Controller`, but are now gone.  Seeing as we have some custom overrides for `triggerMethod` in `AbstractView` it may be more reasonable to just not worry about it.  It could only be utilized internally if we do want to keep it.. none of the public API can benefit.  We'd need to call `Marionette._triggerMethod` directly with no event arguments.

This was discovered while researching https://github.com/marionettejs/backbone.marionette/issues/2581