### PR TITLE
Update Radio and Object Radio API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "backbone": "1.0.0 - 1.2.1",
     "underscore": "1.4.4 - 1.8.3",
     "backbone.babysitter": "^0.1.0",
-    "backbone.radio": "^0.9.0",
+    "backbone.radio": "^1.0.0",
     "backbone-metal": "^0.5.0",
     "jquery": "^1.8.0 || ^2.0.0"
   }

--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -55,16 +55,12 @@ john.graduate();
 ```
 
 ### Radio Events
-`Marionette.Object` integrates with `Backbone.Radio` to provide powerful messaging capabilities.  Objects can respond to any of Radio's three message types; `Events`, `Commands` and `Requests`.  The syntax is similar to the `events` syntax from Backbone Views, and looks like this:
+`Marionette.Object` integrates with `Backbone.Radio` to provide powerful messaging capabilities.  Objects can respond to both of Radio's message types; `Events` and `Requests`.  The syntax is similar to the `events` syntax from Backbone Views, and looks like this:
 
 ```js
 radioEvents: {
   'app start': 'onAppStart',
   'books finish': 'onBooksFinish',
-},
-
-radioCommands: {
-  'app doFoo': 'executeFoo',
 },
 
 radioRequests: {
@@ -75,12 +71,12 @@ radioRequests: {
 where each hash value is in the form `'channel eventName' : 'handler'`.  So
 
 ```js
-radioCommands: {
+radioRequests: {
   'app doFoo': 'executeFoo',
 },
 ```
 
-means that the object will listen for the `doFoo` command on the `app` channel, and run the 'executeFoo' method.  When using Radio Commands and Requests with Objects, the same rules and restrictions that normal Radio use implies also apply here: a single handler can be associated with a command or request, either through manual use of the comply or reply functions, or through the Object API.
+means that the object will listen for the `doFoo` request on the `app` channel, and run the 'executeFoo' method.  When using Radio Requests with Objects, the same rules and restrictions that normal Radio use implies also apply here: a single handler can be associated with a request, either through manual use of the reply functions, or through the Object API.
 
 ### mergeOptions
 Merge keys from the `options` object directly onto the instance. This is the preferred way to access options

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "github": "https://github.com/marionettejs/backbone.marionette",
   "dependencies": {
     "backbone.babysitter": "^0.1.0",
-    "backbone.radio": "^0.9.0",
+    "backbone.radio": "^1.0.0",
     "backbone": "1.0.0 - 1.2.1",
     "backbone-metal": "^0.5.0",
     "underscore": "1.4.4 - 1.8.3"

--- a/src/radio-helpers.js
+++ b/src/radio-helpers.js
@@ -6,10 +6,6 @@
       startMethod: 'on',
       stopMethod: 'off'
     },
-    'radioCommands' : {
-      startMethod: 'comply',
-      stopMethod: 'stopComplying'
-    },
     'radioRequests' : {
       startMethod: 'reply',
       stopMethod: 'stopReplying'

--- a/test/unit/radio-helpers.spec.js
+++ b/test/unit/radio-helpers.spec.js
@@ -10,9 +10,6 @@ describe('Marionette radio helpers', function() {
         radioEvents: {
           'foo bar' : this.clickStub1
         },
-        radioCommands: {
-          'bar foo' : this.clickStub2
-        },
         radioRequests: {
           'foo bar' : 'baz'
         },
@@ -23,16 +20,11 @@ describe('Marionette radio helpers', function() {
       this.object = new this.Object();
       Backbone.Radio.channel('foo').trigger('bar');
       Backbone.Radio.channel('foo').request('bar');
-      Backbone.Radio.channel('bar').command('foo');
 
     });
 
     it('should support listening to radio events declaratively', function() {
       expect(this.clickStub1).to.have.been.calledOnce;
-    });
-
-    it('should support complying to radio commands declaratively', function() {
-      expect(this.clickStub2).to.have.been.calledOnce;
     });
 
     it('should support replying to radio requests declaratively', function() {
@@ -43,12 +35,6 @@ describe('Marionette radio helpers', function() {
       this.object.destroy();
       Backbone.Radio.channel('foo').trigger('bar');
       expect(this.clickStub1).to.have.been.calledOnce;
-    });
-
-    it('should unsubscribe commands when the object is destroyed', function() {
-      this.object.destroy();
-      Backbone.Radio.channel('bar').command('foo');
-      expect(this.clickStub2).to.have.been.calledOnce;
     });
 
     it('should unsubscribe requests when the object is destroyed', function() {
@@ -62,13 +48,6 @@ describe('Marionette radio helpers', function() {
       this.object.destroy();
       Backbone.Radio.channel('foo').trigger('bar');
       expect(this.clickStub1).to.have.been.calledTwice;
-    });
-
-    it('shouldn\'t overunsubscribe commands when the object is destroyed', function() {
-      this.object2 = new this.Object();
-      this.object.destroy();
-      Backbone.Radio.channel('bar').command('foo');
-      expect(this.clickStub2).to.have.been.calledTwice;
     });
 
     it('shouldn\'t overunsubscribe requests when the object is destroyed', function() {


### PR DESCRIPTION
Radio is now `v1` and has removed Commands.
 
Resolves https://github.com/marionettejs/backbone.marionette/issues/2569