### PR TITLE
Fixed a small typo error.

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -740,7 +740,7 @@ The `before:render:collection` event is triggered before the `collectionView`'s 
 
 ### render:collection event
 
-The `render:collection` event is triggered after a `collectionView`'s children have been rendered and buffered. It differs from the `collectionViews`'s `render` event in that it happens __only__ if the `collection` is not not empty.
+The `render:collection` event is triggered after a `collectionView`'s children have been rendered and buffered. It differs from the `collectionViews`'s `render` event in that it happens __only__ if the `collection` is not empty.
 
 ## CollectionView render
 


### PR DESCRIPTION
There were 2 'not' in the render:collection event description.