### PR TITLE
Modify how views execute the View constructor to better allow monkey patching

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -25,7 +25,7 @@ Marionette.CollectionView = Marionette.View.extend({
     this.once('render', this._initialEvents);
     this._initChildViewStorage();
 
-    Marionette.View.apply(this, arguments);
+    Marionette.View.prototype.constructor.apply(this, arguments);
 
     this.on({
       'before:show':   this._onBeforeShowCalled,

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -14,7 +14,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
   // maintaining the sorted order of the collection.
   // This will fallback onto appending childView's to the end.
   constructor: function() {
-    Marionette.CollectionView.apply(this, arguments);
+    Marionette.CollectionView.prototype.constructor.apply(this, arguments);
   },
 
   // Configured the initial events that the composite view

--- a/src/item-view.js
+++ b/src/item-view.js
@@ -9,7 +9,7 @@ Marionette.ItemView = Marionette.View.extend({
   // Setting up the inheritance chain which allows changes to
   // Marionette.View.prototype.constructor which allows overriding
   constructor: function() {
-    Marionette.View.apply(this, arguments);
+    Marionette.View.prototype.constructor.apply(this, arguments);
   },
 
   // Serialize the model or collection for the view. If a model is

--- a/src/layout-view.js
+++ b/src/layout-view.js
@@ -26,7 +26,7 @@ Marionette.LayoutView = Marionette.ItemView.extend({
     this._firstRender = true;
     this._initializeRegions(options);
 
-    Marionette.ItemView.call(this, options);
+    Marionette.ItemView.prototype.constructor.call(this, options);
   },
 
   // LayoutView's render will use the existing region objects the

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -1206,7 +1206,7 @@ describe('collection view', function() {
 
   describe('has a valid inheritance chain back to Marionette.View', function() {
     beforeEach(function() {
-      this.constructor = this.sinon.spy(Marionette, 'View');
+      this.constructor = this.sinon.spy(Marionette.View.prototype, 'constructor');
       this.collectionView = new Marionette.CollectionView();
     });
 

--- a/test/unit/composite-view.spec.js
+++ b/test/unit/composite-view.spec.js
@@ -828,7 +828,7 @@ describe('composite view', function() {
 
   describe('has a valid inheritance chain back to Marionette.CollectionView', function() {
     beforeEach(function() {
-      this.constructor = this.sinon.spy(Marionette, 'CollectionView');
+      this.constructor = this.sinon.spy(Marionette.CollectionView.prototype, 'constructor');
       this.compositeView = new Marionette.CompositeView();
     });
 

--- a/test/unit/item-view.spec.js
+++ b/test/unit/item-view.spec.js
@@ -323,7 +323,7 @@ describe('item view', function() {
 
   describe('has a valid inheritance chain back to Marionette.View', function() {
     beforeEach(function() {
-      this.constructorSpy = this.sinon.spy(Marionette, 'View');
+      this.constructorSpy = this.sinon.spy(Marionette.View.prototype, 'constructor');
       this.itemView = new Marionette.ItemView();
     });
 
@@ -420,7 +420,7 @@ describe('item view', function() {
 
   describe('has a valid inheritance chain back to Marionette.View', function() {
     beforeEach(function() {
-      this.constructor = this.sinon.spy(Marionette, 'View');
+      this.constructor = this.sinon.spy(Marionette.View.prototype, 'constructor');
       this.collectionView = new Marionette.ItemView();
     });
 

--- a/test/unit/layout-view.spec.js
+++ b/test/unit/layout-view.spec.js
@@ -408,7 +408,7 @@ describe('layoutView', function() {
 
   describe('has a valid inheritance chain back to Marionette.View', function() {
     beforeEach(function() {
-      this.constructor = this.sinon.spy(Marionette, 'View');
+      this.constructor = this.sinon.spy(Marionette.View.prototype, 'constructor');
       this.layoutView = new Marionette.LayoutView();
     });
 


### PR DESCRIPTION
In my app I wanted to add some custom code to all views as follows:

```javascript
Marionette.View.prototype.constructor = (function (original) {
	return function () {
		// Do some custom thing to all views before executing original constructor
		// ...
		original.apply(this, arguments);
	};
})(Marionette.View.prototype.constructor);
```

Without the changes in this pull request the monkey patched function doesn't get executed.