### PR TITLE
Improved childEvents docs

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -213,16 +213,16 @@ in the constructor function call, to get a view instance.
 
 ### CollectionView's `childEvents`
 
-You can specify a `childEvents` hash or method which allows you to capture all bubbling childEvents without having to manually set bindings. The keys of the hash can either be a function or a string that is the name of a method on the collection view.
+A `childEvents` hash or method permits handling of child view events without manually setting bindings. The values of the hash can either be a function or a string method name on the collection view.
 
 ```js
 // childEvents can be specified as a hash...
 var MyCollectionView = Marionette.CollectionView.extend({
 
-  // This callback will be called whenever a child is rendered or emits a `render` event
   childEvents: {
+    // This callback will be called whenever a child is rendered or emits a `render` event
     render: function() {
-      console.log("a childView has been rendered");
+      console.log('A child view has been rendered.');
     }
   }
 });
@@ -234,33 +234,53 @@ var MyCollectionView = Marionette.CollectionView.extend({
     return {
       render: this.onChildRendered
     }
+  },
+
+  onChildRendered: function () {
+    console.log('A child view has been rendered.');
+  }
 });
 ```
 
-This also works for custom events that you might fire on your child views.
+`childEvents` also catches custom events fired by a child view.  Take note that the first argument to a `childEvents` handler is the child view itself.
 
 ```js
 // The child view fires a custom event, `show:message`
 var ChildView = Marionette.ItemView.extend({
+
+  // Events hash defines local event handlers that in turn may call `triggerMethod`.
   events: {
-    'click .button': 'showMessage'
+    'click .button': 'onClickButton'
   },
 
-  showMessage: function () {
-    console.log('The button was clicked.');
+  // Triggers hash converts DOM events directly to view events catchable on the parent.
+  triggers: {
+    'submit form': 'submit:form'
+  },
 
-    this.triggerMethod('show:message');
+  onClickButton: function () {
+    // Both `trigger` and `triggerMethod` events will be caught by parent.
+    this.trigger('show:message', 'foo');
+    this.triggerMethod('show:message', 'bar');
   }
 });
 
-// The parent uses childEvents to catch that custom event on the child view
+// The parent uses childEvents to catch the child view's custom event
 var ParentView = Marionette.CollectionView.extend({
+
   childView: ChildView,
 
   childEvents: {
-    'show:message': function () {
-      console.log('The show:message event bubbled up to the parent.');
-    }
+    'show:message': 'onChildShowMessage',
+    'submit:form': 'onChildSubmit'
+  },
+
+  onChildShowMessage: function (childView, message) {
+    console.log('A child view fired show:message with ' + message);
+  },
+
+  onChildSubmitForm: function (childView) {
+    console.log('A child view fired submit:form');
   }
 });
 ```

--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -105,73 +105,71 @@ new Marionette.LayoutView({
 
 ### LayoutView childEvents
 
-You can specify a `childEvents` hash or method which allows you to capture all
-bubbling `childEvents` without having to manually set bindings.
-
-The keys of the hash can either be a function or a string
-that is the name of a method on the layout view.
-
-The function is called in the context of the view. The first parameter is
-the child view, which emitted the event, the remainder are the arguments
-associated with the event.
+A `childEvents` hash or method permits handling of child view events without manually setting bindings. The values of the hash can either be a function or a string method name on the collection view.
 
 ```js
 // childEvents can be specified as a hash...
-var MyLayoutView = Marionette.LayoutView.extend({
+var MyCollectionView = Marionette.CollectionView.extend({
 
-  // This callback will be called whenever a child is rendered or emits a `render` event
   childEvents: {
-    render: function(childView) {
-      console.log("a childView has been rendered");
+    // This callback will be called whenever a child is rendered or emits a `render` event
+    render: function() {
+      console.log('A child view has been rendered.');
     }
   }
 });
 
 // ...or as a function that returns a hash.
-var MyLayoutView = Marionette.LayoutView.extend({
+var MyCollectionView = Marionette.CollectionView.extend({
 
   childEvents: function() {
     return {
-      render: this.onChildRender
+      render: this.onChildRendered
     }
   },
 
-  onChildRender: function(childView) {
+  onChildRendered: function () {
+    console.log('A child view has been rendered.');
   }
 });
 ```
 
-This also works for custom events that you might fire on your child views.
+`childEvents` also catches custom events fired by a child view.  Take note that the first argument to a `childEvents` handler is the child view itself.  Caution: Events triggered on the child view through the `triggers` hash or `this.trigger` are not yet supported for LayoutView `childEvents`.  Use strictly `triggerMethod` within the child view.
 
 ```js
-  // The child view fires a custom event, `show:message`
-  var ChildView = new Marionette.ItemView.extend({
-    events: {
-      'click .button': 'showMessage'
-    },
+// The child view fires a custom event, `show:message`
+var ChildView = Marionette.ItemView.extend({
 
-    showMessage: function (e) {
-      console.log('The button was clicked.');
-      this.triggerMethod('show:message', msg);
-    }
-  });
+  // Events hash defines local event handlers that in turn may call `triggerMethod`.
+  events: {
+    'click .button': 'onClickButton',
+    'submit form': function () { this.triggerMethod('submit:form'); }
+  },
 
-  // The parent uses childEvents to catch that custom event on the child view
-  var ParentView = new Marionette.LayoutView.extend({
-    childEvents: {
-      'show:message': function (childView, msg) {
-        console.log('The show:message event bubbled up to the parent.');
-      }
-    },
+  onClickButton: function () {
+    this.triggerMethod('show:message', 'foo');
+  }
+});
 
-    // Alternatively we can use the trigger notation with childview: as the
-    // prefix
-    onChildviewShowMessage: function (childView, msg) {
-      console.log('The show:message event bubbled up to the parent.');
-    }
-  });
+// The parent uses childEvents to catch that custom event on the child view
+var ParentView = Marionette.CollectionView.extend({
+
+  childView: ChildView,
+
+  childEvents: {
+    'show:message': 'onChildShowMessage',
+    'submit:form': 'onChildSubmit'
+  },
+
+  onChildShowMessage: function (childView, message) {
+    console.log('A child view fired show:message with ' + message);
+  },
+
+  onChildSubmitForm: function (childView) {
+    console.log('A child view fired submit:form');
+  }
+});
 ```
-
 
 ### Specifying Regions As A Function
 


### PR DESCRIPTION
Aims to fix #2531 through clearer examples rather than a "hey, don't do this" warning (unless someone prefers to have that warning).  I also made it clearer the first argument of a childView event is the child view and took note that LayoutView only supports child view events triggered with `triggerMethod`.

Side note: this very much highlights the need for #2464 resolution.