### PR TITLE
Prevent Object's Radio API from silently failing

### DIFF
--- a/src/radio-helpers.js
+++ b/src/radio-helpers.js
@@ -25,9 +25,6 @@
       }
       _.each(hash, function(handler, radioMessage) {
         handler = normalizeHandler.call(this, handler);
-        if (!handler) {
-          return;
-        }
         var messageComponents = radioMessage.split(' ');
         var channel = messageComponents[0];
         var messageName = messageComponents[1];


### PR DESCRIPTION
If you give the Radio API a bad function name it will silently fail.

This is inconsistent with other hashes that accept functions.  If you mistype a function, javascript can handle the error.

I found this while investigating https://github.com/marionettejs/backbone.marionette/issues/2581  This line is currently not tested, but I think it is better it is simply removed.
