### PR TITLE
Improve support for Backbone.View childViews

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -54,6 +54,8 @@ will provide features such as `onShow` callbacks, etc. Please see
   * ["childview:\*" event bubbling from child views](#childview-event-bubbling-from-child-views)
   * ["before:render:collection" event](#beforerendercollection-event)
   * ["render:collection" event](#rendercollection-event)
+* [CollectionView Child View Events](#collectionview-child-view-events)
+  * [Backbone View Child Views](#backbone-view-child-views)
 * [CollectionView render](#collectionview-render)
 * [CollectionView: Automatic Rendering](#collectionview-automatic-rendering)
 * [CollectionView: Re-render Collection](#collectionview-re-render-collection)
@@ -741,6 +743,20 @@ The `before:render:collection` event is triggered before the `collectionView`'s 
 ### render:collection event
 
 The `render:collection` event is triggered after a `collectionView`'s children have been rendered and buffered. It differs from the `collectionViews`'s `render` event in that it happens __only__ if the `collection` is not not empty.
+
+## CollectionView Child View Events
+
+* `before:show` / `onBeforeShow` - Called after the child view has been rendered, but before it has been bound to the CollectionView.
+* `show` / `onShow` - Called when the view has been rendered and bound to the CollectionView.
+* `before:render` / `onBeforeRender` - Called before the view is rendered.
+* `render` / `onRender` - Called after the view is rendered, but before it is attached to the DOM.
+* `dom:refresh` / `onDomRefresh` - Called when the view is shown, rendered, and attached to the DOM.
+* `before:attach` / `onBeforeAttach` - Called before the view is attached to the DOM.
+* `attach` / `onAttach` - Called after the view is attached to the DOM.
+* `before:destroy` / `onBeforeDestroy` - Called before destroying a view.
+* `destroy` / `onDestroy` - Called after destroying a view.
+
+Note: All events and event handlers are also supported on pure Backbone views during child view operations.  Keep in mind that `render/onRender` and `destroy/onDestroy` are not fired when calling `childView.render()` or `childView.remove()` manually.
 
 ## CollectionView render
 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -22,7 +22,10 @@ Using the `LayoutView` class you can create nested regions.
   * [Set `currentView` On Initialization](#set-currentview-on-initialization)
   * [Call `attachView` On Region](#call-attachview-on-region)
 * [Region Events And Callbacks](#region-events-and-callbacks)
-  * [Events raised during `show`](#events-raised-during-show)
+  * [Events Raised on the Region During `show`](#events-raised-on-the-region-during-show)
+  * [Events Raised on the View During `show`](#events-raised-on-the-view-during-show)
+    * [Backbone Views](#backbone-views)
+  * [Example Event Handlers](#example-event-handlers)
 * [Custom Region Classes](#custom-region-classes)
   * [Attaching Custom Region Classes](#attaching-custom-region-classes)
   * [Instantiate Your Own Region](#instantiate-your-own-region)
@@ -424,24 +427,34 @@ MyApp.someRegion.attachView(myView);
 
 ## Region Events And Callbacks
 
-### Events raised during `show`:
-A region will raise a few events when showing
-and destroying views:
+A region will raise a few events on itself and on the target view when showing and destroying views.
 
-* "before:show" / `onBeforeShow` - Called on the view instance after the view has been rendered, but before its been displayed.
-* "before:show" / `onBeforeShow` - Called on the region instance after the view has been rendered, but before its been displayed.
-* "show" / `onShow` - Called on the view instance when the view has been rendered and displayed.
-* "show" / `onShow` - Called on the region instance when the view has been rendered and displayed.
-* "before:swap" / `onBeforeSwap` - Called on the region instance before a new view is shown. NOTE: this will only be called when a view is being swapped, not when the region is empty.
-* "before:swapOut" / `onBeforeSwapOut` - Called on the region instance before a new view swapped in. NOTE: this will only be called when a view is being swapped, not when the region is empty.
-* "swap" / `onSwap` - Called on the region instance when a new view is shown. NOTE: this will only be called when a view is being swapped, not when the region is empty.
-* "swapOut" / `onSwapOut` - Called on the region instance when a new view swapped in to replace the currently shown view. NOTE: this will only be called when a view is being swapped, not when the region is empty.
+### Events Raised on the Region During `show`
 
-* "before:empty" / `onBeforeEmpty` - Called on the region instance before the view has been emptied.
-* "empty" / `onEmpty` - Called when the view has been emptied.
+* `before:show` / `onBeforeShow` - Called after the view has been rendered, but before its been displayed.
+* `show` / `onShow` - Called when the view has been rendered and displayed.
+* `before:swap` / `onBeforeSwap` - Called before a new view is shown. NOTE: this will only be called when a view is being swapped, not when the region is empty.
+* `swap` / `onSwap` - Called when a new view is shown. NOTE: this will only be called when a view is being swapped, not when the region is empty.
+* `before:swapOut` / `onBeforeSwapOut` - Called before a new view swapped in. NOTE: this will only be called when a view is being swapped, not when the region is empty.
+* `swapOut` / `onSwapOut` - Called when a new view swapped in to replace the currently shown view. NOTE: this will only be called when a view is being swapped, not when the region is empty.
+* `before:empty` / `onBeforeEmpty` - Called before the view has been emptied.
+* `empty` / `onEmpty` - Called when the view has been emptied.
 
-These events can be used to run code when your region
-opens and destroys views.
+### Events Raised on the View During `show`
+
+* `before:show` / `onBeforeShow` - Called after the view has been rendered, but before it has been bound to the region.
+* `show` / `onShow` - Called when the view has been rendered and bound to the region.
+* `before:render` / `onBeforeRender` - Called before the view is rendered.
+* `render` / `onRender` - Called after the view is rendered, but before it is attached to the DOM.
+* `dom:refresh` / `onDomRefresh` - Called when the view is shown, rendered, and attached to the DOM.
+* `before:attach` / `onBeforeAttach` - Called before the view is attached to the DOM.
+* `attach` / `onAttach` - Called after the view is attached to the DOM.
+* `before:destroy` / `onBeforeDestroy` - Called before destroying a view (on empty or swapOut).
+* `destroy` / `onDestroy` - Called after destroying a view (on empty or swapOut).
+
+Note: All events and event handlers are also supported on pure Backbone views during a `show`.  Keep in mind that `render/onRender` and `destroy/onDestroy` are not fired when calling `view.render()` or `view.remove()` manually.
+
+### Example Event Handlers
 
 ```js
 MyApp.mainRegion.on("before:show", function(view, region, options){

--- a/src/dom-refresh.js
+++ b/src/dom-refresh.js
@@ -6,6 +6,7 @@
 // re-rendered.
 
 Marionette.MonitorDOMRefresh = function(view) {
+  view._isDomRefreshMonitored = true;
 
   // track when the view has been shown in the DOM,
   // using a Marionette.Region (or by other means of triggering "show")
@@ -23,9 +24,7 @@ Marionette.MonitorDOMRefresh = function(view) {
   // Trigger the "dom:refresh" event and corresponding "onDomRefresh" method
   function triggerDOMRefresh() {
     if (view._isShown && view._isRendered && Marionette.isNodeAttached(view.el)) {
-      if (_.isFunction(view.triggerMethod)) {
-        view.triggerMethod('dom:refresh');
-      }
+      Marionette.triggerMethodOn(view, 'dom:refresh', view);
     }
   }
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -4,64 +4,17 @@ describe('collection view', function() {
   beforeEach(function() {
     // Shared View Definitions
     // -----------------------
-
-    var spec = this;
-
-    this.ChildView = Backbone.Marionette.ItemView.extend({
+    this.ChildView = Marionette.ItemView.extend({
       tagName: 'span',
-      // Stub methods in contructor to ensure calls are counted from the moment the parent
-      // CollectionView instantiates it.
-      constructor: function(options) {
-        Marionette.ItemView.prototype.constructor.call(this, options);
-        this.onBeforeShow = spec.sinon.stub();
-        this.onShow = spec.sinon.stub();
-        this.onDomRefresh = spec.sinon.stub();
-      },
       render: function() {
+        this.trigger('before:render', this);
         this.$el.html(this.model.get('foo'));
-        this.trigger('render');
-      },
-      // Init region manager creates a circular reference, which
-      // explodes Sinon's deep equals assertion. These tests
-      // do not care if the view has a region manager or not.
-      _initializeRegions: function() {},
-      // The ItemView's destroy method tries to destroy the
-      // RegionManager, which, from the above, does not exist.
-      destroy: Marionette.View.prototype.destroy,
-      onRender: function() {},
-      onBeforeShow: function() {},
-      onShow: function() {},
-      onDomRefresh: function() {},
-    });
-
-    this.DeepEqualChildView = this.ChildView.extend({
-      // Init region manager creates a circular reference, which explodes Sinon's deep equals
-      // assertion. Some tests do not care if the view has a region manager or not, but do care
-      // about deep equality.
-      _initializeRegions: function() {},
-      // The View's destroy method tries to destroy the RegionManager, which, from the above,
-      // does not exist.
-      destroy: Marionette.View.prototype.destroy
+        this.trigger('render', this);
+      }
     });
 
     this.CollectionView = Marionette.CollectionView.extend({
-      childView: this.ChildView,
-      onBeforeRender: function() {
-        return this.isRendered;
-      },
-      onRender: function() {
-        return this.isRendered;
-      },
-      onBeforeAddChild: function() {},
-      onAddChild: function() {},
-      onBeforeRemoveChild: function() {},
-      onRemoveChild: function() {},
-      onRenderCollection: function() {},
-      onBeforeRenderCollection: function() {}
-    });
-
-    this.DeepEqualCollectionView = this.CollectionView.extend({
-      childView: this.DeepEqualChildView,
+      childView: this.ChildView
     });
   });
 
@@ -70,51 +23,48 @@ describe('collection view', function() {
 
   describe('before rendering a collection view', function() {
     beforeEach(function() {
+      var CollectionView = this.CollectionView.extend({
+        sort: function() { return 1; },
+        onAddChild: this.sinon.stub(),
+        onRemoveChild: this.sinon.stub()
+      });
+
       this.collection = new Backbone.Collection([]);
-      this.CollectionView = this.DeepEqualCollectionView.extend({
-        sort: function() { return 1; }
+      this.collectionView = new CollectionView({
+        collection: this.collection
       });
 
-      this.collectionView = new this.CollectionView({
-        collection: this.collection,
-        _sortViews: function() {}
-      });
-
-      this.onAddChildSpy = this.sinon.spy(this.collectionView, 'onAddChild');
-      this.onRemoveChildSpy = this.sinon.spy(this.collectionView, 'onRemoveChild');
-      this.onSortViewsSpy = this.sinon.spy(this.collectionView, '_sortViews');
+      this.sinon.spy(this.collectionView, '_sortViews');
     });
 
     it('should not add a child', function() {
       this.collection.push({});
-
-      expect(this.onAddChildSpy).to.not.have.been.called;
+      expect(this.collectionView.onAddChild).to.not.have.been.called;
     });
 
     it('should not add a child', function() {
       this.collection.reset([{}]);
-
-      expect(this.onAddChildSpy).to.not.have.been.called;
+      expect(this.collectionView.onAddChild).to.not.have.been.called;
     });
 
     it('should not remove a child', function() {
       var model = new Backbone.Model();
       this.collection.add(model);
       this.collection.remove(model);
-
-      expect(this.onRemoveChildSpy).to.not.have.been.called;
+      expect(this.collectionView.onRemoveChild).to.not.have.been.called;
     });
 
     it('should not call sort', function() {
       this.collection.trigger('sort');
-
-      expect(this.onSortViewsSpy).to.not.have.been.called;
+      expect(this.collectionView._sortViews).to.not.have.been.called;
     });
   });
 
   describe('when rendering a collection view with no "childView" specified', function() {
     beforeEach(function() {
-      this.NoChildView = Backbone.Marionette.CollectionView.extend();
+      this.NoChildView = this.CollectionView.extend({
+        childView: undefined
+      });
 
       this.collection = new Backbone.Collection([{foo:'bar'}, {foo: 'baz'}]);
       this.collectionView = new this.NoChildView({
@@ -129,22 +79,26 @@ describe('collection view', function() {
 
   describe('when rendering a collection view', function() {
     beforeEach(function() {
+      var CollectionView = this.CollectionView.extend({
+        childEvents: {
+          'render': 'onChildViewRender'
+        },
+        onBeforeRender:           function() { return this.isRendered; },
+        onRender:                 function() { return this.isRendered; },
+        onBeforeAddChild:         this.sinon.stub(),
+        onAddChild:               this.sinon.stub(),
+        onBeforeRenderCollection: this.sinon.stub(),
+        onRenderCollection:       this.sinon.stub(),
+        onChildViewRender:        this.sinon.stub()
+      });
+
       this.collection = new Backbone.Collection([{foo: 'bar'}, {foo: 'baz'}]);
-
-      this.childViewRender = this.sinon.stub();
-
-      this.collectionView = new this.DeepEqualCollectionView({
+      this.collectionView = new CollectionView({
         collection: this.collection
       });
 
-      this.collectionView.on('childview:render', this.childViewRender);
-
-      this.sinon.spy(this.collectionView, 'onRender');
-      this.sinon.spy(this.collectionView, 'onBeforeAddChild');
-      this.sinon.spy(this.collectionView, 'onAddChild');
       this.sinon.spy(this.collectionView, 'onBeforeRender');
-      this.sinon.spy(this.collectionView, 'onBeforeRenderCollection');
-      this.sinon.spy(this.collectionView, 'onRenderCollection');
+      this.sinon.spy(this.collectionView, 'onRender');
       this.sinon.spy(this.collectionView, 'trigger');
       this.sinon.spy(this.collectionView, 'attachHtml');
       this.sinon.spy(this.collectionView.$el, 'append');
@@ -206,7 +160,7 @@ describe('collection view', function() {
     });
 
     it('should not be rendered when "onBeforeRender" is called', function() {
-      expect(this.collectionView.onBeforeRender.lastCall.returnValue).not.to.be.ok;
+      expect(this.collectionView.onBeforeRender.lastCall.returnValue).to.not.be.ok;
     });
 
     it('should be rendered when "onRender" is called', function() {
@@ -252,7 +206,7 @@ describe('collection view', function() {
     });
 
     it('should trigger "childview:render" for each item in the collection', function() {
-      expect(this.childViewRender.callCount).to.equal(2);
+      expect(this.collectionView.onChildViewRender.callCount).to.equal(2);
     });
 
     it('should call "getChildView" for each item in the collection', function() {
@@ -269,10 +223,12 @@ describe('collection view', function() {
   describe('when rendering a collection view and accessing children via the DOM', function() {
     beforeEach(function() {
       var suite = this;
+      var CollectionView = this.CollectionView.extend({
+        onRenderCollection: function() {}
+      });
 
       this.collection = new Backbone.Collection([{foo: 'bar'}, {foo: 'baz'}]);
-
-      this.collectionView = new this.DeepEqualCollectionView({
+      this.collectionView = new CollectionView({
         collection: this.collection
       });
 
@@ -290,10 +246,12 @@ describe('collection view', function() {
 
   describe('when rendering a collection view without a collection', function() {
     beforeEach(function() {
-      this.collectionView = new this.DeepEqualCollectionView();
+      var CollectionView = this.CollectionView.extend({
+        onRender:       this.sinon.stub(),
+        onBeforeRender: this.sinon.stub()
+      });
+      this.collectionView = new CollectionView();
 
-      this.sinon.spy(this.collectionView, 'onRender');
-      this.sinon.spy(this.collectionView, 'onBeforeRender');
       this.sinon.spy(this.collectionView, 'trigger');
 
       this.collectionView.render();
@@ -311,8 +269,7 @@ describe('collection view', function() {
   describe('when rendering a childView', function() {
     beforeEach(function() {
       this.collection = new Backbone.Collection([{foo: 'bar'}]);
-      this.collectionView = new Marionette.CollectionView({
-        childView: this.ChildView,
+      this.collectionView = new this.CollectionView({
         collection: this.collection
       });
 
@@ -352,12 +309,8 @@ describe('collection view', function() {
     });
 
     it('should not update the order of children when "sort" is set to "false" as a property on a class', function() {
-      this.CollectionView = Marionette.CollectionView.extend({
-        childView: this.ChildView,
-        sort : false
-      });
       this.collectionView = new this.CollectionView({
-        childView: this.ChildView,
+        sort: false,
         collection: this.collection
       });
       this.collectionView.render();
@@ -367,11 +320,7 @@ describe('collection view', function() {
     });
 
     it('should not update the order of children when "sort" is set to "false" inside options', function() {
-      this.CollectionView = Marionette.CollectionView.extend({
-        childView: this.ChildView,
-      });
       this.collectionView = new this.CollectionView({
-        childView: this.ChildView,
         sort : false,
         collection: this.collection
       });
@@ -384,8 +333,8 @@ describe('collection view', function() {
 
   describe('when instantiating a view with a different sort option than in the view\'s definition', function() {
     it('should maintain the instantiated sort option', function() {
-      this.CollectionView = Marionette.CollectionView.extend({sort: false});
-      this.newCollectionView = new this.CollectionView({sort: true});
+      var CollectionView = this.CollectionView.extend({sort: false});
+      this.newCollectionView = new CollectionView({sort: true});
       expect(this.newCollectionView.getOption('sort')).to.equal(true);
     });
   });
@@ -393,8 +342,7 @@ describe('collection view', function() {
   describe('when a model is added to the collection', function() {
     beforeEach(function() {
       this.collection = new Backbone.Collection();
-      this.collectionView = new this.DeepEqualCollectionView({
-        childView: this.ChildView,
+      this.collectionView = new this.CollectionView({
         collection: this.collection
       });
       this.collectionView.render();
@@ -429,8 +377,7 @@ describe('collection view', function() {
     beforeEach(function() {
       this.collection = new Backbone.Collection({foo: 'bar'});
 
-      this.collectionView = new this.DeepEqualCollectionView({
-        childView: this.ChildView,
+      this.collectionView = new this.CollectionView({
         collection: this.collection
       });
       this.collectionView.render();
@@ -473,12 +420,11 @@ describe('collection view', function() {
 
       this.model = new Backbone.Model({foo: 'bar'});
 
-      this.EmptyView = Backbone.Marionette.ItemView.extend({
+      this.EmptyView = Backbone.View.extend({
         render: function() {}
       });
 
-      this.CollectionView = Backbone.Marionette.CollectionView.extend({
-        childView: this.ChildView,
+      this.CollectionView = this.CollectionView.extend({
         emptyView: this.EmptyView,
 
         onBeforeRenderEmpty: function() {},
@@ -523,12 +469,16 @@ describe('collection view', function() {
 
   describe('when a model is removed from the collection', function() {
     beforeEach(function() {
+      var CollectionView = this.CollectionView.extend({
+        onBeforeRemoveChild: this.sinon.stub(),
+        onRemoveChild: this.sinon.stub()
+      });
+
       this.model = new Backbone.Model({foo: 'bar'});
       this.collection = new Backbone.Collection();
       this.collection.add(this.model);
 
-      this.collectionView = new this.DeepEqualCollectionView({
-        childView: this.ChildView,
+      this.collectionView = new CollectionView({
         collection: this.collection
       });
       this.collectionView.render();
@@ -536,9 +486,6 @@ describe('collection view', function() {
       this.childView = this.collectionView.children.findByIndex(0);
 
       this.sinon.spy(this.childView, 'destroy');
-
-      this.onBeforeRemoveChildSpy = this.sinon.spy(this.collectionView, 'onBeforeRemoveChild');
-      this.onRemoveChildSpy = this.sinon.spy(this.collectionView, 'onRemoveChild');
 
       this.collection.remove(this.model);
     });
@@ -552,30 +499,29 @@ describe('collection view', function() {
     });
 
     it('should execute onBeforeRemoveChild', function() {
-      expect(this.onBeforeRemoveChildSpy).to.have.been.calledOnce;
+      expect(this.collectionView.onBeforeRemoveChild).to.have.been.calledOnce;
     });
 
     it('should pass the removed view to onBeforeRemoveChild', function() {
-      expect(this.onBeforeRemoveChildSpy).to.have.been.calledWithExactly(this.childView);
+      expect(this.collectionView.onBeforeRemoveChild).to.have.been.calledWithExactly(this.childView);
     });
 
     it('should execute onRemoveChild', function() {
-      expect(this.onRemoveChildSpy).to.have.been.calledOnce;
+      expect(this.collectionView.onRemoveChild).to.have.been.calledOnce;
     });
 
     it('should pass the removed view to _onCollectionRemove', function() {
-      expect(this.onRemoveChildSpy).to.have.been.calledWithExactly(this.childView);
+      expect(this.collectionView.onRemoveChild).to.have.been.calledWithExactly(this.childView);
     });
 
     it('should execute onBeforeRemoveChild before _onCollectionRemove', function() {
-      expect(this.onBeforeRemoveChildSpy).to.have.been.calledBefore(this.onRemoveChildSpy);
+      expect(this.collectionView.onBeforeRemoveChild).to.have.been.calledBefore(this.collectionView.onRemoveChild);
     });
   });
 
   describe('when destroying a collection view', function() {
     beforeEach(function() {
-      this.EventedView = Backbone.Marionette.CollectionView.extend({
-        childView: this.ChildView,
+      this.EventedView = this.CollectionView.extend({
         someCallback: function() {},
         onBeforeDestroy: function() {
           return {
@@ -731,7 +677,7 @@ describe('collection view', function() {
 
   describe('when removing a childView that does not have a "destroy" method', function() {
     beforeEach(function() {
-      this.collectionView = new Marionette.CollectionView({
+      this.collectionView = new this.CollectionView({
         childView: Backbone.View,
         collection: new Backbone.Collection([{id: 1}])
       });
@@ -756,7 +702,7 @@ describe('collection view', function() {
 
   describe('when destroying all children', function() {
     beforeEach(function() {
-      this.collectionView = new Marionette.CollectionView({
+      this.collectionView = new this.CollectionView({
         childView: Backbone.View,
         collection: new Backbone.Collection([{id: 1}, {id: 2}])
       });
@@ -806,8 +752,7 @@ describe('collection view', function() {
 
   describe('when override attachHtml', function() {
     beforeEach(function() {
-      this.PrependHtmlView = Backbone.Marionette.CollectionView.extend({
-        childView: this.ChildView,
+      this.PrependHtmlView = this.CollectionView.extend({
 
         attachHtml: function(collectionView, childView) {
           collectionView.$el.prepend(childView.el);
@@ -835,7 +780,7 @@ describe('collection view', function() {
       this.model = new Backbone.Model({foo: 'bar'});
       this.collection = new Backbone.Collection([this.model]);
 
-      this.collectionView = new this.DeepEqualCollectionView({collection: this.collection});
+      this.collectionView = new this.CollectionView({collection: this.collection});
       this.collectionView.on('childview:some:event', this.someEventSpy);
       this.collectionView.render();
 
@@ -855,7 +800,7 @@ describe('collection view', function() {
 
   describe('when configuring a custom childViewEventPrefix', function() {
     beforeEach(function() {
-      this.CollectionView = this.DeepEqualCollectionView.extend({
+      this.CollectionView = this.CollectionView.extend({
         childViewEventPrefix: 'myPrefix'
       });
 
@@ -887,10 +832,7 @@ describe('collection view', function() {
       this.model = new Backbone.Model({foo: 'bar'});
       this.collection = new Backbone.Collection([this.model]);
 
-      this.collectionView = new this.DeepEqualCollectionView({
-        childView: Backbone.Marionette.ItemView.extend({
-          template: function() { return '<%= foo %>'; }
-        }),
+      this.collectionView = new this.CollectionView({
         collection: this.collection
       });
     });
@@ -942,7 +884,7 @@ describe('collection view', function() {
       this.model = new Backbone.Model({foo: 'bar'});
       this.collection = new Backbone.Collection([this.model]);
 
-      this.collectionView = new this.DeepEqualCollectionView({
+      this.collectionView = new this.CollectionView({
         template: '#itemTemplate',
         collection: this.collection
       });
@@ -976,7 +918,7 @@ describe('collection view', function() {
       this.model = new Backbone.Model({foo: 'bar'});
       this.collection = new Backbone.Collection([this.model]);
 
-      this.collectionView = new this.DeepEqualCollectionView({
+      this.collectionView = new this.CollectionView({
         template: '#itemTemplate',
         collection: this.collection
       });
@@ -1000,52 +942,98 @@ describe('collection view', function() {
     });
   });
 
-  describe('when a child view is added to a collection view, after the collection view has been shown', function() {
+  describe('when a collection view is initially attached to the DOM and shown', function() {
     beforeEach(function() {
-      this.setFixtures($('<div id="fixture-container"></div>'));
-
-      this.model1 = new Backbone.Model({foo: 1});
-      this.model2 = new Backbone.Model({foo: 2});
-      this.collection = new Backbone.Collection([this.model1]);
-      this.collectionView = new this.CollectionView({
-        collection: this.collection
+      var spec = this;
+      var ChildView = this.ChildView.extend({
+        constructor: function() {
+          ChildView.__super__.constructor.apply(this, arguments);
+          spec.sinon.stub(this, 'onBeforeShow');
+          spec.sinon.stub(this, 'onShow');
+          spec.sinon.stub(this, 'onDomRefresh');
+        },
+        onRender: function() {},
+        onBeforeShow: function() {},
+        onShow: function() {},
+        onBeforeAttach: function() {},
+        onAttach: function() {},
+        onDomRefresh: function() {}
       });
-      $('#fixture-container').append(this.collectionView.el);
 
-      this.collectionView.render();
-      this.collectionView.trigger('show');
+      this.collection = new Backbone.Collection([{foo: 1}, {foo: 2}]);
+      this.collectionView = new this.CollectionView({
+        childView: ChildView,
+        collection: this.collection,
+        emptyView: ChildView
+      });
 
-      this.sinon.spy(this.collectionView, 'attachBuffer');
-      this.sinon.spy(this.collectionView, 'getChildView');
+      this.setFixtures($('<div id="fixture-container"></div>'));
+      var region = new Marionette.Region({el: '#fixture-container'});
+      region.show(this.collectionView);
 
-      this.collection.add(this.model2);
+      this.childView1 = this.collectionView.children.findByIndex(0);
       this.childView2 = this.collectionView.children.findByIndex(1);
     });
 
-    it('should not use the render buffer', function() {
-      expect(this.collectionView.attachBuffer).not.to.have.been.called;
+    it('onBeforeShow should propagate to each initial child view', function() {
+      expect(this.childView1.onBeforeShow)
+        .to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView1)
+        .and.to.have.been.calledWith(this.childView1);
+      expect(this.childView2.onBeforeShow)
+        .to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView2)
+        .and.to.have.been.calledWith(this.childView2);
     });
 
-    it('should call onBeforeShow of the added child view', function() {
-      expect(this.childView2.onBeforeShow).to.have.been.calledOnce;
-      expect(this.childView2.onBeforeShow).to.have.been.calledOn(this.childView2);
-      expect(this.childView2.onBeforeShow).to.have.been.calledWith(this.childView2);
+    it('onShow should propagate to each initial child view', function() {
+      expect(this.childView1.onShow)
+        .to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView1)
+        .and.to.have.been.calledWith(this.childView1);
+      expect(this.childView2.onShow)
+        .to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView2)
+        .and.to.have.been.calledWith(this.childView2);
     });
 
-    it('should call onShow of the added child view', function() {
-      expect(this.childView2.onShow).to.have.been.calledOnce;
-      expect(this.childView2.onShow).to.have.been.calledOn(this.childView2);
-      expect(this.childView2.onShow).to.have.been.calledWith(this.childView2);
-    });
+    describe('when a child view is added to a collection view, after the collection view has been shown', function() {
+      beforeEach(function() {
+        this.sinon.spy(this.collectionView, 'attachBuffer');
+        this.sinon.spy(this.collectionView, 'getChildView');
+        this.model3 = new Backbone.Model({foo: 3});
+        this.collection.add(this.model3);
+        this.childView3 = this.collectionView.children.findByIndex(2);
+      });
 
-    it('should call onDomRefresh of the added child view', function() {
-      expect(this.childView2.onDomRefresh).to.have.been.calledOnce;
-      expect(this.childView2.onDomRefresh).to.have.been.calledOn(this.childView2);
-      expect(this.childView2.onDomRefresh).to.have.been.calledWithExactly(); // no args
-    });
+      it('should not use the render buffer', function() {
+        expect(this.collectionView.attachBuffer).not.to.have.been.called;
+      });
 
-    it('should call getChildView with the new model', function() {
-      expect(this.collectionView.getChildView).to.have.been.calledWith(this.model2);
+      it('should call onBeforeShow of the added child view', function() {
+        expect(this.childView3.onBeforeShow)
+          .to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView3)
+          .and.to.have.been.calledWith(this.childView3);
+      });
+
+      it('should call onShow of the added child view', function() {
+        expect(this.childView3.onShow)
+          .to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView3)
+          .and.to.have.been.calledWith(this.childView3);
+      });
+
+      it('should call onDomRefresh of the added child view', function() {
+        expect(this.childView3.onDomRefresh)
+          .to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView3)
+          .and.to.have.been.calledWithExactly(); // no args
+      });
+
+      it('should call getChildView with the new model', function() {
+        expect(this.collectionView.getChildView).to.have.been.calledWith(this.model3);
+      });
     });
 
     describe('when the childView is added at an existing index', function() {
@@ -1068,14 +1056,14 @@ describe('collection view', function() {
 
   describe('when setting a childView in the constructor options', function() {
     beforeEach(function() {
-      this.ItemView = Marionette.ItemView.extend({
+      var ChildView = this.ChildView.extend({
         template: function() {},
         MyItemView: true
       });
 
       this.collection = new Backbone.Collection([{a: 'b'}]);
-      this.collectionView = new Marionette.CollectionView({
-        childView: this.ItemView,
+      this.collectionView = new this.CollectionView({
+        childView: ChildView,
         collection: this.collection
       });
 
@@ -1091,7 +1079,7 @@ describe('collection view', function() {
 
   describe('when calling childEvents via a childEvents method', function() {
     beforeEach(function() {
-      this.CollectionView = this.DeepEqualCollectionView.extend({
+      this.CollectionView = this.CollectionView.extend({
         childEvents: function() {
           return {
             'some:event': 'someEvent'
@@ -1126,7 +1114,7 @@ describe('collection view', function() {
     beforeEach(function() {
       this.onSomeEventSpy = this.sinon.stub();
 
-      this.CollectionView = this.DeepEqualCollectionView.extend({
+      this.CollectionView = this.CollectionView.extend({
         childEvents: {
           'some:event': this.onSomeEventSpy
         }
@@ -1154,7 +1142,7 @@ describe('collection view', function() {
 
   describe('when calling childEvents via the childEvents hash with a string of the function name', function() {
     beforeEach(function() {
-      this.CollectionView = this.DeepEqualCollectionView.extend({
+      var CollectionView = this.CollectionView.extend({
         childEvents: {
           'some:event': 'someEvent'
         }
@@ -1165,7 +1153,7 @@ describe('collection view', function() {
       this.model = new Backbone.Model({foo: 'bar'});
       this.collection = new Backbone.Collection([this.model]);
 
-      this.collectionView = new this.CollectionView({collection: this.collection});
+      this.collectionView = new CollectionView({collection: this.collection});
       this.collectionView.someEvent = this.someEventSpy;
       this.collectionView.render();
 
@@ -1185,14 +1173,13 @@ describe('collection view', function() {
 
   describe('calling childEvents via the childEvents hash with a string of a nonexistent function name', function() {
     beforeEach(function() {
-      this.CollectionView = Marionette.CollectionView.extend({
-        childView: this.ChildView,
+      var CollectionView = this.CollectionView.extend({
         childEvents: {
           'render': 'nonexistentFn'
         }
       });
 
-      this.collectionView = new this.CollectionView({
+      this.collectionView = new CollectionView({
         collection: (new Backbone.Collection([{}]))
       });
 
@@ -1207,7 +1194,7 @@ describe('collection view', function() {
   describe('has a valid inheritance chain back to Marionette.View', function() {
     beforeEach(function() {
       this.constructor = this.sinon.spy(Marionette, 'View');
-      this.collectionView = new Marionette.CollectionView();
+      this.collectionView = new this.ChildView();
     });
 
     it('calls the parent Marionette.Views constructor function on instantiation', function() {
@@ -1216,52 +1203,53 @@ describe('collection view', function() {
   });
 
   describe('when a collection is reset child views should not be shown until the buffering is over', function() {
-    beforeEach(function() {
-      var suite = this;
+    var suite;
 
-      this.ItemView = Marionette.ItemView.extend({
+    beforeEach(function() {
+      suite = this;
+
+      var ChildView = this.ChildView.extend({
         template: _.template('<div>hi mom</div>'),
+        constructor: function() {
+          suite.ChildView.prototype.constructor.apply(this, arguments);
+          suite.sinon.spy(this, 'onShow');
+        },
         onShow: function() {
-          suite.isBuffering = suite.collectionView.isBuffering;
+          suite.isBufferingOnChildShow = suite.collectionView.isBuffering;
         }
       });
 
-      this.CollectionView = Marionette.CollectionView.extend({
-        childView: this.ItemView
-      });
-
-      this.isBuffering = null;
       this.collection = new Backbone.Collection([{}]);
-      this.collectionView = new this.CollectionView({collection: this.collection});
-      this.collectionView.render().trigger('show');
+      this.collectionView = new this.CollectionView({
+        childView: ChildView,
+        collection: this.collection
+      });
+      this.collectionView.render();
+      this.childView = this.collectionView.children.findByIndex(0);
     });
 
-    it('collectionView should not be buffering on childView show', function() {
-      expect(this.isBuffering).to.be.false;
+    it('collectionView should not trigger child view show events if the view has not been shown', function() {
+      expect(this.childView.onShow).to.not.have.been.calledOnce;
     });
 
-    it('collectionView should not be buffering after reset on childView show', function() {
-      this.isBuffering = undefined;
-      this.collection.reset([{}]);
-      expect(this.isBuffering).to.be.false;
-    });
-
-    describe('child view show events', function() {
+    describe('when collectionView is shown', function() {
       beforeEach(function() {
-        var suite = this;
-        this.showCalled = false;
-        this.ItemView.prototype.onShow = function() { suite.showCalled = true; };
+        suite.isBufferingOnChildShow = undefined;
+        this.collectionView.trigger('show');
       });
 
-      it('collectionView should trigger the show events when the buffer is inserted and the view has been shown', function() {
+      it('collectionView should not be buffering on childView show', function() {
+        expect(suite.isBufferingOnChildShow).to.be.false;
+      });
+
+      it('collectionView should not be buffering after reset on childView show', function() {
         this.collection.reset([{}]);
-        expect(this.showCalled).to.equal(true);
+        expect(suite.isBufferingOnChildShow).to.be.false;
       });
 
-      it('collectionView should not trigger the show events if the view has not been shown', function() {
-        this.collectionView = new this.CollectionView({collection: this.collection});
-        this.collectionView.render();
-        expect(this.showCalled).to.equal(false);
+      it('collectionView should trigger child view show events when the buffer is inserted and the view has been shown', function() {
+        this.collection.reset([{}]);
+        expect(this.childView.onShow).to.have.been.calledOnce;
       });
     });
   });
@@ -1271,8 +1259,7 @@ describe('collection view', function() {
       var suite = this;
       this.Model       = Backbone.Model.extend({});
       this.Collection  = Backbone.Collection.extend({model: this.Model});
-      this.CollectionView = Backbone.Marionette.CollectionView.extend({
-        childView: this.ChildView,
+      this.CollectionView = this.CollectionView.extend({
         tagName: 'ul'
       });
 
@@ -1321,52 +1308,12 @@ describe('collection view', function() {
   describe('when returning the view from addChild', function() {
     beforeEach(function() {
       this.model = new Backbone.Model({foo: 'bar'});
-
-      this.CollectionView = Backbone.Marionette.CollectionView.extend({
-        childView: this.ChildView
-      });
-
       this.collectionView = new this.CollectionView();
-
       this.childView = this.collectionView.addChild(this.model, this.ChildView, 0);
     });
 
     it('should return the child view for the model', function() {
       expect(this.childView.$el).to.contain.$text('bar');
-    });
-  });
-
-  describe('when a collection view is initially shown', function() {
-    beforeEach(function() {
-      this.collection = new Backbone.Collection([{foo: 1}, {foo: 2}]);
-      this.collectionView = new this.CollectionView({
-        collection: this.collection
-      });
-
-      this.collectionView.render();
-      this.collectionView.trigger('before:show');
-      this.collectionView.trigger('show');
-
-      this.childView1 = this.collectionView.children.findByIndex(0);
-      this.childView2 = this.collectionView.children.findByIndex(1);
-    });
-
-    it('onBeforeShow should propagate to each child view', function() {
-      expect(this.childView1.onBeforeShow).to.have.been.calledOnce;
-      expect(this.childView1.onBeforeShow).to.have.been.calledOn(this.childView1);
-      expect(this.childView1.onBeforeShow).to.have.been.calledWith(this.childView1);
-      expect(this.childView2.onBeforeShow).to.have.been.calledOnce;
-      expect(this.childView2.onBeforeShow).to.have.been.calledOn(this.childView2);
-      expect(this.childView2.onBeforeShow).to.have.been.calledWith(this.childView2);
-    });
-
-    it('onShow should propagate to each child view', function() {
-      expect(this.childView1.onShow).to.have.been.calledOnce;
-      expect(this.childView1.onShow).to.have.been.calledOn(this.childView1);
-      expect(this.childView1.onShow).to.have.been.calledWith(this.childView1);
-      expect(this.childView2.onShow).to.have.been.calledOnce;
-      expect(this.childView2.onShow).to.have.been.calledOn(this.childView2);
-      expect(this.childView2.onShow).to.have.been.calledWith(this.childView2);
     });
   });
 });

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -2,9 +2,18 @@ describe('collection view', function() {
   'use strict';
 
   beforeEach(function() {
+    this.sinon.spy(Backbone, 'View');
+
     // Shared View Definitions
     // -----------------------
-    this.ChildView = Marionette.ItemView.extend({
+    this.ChildView = Backbone.View.extend({
+      tagName: 'span',
+      render: function() {
+        this.$el.html(this.model.get('foo'));
+      }
+    });
+
+    this.MnChildView = Marionette.View.extend({
       tagName: 'span',
       render: function() {
         this.trigger('before:render', this);
@@ -426,6 +435,7 @@ describe('collection view', function() {
 
       this.CollectionView = this.CollectionView.extend({
         emptyView: this.EmptyView,
+        childView: this.MnChildView,
 
         onBeforeRenderEmpty: function() {},
         onRenderEmpty: function() {},
@@ -470,6 +480,7 @@ describe('collection view', function() {
   describe('when a model is removed from the collection', function() {
     beforeEach(function() {
       var CollectionView = this.CollectionView.extend({
+        childView: this.MnChildView,
         onBeforeRemoveChild: this.sinon.stub(),
         onRemoveChild: this.sinon.stub()
       });
@@ -522,6 +533,7 @@ describe('collection view', function() {
   describe('when destroying a collection view', function() {
     beforeEach(function() {
       this.EventedView = this.CollectionView.extend({
+        childView: this.MnChildView,
         someCallback: function() {},
         onBeforeDestroy: function() {
           return {
@@ -1028,7 +1040,7 @@ describe('collection view', function() {
         expect(this.childView3.onDomRefresh)
           .to.have.been.calledOnce
           .and.to.have.been.calledOn(this.childView3)
-          .and.to.have.been.calledWithExactly(); // no args
+          .and.to.have.been.calledWith(this.childView3);
       });
 
       it('should call getChildView with the new model', function() {
@@ -1191,14 +1203,13 @@ describe('collection view', function() {
     });
   });
 
-  describe('has a valid inheritance chain back to Marionette.View', function() {
+  describe('has a valid inheritance chain back to Backbone.View', function() {
     beforeEach(function() {
-      this.constructor = this.sinon.spy(Marionette, 'View');
       this.collectionView = new this.ChildView();
     });
 
-    it('calls the parent Marionette.Views constructor function on instantiation', function() {
-      expect(this.constructor).to.have.been.called;
+    it('calls the parent Backbone.View constructor function on instantiation', function() {
+      expect(Backbone.View).to.have.been.called;
     });
   });
 

--- a/test/unit/on-attach.spec.js
+++ b/test/unit/on-attach.spec.js
@@ -2,6 +2,7 @@ describe('onAttach', function() {
   'use strict';
 
   beforeEach(function() {
+    var spec = this;
 
     // A Region to show our LayoutView within
     this.setFixtures('<div id="region"></div>');
@@ -11,11 +12,31 @@ describe('onAttach', function() {
     // A view we can use as nested child views
     this.BasicView = Marionette.ItemView.extend({
       template: false,
+      constructor: function(options) {
+        Marionette.ItemView.prototype.constructor.call(this, options);
+        spec.sinon.spy(this, 'onAttach');
+        spec.sinon.spy(this, 'onBeforeAttach');
+      },
       onAttach: function() {},
       onBeforeAttach: function() {}
     });
 
-    var spec = this;
+    this.BasicLayoutView = Marionette.LayoutView.extend({
+      template: _.template('<header></header><main></main><footer></footer>'),
+      regions: {
+        header: 'header',
+        main: 'main',
+        footer: 'footer'
+      },
+      constructor: function() {
+        Marionette.LayoutView.prototype.constructor.apply(this, arguments);
+        spec.sinon.spy(this, 'onBeforeAttach');
+        spec.sinon.spy(this, 'onAttach');
+      },
+      onAttach: function() {},
+      onBeforeAttach: function() {}
+    });
+
     this.EmptyView = Marionette.ItemView.extend({
       template: false,
       constructor: function(options) {
@@ -231,29 +252,9 @@ describe('onAttach', function() {
   });
 
   describe('when the parent view is initially detached', function() {
-    beforeEach(function() {
-
-      // A LayoutView class that we can use for all of our tests
-      this.LayoutView = Marionette.LayoutView.extend({
-        template: _.template('<main></main><footer></footer>'),
-        regions: {
-          main: 'main',
-          footer: 'footer'
-        },
-        onBeforeAttach: function() {},
-        onAttach: function() {}
-      });
-    });
-
     describe('When showing a View in a Region', function() {
       beforeEach(function() {
-        this.MyView = Marionette.ItemView.extend({
-          template: _.template(''),
-          onBeforeAttach: this.sinon.stub(),
-          onAttach: this.sinon.stub()
-        });
-
-        this.myView = new this.MyView();
+        this.myView = new this.BasicView();
         this.region.show(this.myView);
       });
 
@@ -275,14 +276,9 @@ describe('onAttach', function() {
         this.mainView = new this.BasicView();
         this.footerView = new this.BasicView();
 
-        this.sinon.spy(this.mainView, 'onAttach');
-        this.sinon.spy(this.mainView, 'onBeforeAttach');
-        this.sinon.spy(this.footerView, 'onAttach');
-        this.sinon.spy(this.footerView, 'onBeforeAttach');
-
         var suite = this;
 
-        this.CustomLayoutView = this.LayoutView.extend({
+        this.CustomLayoutView = this.BasicLayoutView.extend({
           onBeforeShow: function() {
             this.getRegion('main').show(suite.mainView);
             this.getRegion('footer').show(suite.footerView);
@@ -290,8 +286,6 @@ describe('onAttach', function() {
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onAttach');
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
 
         this.region.show(this.layoutView);
       });
@@ -317,14 +311,9 @@ describe('onAttach', function() {
         this.mainView = new this.BasicView();
         this.footerView = new this.BasicView();
 
-        this.sinon.spy(this.mainView, 'onAttach');
-        this.sinon.spy(this.mainView, 'onBeforeAttach');
-        this.sinon.spy(this.footerView, 'onAttach');
-        this.sinon.spy(this.footerView, 'onBeforeAttach');
-
         var suite = this;
 
-        this.CustomLayoutView = this.LayoutView.extend({
+        this.CustomLayoutView = this.BasicLayoutView.extend({
           onBeforeAttach: function() {
             this.getRegion('main').show(suite.mainView);
             this.getRegion('footer').show(suite.footerView);
@@ -332,8 +321,6 @@ describe('onAttach', function() {
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onAttach');
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
 
         this.region.show(this.layoutView);
       });
@@ -358,10 +345,8 @@ describe('onAttach', function() {
       beforeEach(function() {
         var suite = this;
         this.headerView = new this.BasicView();
-        this.sinon.spy(this.headerView, 'onAttach');
-        this.sinon.spy(this.headerView, 'onBeforeAttach');
 
-        this.MainView = this.LayoutView.extend({
+        this.MainView = this.BasicLayoutView.extend({
           template: _.template('<header></header>'),
           regions: {
             header: 'header'
@@ -371,18 +356,14 @@ describe('onAttach', function() {
           }
         });
         this.mainView = new this.MainView();
-        this.sinon.spy(this.mainView, 'onAttach');
-        this.sinon.spy(this.mainView, 'onBeforeAttach');
 
-        this.CustomLayoutView = this.LayoutView.extend({
+        this.CustomLayoutView = this.BasicLayoutView.extend({
           onBeforeShow: function() {
             this.getRegion('main').show(suite.mainView);
           }
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onAttach');
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
 
         this.region.show(this.layoutView);
       });
@@ -407,13 +388,9 @@ describe('onAttach', function() {
       beforeEach(function() {
         var suite = this;
         this.headerView = new this.BasicView();
-        this.sinon.spy(this.headerView, 'onBeforeAttach');
-        this.sinon.spy(this.headerView, 'onAttach');
 
-        this.MainView = Marionette.LayoutView.extend({
+        this.MainView = this.BasicLayoutView.extend({
           template: _.template('<header></header>'),
-          onAttach: this.sinon.stub(),
-          onBeforeAttach: this.sinon.stub(),
           regions: {
             header: 'header'
           },
@@ -423,15 +400,13 @@ describe('onAttach', function() {
         });
         this.mainView = new this.MainView();
 
-        this.CustomLayoutView = this.LayoutView.extend({
+        this.CustomLayoutView = this.BasicLayoutView.extend({
           onBeforeShow: function() {
             this.getRegion('main').show(suite.mainView);
           }
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onAttach');
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
 
         this.region.show(this.layoutView);
       });
@@ -456,31 +431,21 @@ describe('onAttach', function() {
       beforeEach(function() {
         var suite = this;
         this.headerView = new this.BasicView();
-        this.sinon.spy(this.headerView, 'onBeforeAttach');
-        this.sinon.spy(this.headerView, 'onAttach');
 
-        this.MainView = Marionette.LayoutView.extend({
-          template: _.template('<header></header>'),
-          onAttach: this.sinon.stub(),
-          onBeforeAttach: this.sinon.stub(),
-          regions: {
-            header: 'header'
-          },
+        this.MainView = this.BasicLayoutView.extend({
           onBeforeShow: function() {
             this.getRegion('header').show(suite.headerView);
           }
         });
         this.mainView = new this.MainView();
 
-        this.CustomLayoutView = this.LayoutView.extend({
+        this.CustomLayoutView = this.BasicLayoutView.extend({
           onShow: function() {
             this.getRegion('main').show(suite.mainView);
           }
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
-        this.sinon.spy(this.layoutView, 'onAttach');
 
         this.region.show(this.layoutView);
       });
@@ -506,14 +471,9 @@ describe('onAttach', function() {
         this.mainView = new this.BasicView();
         this.footerView = new this.BasicView();
 
-        this.sinon.spy(this.mainView, 'onBeforeAttach');
-        this.sinon.spy(this.mainView, 'onAttach');
-        this.sinon.spy(this.footerView, 'onBeforeAttach');
-        this.sinon.spy(this.footerView, 'onAttach');
-
         var suite = this;
 
-        this.CustomLayoutView = this.LayoutView.extend({
+        this.CustomLayoutView = this.BasicLayoutView.extend({
           onShow: function() {
             this.getRegion('main').show(suite.mainView);
             this.getRegion('footer').show(suite.footerView);
@@ -521,8 +481,6 @@ describe('onAttach', function() {
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
-        this.sinon.spy(this.layoutView, 'onAttach');
 
         this.region.show(this.layoutView);
       });
@@ -549,28 +507,14 @@ describe('onAttach', function() {
       this.setFixtures('<div class="layout-view"></div>');
 
       // A LayoutView class that we can use for all of our tests
-      this.LayoutView = Marionette.LayoutView.extend({
-        el: '.layout-view',
-        template: _.template('<main></main><footer></footer>'),
-        regions: {
-          main: 'main',
-          footer: 'footer'
-        },
-        onAttach: function() {},
-        onBeforeAttach: function() {}
+      this.LayoutView = this.BasicLayoutView.extend({
+        el: '.layout-view'
       });
     });
 
     describe('When showing a View in a Region', function() {
       beforeEach(function() {
-        this.MyView = Marionette.ItemView.extend({
-          el: '.layout-view',
-          template: _.template(''),
-          onBeforeAttach: this.sinon.stub(),
-          onAttach: this.sinon.stub()
-        });
-
-        this.myView = new this.MyView();
+        this.myView = new this.BasicView();
         this.region.show(this.myView);
       });
 
@@ -585,11 +529,6 @@ describe('onAttach', function() {
         this.mainView = new this.BasicView();
         this.footerView = new this.BasicView();
 
-        this.sinon.spy(this.mainView, 'onBeforeAttach');
-        this.sinon.spy(this.mainView, 'onAttach');
-        this.sinon.spy(this.footerView, 'onBeforeAttach');
-        this.sinon.spy(this.footerView, 'onAttach');
-
         var suite = this;
 
         this.CustomLayoutView = this.LayoutView.extend({
@@ -600,8 +539,6 @@ describe('onAttach', function() {
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
-        this.sinon.spy(this.layoutView, 'onAttach');
 
         this.region.show(this.layoutView);
       });
@@ -626,16 +563,8 @@ describe('onAttach', function() {
       beforeEach(function() {
         var suite = this;
         this.headerView = new this.BasicView();
-        this.sinon.spy(this.headerView, 'onBeforeAttach');
-        this.sinon.spy(this.headerView, 'onAttach');
 
-        this.MainView = Marionette.LayoutView.extend({
-          template: _.template('<header></header>'),
-          onAttach: this.sinon.stub(),
-          onBeforeAttach: this.sinon.stub(),
-          regions: {
-            header: 'header'
-          },
+        this.MainView = this.BasicLayoutView.extend({
           onBeforeShow: function() {
             this.getRegion('header').show(suite.headerView);
           }
@@ -649,8 +578,6 @@ describe('onAttach', function() {
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
-        this.sinon.spy(this.layoutView, 'onAttach');
 
         this.region.show(this.layoutView);
       });
@@ -675,16 +602,8 @@ describe('onAttach', function() {
       beforeEach(function() {
         var suite = this;
         this.headerView = new this.BasicView();
-        this.sinon.spy(this.headerView, 'onBeforeAttach');
-        this.sinon.spy(this.headerView, 'onAttach');
 
-        this.MainView = Marionette.LayoutView.extend({
-          template: _.template('<header></header>'),
-          onAttach: this.sinon.stub(),
-          onBeforeAttach: this.sinon.stub(),
-          regions: {
-            header: 'header'
-          },
+        this.MainView = this.BasicLayoutView.extend({
           onShow: function() {
             this.getRegion('header').show(suite.headerView);
           }
@@ -698,8 +617,6 @@ describe('onAttach', function() {
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
-        this.sinon.spy(this.layoutView, 'onAttach');
 
         this.region.show(this.layoutView);
       });
@@ -724,16 +641,8 @@ describe('onAttach', function() {
       beforeEach(function() {
         var suite = this;
         this.headerView = new this.BasicView();
-        this.sinon.spy(this.headerView, 'onBeforeAttach');
-        this.sinon.spy(this.headerView, 'onAttach');
 
-        this.MainView = Marionette.LayoutView.extend({
-          template: _.template('<header></header>'),
-          onAttach: this.sinon.stub(),
-          onBeforeAttach: this.sinon.stub(),
-          regions: {
-            header: 'header'
-          },
+        this.MainView = this.BasicLayoutView.extend({
           onBeforeShow: function() {
             this.getRegion('header').show(suite.headerView);
           }
@@ -747,8 +656,6 @@ describe('onAttach', function() {
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
-        this.sinon.spy(this.layoutView, 'onAttach');
 
         this.region.show(this.layoutView);
       });
@@ -774,11 +681,6 @@ describe('onAttach', function() {
         this.mainView = new this.BasicView();
         this.footerView = new this.BasicView();
 
-        this.sinon.spy(this.mainView, 'onBeforeAttach');
-        this.sinon.spy(this.mainView, 'onAttach');
-        this.sinon.spy(this.footerView, 'onBeforeAttach');
-        this.sinon.spy(this.footerView, 'onAttach');
-
         var suite = this;
 
         this.CustomLayoutView = this.LayoutView.extend({
@@ -789,8 +691,6 @@ describe('onAttach', function() {
         });
 
         this.layoutView = new this.CustomLayoutView();
-        this.sinon.spy(this.layoutView, 'onBeforeAttach');
-        this.sinon.spy(this.layoutView, 'onAttach');
 
         this.region.show(this.layoutView);
       });
@@ -824,12 +724,14 @@ describe('onAttach', function() {
 
     it('should trigger onBeforeAttach and onAttach on the emptyView a single time', function() {
       expect(this.childView).to.be.an.instanceof(this.EmptyView);
-      expect(this.childView.onBeforeAttach).to.have.been.calledOnce;
-      expect(this.childView.onBeforeAttach).to.have.been.calledOn(this.childView);
-      expect(this.childView.onBeforeAttach).to.have.been.calledWith(this.childView);
-      expect(this.childView.onAttach).to.have.been.calledOnce;
-      expect(this.childView.onAttach).to.have.been.calledOn(this.childView);
-      expect(this.childView.onAttach).to.have.been.calledWith(this.childView);
+      expect(this.childView.onBeforeAttach)
+        .and.to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView)
+        .and.to.have.been.calledWith(this.childView);
+      expect(this.childView.onAttach)
+        .and.to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView)
+        .and.to.have.been.calledWith(this.childView);
     });
 
     describe('when adding a new element to the collection', function() {
@@ -839,12 +741,14 @@ describe('onAttach', function() {
       });
       it('should trigger onBeforeAttach and onAttach on the childView a single time', function() {
         expect(this.childView).to.be.an.instanceof(this.ChildView);
-        expect(this.childView.onBeforeAttach).to.have.been.calledOnce;
-        expect(this.childView.onBeforeAttach).to.have.been.calledOn(this.childView);
-        expect(this.childView.onBeforeAttach).to.have.been.calledWith(this.childView);
-        expect(this.childView.onAttach).to.have.been.calledOnce;
-        expect(this.childView.onAttach).to.have.been.calledOn(this.childView);
-        expect(this.childView.onAttach).to.have.been.calledWith(this.childView);
+        expect(this.childView.onBeforeAttach)
+          .and.to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView)
+          .and.to.have.been.calledWith(this.childView);
+        expect(this.childView.onAttach)
+          .and.to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView)
+          .and.to.have.been.calledWith(this.childView);
       });
     });
   });
@@ -863,13 +767,15 @@ describe('onAttach', function() {
 
     it('should not trigger onAttach or onBeforeAttach on the emptyView a single time', function() {
       expect(this.childView).to.be.an.instanceof(this.EmptyView);
-      expect(this.childView.onBeforeAttach).to.not.have.been.calledOnce;
-      expect(this.childView.onBeforeAttach).to.not.have.been.calledOn(this.childView);
-      expect(this.childView.onBeforeAttach).to.not.have.been.calledWith(this.childView);
-      expect(this.childView.onAttach).to.not.have.been.calledOnce;
-      expect(this.childView.onAttach).to.not.have.been.calledOn(this.childView);
-      expect(this.childView.onAttach).to.not.have.been.calledWith(this.childView);
-    });
+      expect(this.childView.onBeforeAttach)
+        .and.to.not.have.been.calledOnce
+        .and.to.not.have.been.calledOn(this.childView)
+        .and.to.not.have.been.calledWith(this.childView);
+      expect(this.childView.onAttach)
+        .and.to.not.have.been.calledOnce
+        .and.to.not.have.been.calledOn(this.childView)
+        .and.to.not.have.been.calledWith(this.childView);
+      });
 
     describe('when adding a new element to the collection', function() {
       beforeEach(function() {
@@ -878,12 +784,14 @@ describe('onAttach', function() {
       });
       it('should not trigger onBeforeAttach or onAttach on the childView a single time', function() {
         expect(this.childView).to.be.an.instanceof(this.ChildView);
-        expect(this.childView.onBeforeAttach).to.not.have.been.calledOnce;
-        expect(this.childView.onBeforeAttach).to.not.have.been.calledOn(this.childView);
-        expect(this.childView.onBeforeAttach).to.not.have.been.calledWith(this.childView);
-        expect(this.childView.onAttach).to.not.have.been.calledOnce;
-        expect(this.childView.onAttach).to.not.have.been.calledOn(this.childView);
-        expect(this.childView.onAttach).to.not.have.been.calledWith(this.childView);
+        expect(this.childView.onBeforeAttach)
+          .and.to.not.have.been.calledOnce
+          .and.to.not.have.been.calledOn(this.childView)
+          .and.to.not.have.been.calledWith(this.childView);
+        expect(this.childView.onAttach)
+          .and.to.not.have.been.calledOnce
+          .and.to.not.have.been.calledOn(this.childView)
+          .and.to.not.have.been.calledWith(this.childView);
       });
     });
   });
@@ -900,18 +808,22 @@ describe('onAttach', function() {
     });
 
     it('should trigger onBeforeAttach and onAttach on each of its childViews a single time', function() {
-      expect(this.childView1.onBeforeAttach).to.have.been.calledOnce;
-      expect(this.childView1.onBeforeAttach).to.have.been.calledOn(this.childView1);
-      expect(this.childView1.onBeforeAttach).to.have.been.calledWith(this.childView1);
-      expect(this.childView1.onAttach).to.have.been.calledOnce;
-      expect(this.childView1.onAttach).to.have.been.calledOn(this.childView1);
-      expect(this.childView1.onAttach).to.have.been.calledWith(this.childView1);
-      expect(this.childView2.onBeforeAttach).to.have.been.calledOnce;
-      expect(this.childView2.onBeforeAttach).to.have.been.calledOn(this.childView2);
-      expect(this.childView2.onBeforeAttach).to.have.been.calledWith(this.childView2);
-      expect(this.childView2.onAttach).to.have.been.calledOnce;
-      expect(this.childView2.onAttach).to.have.been.calledOn(this.childView2);
-      expect(this.childView2.onAttach).to.have.been.calledWith(this.childView2);
+      expect(this.childView1.onBeforeAttach)
+        .and.to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView1)
+        .and.to.have.been.calledWith(this.childView1);
+      expect(this.childView1.onAttach)
+        .and.to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView1)
+        .and.to.have.been.calledWith(this.childView1);
+      expect(this.childView2.onBeforeAttach)
+        .and.to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView2)
+        .and.to.have.been.calledWith(this.childView2);
+      expect(this.childView2.onAttach)
+        .and.to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.childView2)
+        .and.to.have.been.calledWith(this.childView2);
     });
 
     describe('when re-rendering the CollectionView', function() {
@@ -920,18 +832,22 @@ describe('onAttach', function() {
       });
 
       it('should trigger onBeforeAttach and onAttach on each of its childViews a single time', function() {
-        expect(this.childView1.onBeforeAttach).to.have.been.calledOnce;
-        expect(this.childView1.onBeforeAttach).to.have.been.calledOn(this.childView1);
-        expect(this.childView1.onBeforeAttach).to.have.been.calledWith(this.childView1);
-        expect(this.childView1.onAttach).to.have.been.calledOnce;
-        expect(this.childView1.onAttach).to.have.been.calledOn(this.childView1);
-        expect(this.childView1.onAttach).to.have.been.calledWith(this.childView1);
-        expect(this.childView2.onBeforeAttach).to.have.been.calledOnce;
-        expect(this.childView2.onBeforeAttach).to.have.been.calledOn(this.childView2);
-        expect(this.childView2.onBeforeAttach).to.have.been.calledWith(this.childView2);
-        expect(this.childView2.onAttach).to.have.been.calledOnce;
-        expect(this.childView2.onAttach).to.have.been.calledOn(this.childView2);
-        expect(this.childView2.onAttach).to.have.been.calledWith(this.childView2);
+        expect(this.childView1.onBeforeAttach)
+          .and.to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView1)
+          .and.to.have.been.calledWith(this.childView1);
+        expect(this.childView1.onAttach)
+          .and.to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView1)
+          .and.to.have.been.calledWith(this.childView1);
+        expect(this.childView2.onBeforeAttach)
+          .and.to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView2)
+          .and.to.have.been.calledWith(this.childView2);
+        expect(this.childView2.onAttach)
+          .and.to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView2)
+          .and.to.have.been.calledWith(this.childView2);
       });
     });
 
@@ -942,12 +858,14 @@ describe('onAttach', function() {
       });
       it('should trigger onBeforeAttach and onAttach on the emptyView a single time', function() {
         expect(this.childView).to.be.an.instanceof(this.EmptyView);
-        expect(this.childView.onBeforeAttach).to.have.been.calledOnce;
-        expect(this.childView.onBeforeAttach).to.have.been.calledOn(this.childView);
-        expect(this.childView.onBeforeAttach).to.have.been.calledWith(this.childView);
-        expect(this.childView.onAttach).to.have.been.calledOnce;
-        expect(this.childView.onAttach).to.have.been.calledOn(this.childView);
-        expect(this.childView.onAttach).to.have.been.calledWith(this.childView);
+        expect(this.childView.onBeforeAttach)
+          .and.to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView)
+          .and.to.have.been.calledWith(this.childView);
+        expect(this.childView.onAttach)
+          .and.to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.childView)
+          .and.to.have.been.calledWith(this.childView);
       });
     });
   });
@@ -966,18 +884,22 @@ describe('onAttach', function() {
     });
 
     it('should not trigger onBeforeAttach or onAttach on each of its childViews a single time', function() {
-      expect(this.childView1.onBeforeAttach).to.not.have.been.calledOnce;
-      expect(this.childView1.onBeforeAttach).to.not.have.been.calledOn(this.childView1);
-      expect(this.childView1.onBeforeAttach).to.not.have.been.calledWith(this.childView1);
-      expect(this.childView1.onAttach).to.not.have.been.calledOnce;
-      expect(this.childView1.onAttach).to.not.have.been.calledOn(this.childView1);
-      expect(this.childView1.onAttach).to.not.have.been.calledWith(this.childView1);
-      expect(this.childView2.onBeforeAttach).to.not.have.been.calledOnce;
-      expect(this.childView2.onBeforeAttach).to.not.have.been.calledOn(this.childView2);
-      expect(this.childView2.onBeforeAttach).to.not.have.been.calledWith(this.childView2);
-      expect(this.childView2.onAttach).to.not.have.been.calledOnce;
-      expect(this.childView2.onAttach).to.not.have.been.calledOn(this.childView2);
-      expect(this.childView2.onAttach).to.not.have.been.calledWith(this.childView2);
+      expect(this.childView1.onBeforeAttach)
+        .and.to.not.have.been.calledOnce
+        .and.to.not.have.been.calledOn(this.childView1)
+        .and.to.not.have.been.calledWith(this.childView1);
+      expect(this.childView1.onAttach)
+        .and.to.not.have.been.calledOnce
+        .and.to.not.have.been.calledOn(this.childView1)
+        .and.to.not.have.been.calledWith(this.childView1);
+      expect(this.childView2.onBeforeAttach)
+        .and.to.not.have.been.calledOnce
+        .and.to.not.have.been.calledOn(this.childView2)
+        .and.to.not.have.been.calledWith(this.childView2);
+      expect(this.childView2.onAttach)
+        .and.to.not.have.been.calledOnce
+        .and.to.not.have.been.calledOn(this.childView2)
+        .and.to.not.have.been.calledWith(this.childView2);
     });
 
     describe('when re-rendering the CollectionView', function() {
@@ -986,18 +908,22 @@ describe('onAttach', function() {
       });
 
       it('should not trigger onBeforeAttach or onAttach on each of its childViews a single time', function() {
-        expect(this.childView1.onBeforeAttach).to.not.have.been.calledOnce;
-        expect(this.childView1.onBeforeAttach).to.not.have.been.calledOn(this.childView1);
-        expect(this.childView1.onBeforeAttach).to.not.have.been.calledWith(this.childView1);
-        expect(this.childView1.onAttach).to.not.have.been.calledOnce;
-        expect(this.childView1.onAttach).to.not.have.been.calledOn(this.childView1);
-        expect(this.childView1.onAttach).to.not.have.been.calledWith(this.childView1);
-        expect(this.childView2.onBeforeAttach).to.not.have.been.calledOnce;
-        expect(this.childView2.onBeforeAttach).to.not.have.been.calledOn(this.childView2);
-        expect(this.childView2.onBeforeAttach).to.not.have.been.calledWith(this.childView2);
-        expect(this.childView2.onAttach).to.not.have.been.calledOnce;
-        expect(this.childView2.onAttach).to.not.have.been.calledOn(this.childView2);
-        expect(this.childView2.onAttach).to.not.have.been.calledWith(this.childView2);
+        expect(this.childView1.onBeforeAttach)
+          .and.to.not.have.been.calledOnce
+          .and.to.not.have.been.calledOn(this.childView1)
+          .and.to.not.have.been.calledWith(this.childView1);
+        expect(this.childView1.onAttach)
+          .and.to.not.have.been.calledOnce
+          .and.to.not.have.been.calledOn(this.childView1)
+          .and.to.not.have.been.calledWith(this.childView1);
+        expect(this.childView2.onBeforeAttach)
+          .and.to.not.have.been.calledOnce
+          .and.to.not.have.been.calledOn(this.childView2)
+          .and.to.not.have.been.calledWith(this.childView2);
+        expect(this.childView2.onAttach)
+          .and.to.not.have.been.calledOnce
+          .and.to.not.have.been.calledOn(this.childView2)
+          .and.to.not.have.been.calledWith(this.childView2);
       });
     });
 
@@ -1008,12 +934,14 @@ describe('onAttach', function() {
       });
       it('should not trigger onBeforeAttach or onAttach on the emptyView a single time', function() {
         expect(this.childView).to.be.an.instanceof(this.EmptyView);
-        expect(this.childView.onBeforeAttach).to.not.have.been.calledOnce;
-        expect(this.childView.onBeforeAttach).to.not.have.been.calledOn(this.childView);
-        expect(this.childView.onBeforeAttach).to.not.have.been.calledWith(this.childView);
-        expect(this.childView.onAttach).to.not.have.been.calledOnce;
-        expect(this.childView.onAttach).to.not.have.been.calledOn(this.childView);
-        expect(this.childView.onAttach).to.not.have.been.calledWith(this.childView);
+        expect(this.childView.onBeforeAttach)
+          .and.to.not.have.been.calledOnce
+          .and.to.not.have.been.calledOn(this.childView)
+          .and.to.not.have.been.calledWith(this.childView);
+        expect(this.childView.onAttach)
+          .and.to.not.have.been.calledOnce
+          .and.to.not.have.been.calledOn(this.childView)
+          .and.to.not.have.been.calledWith(this.childView);
       });
     });
   });

--- a/test/unit/on-attach.spec.js
+++ b/test/unit/on-attach.spec.js
@@ -10,10 +10,10 @@ describe('onAttach', function() {
     this.region = new Marionette.Region({el: this.el});
 
     // A view we can use as nested child views
-    this.BasicView = Marionette.ItemView.extend({
+    this.BasicView = Backbone.View.extend({
       template: false,
       constructor: function(options) {
-        Marionette.ItemView.prototype.constructor.call(this, options);
+        Backbone.View.prototype.constructor.call(this, options);
         spec.sinon.spy(this, 'onAttach');
         spec.sinon.spy(this, 'onBeforeAttach');
       },
@@ -37,18 +37,18 @@ describe('onAttach', function() {
       onBeforeAttach: function() {}
     });
 
-    this.EmptyView = Marionette.ItemView.extend({
+    this.EmptyView = Backbone.View.extend({
       template: false,
       constructor: function(options) {
-        Marionette.ItemView.prototype.constructor.call(this, options);
+        Backbone.View.prototype.constructor.call(this, options);
         this.onAttach = spec.sinon.stub();
         this.onBeforeAttach = spec.sinon.stub();
       }
     });
-    this.ChildView = Marionette.ItemView.extend({
+    this.ChildView = Backbone.View.extend({
       template: false,
       constructor: function(options) {
-        Marionette.ItemView.prototype.constructor.call(this, options);
+        Backbone.View.prototype.constructor.call(this, options);
         this.onAttach = spec.sinon.stub();
         this.onBeforeAttach = spec.sinon.stub();
       }
@@ -775,7 +775,7 @@ describe('onAttach', function() {
         .and.to.not.have.been.calledOnce
         .and.to.not.have.been.calledOn(this.childView)
         .and.to.not.have.been.calledWith(this.childView);
-      });
+    });
 
     describe('when adding a new element to the collection', function() {
       beforeEach(function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -60,7 +60,7 @@ describe('region', function() {
         el: '#not-existed-region'
       });
 
-      this.MyView = Backbone.Marionette.View.extend({
+      this.MyView = Backbone.View.extend({
         render: function() {
           $(this.el).html('some content');
         }
@@ -472,7 +472,7 @@ describe('region', function() {
         }
       });
 
-      this.SubView = Backbone.Marionette.ItemView.extend({
+      this.SubView = Backbone.View.extend({
         render: function() {
           $(this.el).html('some content');
         },
@@ -618,7 +618,7 @@ describe('region', function() {
     });
   });
 
-  describe('when a view is already shown but destroyed externally', function() {
+  describe('when a Mn view is already shown but destroyed externally', function() {
     beforeEach(function() {
       this.MyRegion = Backbone.Marionette.Region.extend({
         el: '#region'
@@ -1011,7 +1011,7 @@ describe('region', function() {
     });
   });
 
-  describe('when destroying a view in a region', function() {
+  describe('when destroying a Mn view in a region', function() {
     beforeEach(function() {
       this.setFixtures('<div id="region"></div>');
       this.beforeEmptySpy = new sinon.spy();
@@ -1070,6 +1070,50 @@ describe('region', function() {
     it('should throw an error', function() {
       var errorMessage = 'The view passed is undefined and therefore invalid. You must pass a view instance to show.';
       expect(this.insertUndefined).to.throw(errorMessage);
+    });
+  });
+
+  describe('when showing a Backbone.View child view', function() {
+    beforeEach(function() {
+      var BbView = Backbone.View.extend({
+        onBeforeRender: this.sinon.stub(),
+        onRender: this.sinon.stub(),
+        onBeforeDestroy: this.sinon.stub(),
+        onDestroy: this.sinon.stub()
+      });
+      this.region = new Marionette.Region({
+        el: $('<div></div>')
+      });
+      this.view = new BbView();
+      this.region.show(this.view);
+    });
+
+    it('should fire before:render and render on the child view on show', function() {
+      expect(this.view.onBeforeRender)
+        .to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.view)
+        .and.to.have.been.calledWith(this.view);
+      expect(this.view.onRender)
+        .to.have.been.calledOnce
+        .and.to.have.been.calledOn(this.view)
+        .and.to.have.been.calledWith(this.view);
+    });
+
+    describe('when emptying while containing the Backbone.View', function() {
+      beforeEach(function() {
+        this.region.empty();
+      });
+
+      it('should fire before:destroy and destroy on the child view on show', function() {
+        expect(this.view.onBeforeDestroy)
+          .to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.view)
+          .and.to.have.been.calledWith(this.view);
+        expect(this.view.onDestroy)
+          .to.have.been.calledOnce
+          .and.to.have.been.calledOn(this.view)
+          .and.to.have.been.calledWith(this.view);
+      });
     });
   });
 });


### PR DESCRIPTION
**This PR**

1. Cleans up collection-view and on-attach specs.
2. Significantly improves Backbone View child view test coverage (fixes #2657).  Moving child views to Backbone.View in `collection-view.spec.js` and `on-attach.spec.js` broke a handful of existing tests.
3. Fixes #2651.
4. Adds support for `before:render`, `render`, `before:destroy`, `destroy`, and `dom:refresh` view lifecycle events specifically for Backbone.View child views of Regions (and therefore LayoutViews) and CollectionViews.  This _completely fixed_ the broken tests in **(2)** above.

**Thoughts on better testing**

To improve on testing the Backbone View child view case, I converted `collection-view.spec.js` and `on-attach.spec.js` to use Backbone View child views by default.  I imagine this approach can be carried forward to future test cases and backward to any other existing child view test cases.

**Note on dom:refresh support for Backbone.View**

I had to add a flag `_isDomRefreshMonitored` to views within `Marionette.MonitorDOMRefresh` in order to gain `dom:refresh` from Backbone.Views shown by `Region#show` (see [Region#show commit diff](https://github.com/ianmstew/backbone.marionette/commit/730914c6087351f4214a4e7d5ec2957c135578b6#diff-b8da5292cb07ec757ac64e78ff5af5c1R204)).  Please let me know if anyone disapproves.