### PR TITLE
Update marionette.collectionview.md

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -127,7 +127,9 @@ var MyCollectionView = Marionette.CollectionView.extend({
   }
 });
 
-var collectionView = new MyCollectionView();
+var collectionView = new MyCollectionView({
+  collection: new Backbone.Collection();
+});
 var foo = new FooBar({
   isFoo: true
 });


### PR DESCRIPTION
It concerns the 'getChildView' section.
The example is not working if no collection is linked to the collectionView. 
collectionView.collection is undefined and therefore, at the last line, collectionView.collection.add fails. 
Instead,  if a new empty Backbone.Collection is specified, the example is working properly.