### PR TITLE
`attachView` triggers events on parent view

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -251,6 +251,10 @@ Marionette.Region = Marionette.Object.extend({
   // and will not replace the current HTML for the `el`
   // of the region.
   attachView: function(view) {
+    if (this.currentView) {
+      delete this.currentView._parent;
+    }
+    view._parent = this;
     this.currentView = view;
     return this;
   },


### PR DESCRIPTION
Fixes #2568

This was a bit tricky for me to understand so I kept old commits in case anybody also wants to compare `show` and `attachView` behavior. Will squash after :eyes: