### PR TITLE
Make TemplateCache.loadTemplate() work for empty templates (fixes #2347)

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -11,7 +11,7 @@ Marionette.Application = Marionette.Object.extend({
     this.submodules = {};
     _.extend(this, options);
     this._initChannel();
-    Marionette.Object.call(this, options);
+    Marionette.Object.apply(this, arguments);
   },
 
   // Command execution, facilitated by Backbone.Wreqr.Commands

--- a/src/template-cache.js
+++ b/src/template-cache.js
@@ -74,16 +74,15 @@ _.extend(Marionette.TemplateCache.prototype, {
   // using a template-loader plugin as described here:
   // https://github.com/marionettejs/backbone.marionette/wiki/Using-marionette-with-requirejs
   loadTemplate: function(templateId, options) {
-    var template = Backbone.$(templateId).html();
+    var $template = Backbone.$(templateId);
 
-    if (!template || template.length === 0) {
+    if (!$template.length) {
       throw new Marionette.Error({
         name: 'NoTemplateError',
         message: 'Could not find template: "' + templateId + '"'
       });
     }
-
-    return template;
+    return $template.html();
   },
 
   // Pre-compile the template before caching it. Override

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -82,11 +82,17 @@ describe('marionette application', function() {
   describe('when instantiating an app with options specified', function() {
     beforeEach(function() {
       this.fooOption = 'bar';
-      this.app = new Marionette.Application({fooOption: this.fooOption});
+      this.appOptions = {fooOption: this.fooOption};
+      this.initializeStub = this.sinon.stub(Marionette.Application.prototype, 'initialize');
+      this.app = new Marionette.Application(this.appOptions, 'fooArg');
     });
 
     it('should merge those options into the app', function() {
       expect(this.app.fooOption).to.equal(this.fooOption);
+    });
+
+    it('should pass all arguments to the initialize method', function() {
+      expect(this.initializeStub).to.have.been.calledOn(this.app).and.calledWith(this.appOptions, 'fooArg');
     });
   });
 

--- a/test/unit/renderer.spec.js
+++ b/test/unit/renderer.spec.js
@@ -38,6 +38,22 @@ describe('renderer', function() {
     });
   });
 
+  describe('when given an empty template to render', function() {
+    beforeEach(function() {
+      this.setFixtures('<script type="text/template" id="renderer-empty-template"></script>');
+      this.templateSelector = '#renderer-empty-template';
+      this.result = Marionette.Renderer.render(this.templateSelector).trim();
+    });
+
+    it('should retrieve the template from the cache', function() {
+      expect(this.templateCacheSpy).to.have.been.calledWith(this.templateSelector);
+    });
+
+    it('should render the template', function() {
+      expect(this.result).to.equal('');
+    });
+  });
+
   describe('when no template is provided', function() {
     beforeEach(function() {
       this.render = _.bind(Marionette.Renderer.render, Marionette.Renderer);


### PR DESCRIPTION
opened in favour of #2646 