### PR TITLE
Fix pathname for tests in gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,7 +112,7 @@ module.exports = function(grunt) {
     },
 
     instrument: {
-      files: 'src/*.js',
+      files: 'src/**/*.js',
       options: {
         lazy: true,
         basePath: 'test'


### PR DESCRIPTION
This is a submission towards dealing with https://github.com/marionettejs/backbone.marionette/issues/2715. I noticed that `grunt coverage` still fails with:

>Running "coveralls:default" (coveralls) task
>[warn] "2015-08-30T22:00:20.051Z"  'Repo token could not be determined.  Continuing without it.'
>\>\> Failed to submit coverage results to coveralls
>Warning: Task "coveralls:default" failed. Use --force to continue.
>
>Aborted due to warnings.

But I think this might be because I am not running grunt as travisci.