### PR TITLE
Simplify _renderTemplate

### DIFF
--- a/api/abstract-view.yaml
+++ b/api/abstract-view.yaml
@@ -16,6 +16,9 @@ functions:
   getTemplate: |
     @api public
     
+  _renderTemplate: |
+    @api private
+
   serializeModel: |
     @api public
     @param {} model

--- a/api/composite-view.yaml
+++ b/api/composite-view.yaml
@@ -54,17 +54,8 @@ functions:
   _renderChildren:
     description: |
       ...
-      
-      @api private
 
-    examples:
-      
-  _renderTemplate:
-    description: |
-      ...
-      
       @api private
-      @param {} html
 
     examples:
       

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -230,8 +230,6 @@ During the course of rendering a composite, several events will
 be triggered. These events are triggered with the [Marionette.triggerMethod](./marionette.functions.md#marionettetriggermethod)
 function, which calls a corresponding "on{EventName}" method on the view.
 
-* "before:render:template" / `onBeforeRenderTemplate` - before the `model` has been rendered
-* "render:template" / `onRenderTemplate` - after the `model` has been rendered
 * "before:render:collection" / `onBeforeRenderCollection` - before the collection of models is rendered
 * "render:collection" / `onRenderCollection` - after the collection of models has been rendered
 * "before:render" / `onBeforeRender` - before anything has been rendered

--- a/src/abstract-view.js
+++ b/src/abstract-view.js
@@ -37,6 +37,24 @@ Marionette.AbstractView = Backbone.View.extend({
     return this.getOption('template');
   },
 
+  // Internal method to render the template with the serialized data
+  // and template helpers via the `Marionette.Renderer` object.
+  _renderTemplate: function() {
+    var template = this.getTemplate();
+
+    // Allow template-less views
+    if (template === false) {
+      return;
+    }
+
+    // Add in entity data and template helpers
+    var data = this.mixinTemplateHelpers(this.serializeData());
+
+    // Render and add to el
+    var html = Marionette.Renderer.render(template, data, this);
+    this.attachElContent(html);
+  },
+
   // Prepares the special `model` property of a view
   // for being displayed in the template. By default
   // we simply clone the attributes. Override this if

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -77,6 +77,7 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     this.triggerMethod('before:render', this);
 
     this._renderTemplate();
+    this.bindUIElements();
     this._renderChildren();
 
     this._isRendering = false;
@@ -91,26 +92,6 @@ Marionette.CompositeView = Marionette.CollectionView.extend({
     }
   },
 
-  // Render the root template that the children
-  // views are appended to
-  _renderTemplate: function() {
-    this.triggerMethod('before:render:template');
-    var template = this.getTemplate();
-
-    // Allow template-less composite views
-    if (template !== false) {
-      var data = this.mixinTemplateHelpers(this.serializeData());
-
-      var html = Marionette.Renderer.render(template, data, this);
-      this.attachElContent(html);
-    }
-
-    // the ui bindings is done here and not at the end of render since they
-    // will not be available until after the model is rendered, but should be
-    // available before the collection is rendered.
-    this.bindUIElements();
-    this.triggerMethod('render:template');
-  },
   // Attaches the content of the root.
   // This method can be overridden to optimize rendering,
   // or to render in a non standard way.

--- a/src/view.js
+++ b/src/view.js
@@ -89,26 +89,6 @@ Marionette.View = Marionette.AbstractView.extend({
     return this;
   },
 
-  // Internal method to render the template with the serialized data
-  // and template helpers via the `Marionette.Renderer` object.
-  _renderTemplate: function() {
-    var template = this.getTemplate();
-
-    // Allow template-less item views
-    if (template === false) {
-      return;
-    }
-
-    // Add in entity data and template helpers
-    var data = this.mixinTemplateHelpers(this.serializeData());
-
-    // Render and add to el
-    var html = Marionette.Renderer.render(template, data, this);
-    this.attachElContent(html);
-
-    return this;
-  },
-
   // Attaches the content of a given view.
   // This method can be overridden to optimize rendering,
   // or to render in a non standard way.


### PR DESCRIPTION
While researching the renderer I found _renderTemplate to be nearly identical between View and CompositeView with a couple of exceptions.
CompositeView's triggered events and called `bindUIElements` within it instead of in the render to ensure it was called before the children were rendered.

In this PR:
- I removed the events CompositeView was triggering.  I can't think of a use case where this event cannot be handled by either `before:render` or `before:render:collection` so I don't think there's reason to muddy up the event space.  _If_ someone is against their removal they can be added around a `Marionette.CollectionView.prototype._renderRemplate.call(this);`

- Then I moved `bindUIElements` up into the render between `_renderTemplate` and `_renderChildren`  It is called in the same place, resembles the regular view.render more and is enforced by tests.

- Additionally since the `_renderTemplate` was now the same I moved it into the `AbstractView`.  This will mean that `CollectionView` will now get this unused function, but it does make some things cleaner and might be moot if/when CompositeView is part of the `CollectionView`.