### PR TITLE
Expose `originalEvent` to trigger handler args

### DIFF
--- a/docs/marionette.abstractview.md
+++ b/docs/marionette.abstractview.md
@@ -282,8 +282,11 @@ includes the following:
 * view
 * model
 * collection
+* originalEvent
 
-These properties match the `view`, `model`, and `collection` properties of the view that triggered the event.
+The first three properties match the `view`, `model`, and `collection`
+properties of the view that triggered the event, whereas `originalEvent`
+is a reference to the DOM event that was initially triggered on the view.
 
 ```js
 var MyView = Marionette.View.extend({
@@ -300,6 +303,7 @@ view.on("some:event", function(args){
   args.view; // => the view instance that triggered the event
   args.model; // => the view.model, if one was set on the view
   args.collection; // => the view.collection, if one was set on the view
+  args.originalEvent; // => the click event that was triggered on the view
 });
 ```
 

--- a/src/abstract-view.js
+++ b/src/abstract-view.js
@@ -254,7 +254,15 @@ Marionette.AbstractView = Backbone.View.extend({
     var eventName = hasOptions ? options.event : triggerDef;
 
     return function(e) {
+      var args = {
+        view: this,
+        model: this.model,
+        collection: this.collection
+      };
+
       if (e) {
+        args.originalEvent = e;
+
         if (e.preventDefault && options.preventDefault) {
           e.preventDefault();
         }
@@ -263,12 +271,6 @@ Marionette.AbstractView = Backbone.View.extend({
           e.stopPropagation();
         }
       }
-
-      var args = {
-        view: this,
-        model: this.model,
-        collection: this.collection
-      };
 
       this.triggerMethod(eventName, args);
     };

--- a/test/unit/view.triggers.spec.js
+++ b/test/unit/view.triggers.spec.js
@@ -42,6 +42,10 @@ describe('view triggers', function() {
     it('should include the views collection in the event args', function() {
       expect(this.fooHandlerStub.lastCall.args[0]).to.contain({collection: this.collection});
     });
+
+    it('should include the original event in the event args', function() {
+      expect(this.fooHandlerStub.lastCall.args[0]).to.contain({originalEvent: this.fooEvent});
+    });
   });
 
   describe('when triggers and standard events are both configured', function() {


### PR DESCRIPTION
Fixes #2677

This is a minor change to `AbstractView#_buildViewTrigger`, which allows
access to the DOM event that was triggered on the view. This is useful
when you need to access properties of the event that would not otherwise
be available on just the `view` instance.