### PR TITLE
Rename `render:collection` => `render:children

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -49,7 +49,7 @@ will provide features such as `onShow` callbacks, etc. Please see
   * ["before:apply:filter" / "apply:filter" event](#beforeapplyfilter--applyfilter-event)
   * ["before:reorder" / "reorder" event](#beforereorder--reorder-event)
   * ["before:destroy" event](#beforedestroy-event)
-  * ["destroy" / "destroy:collection" event](#destroy--destroycollection-event)
+  * ["destroy" / "destroy:childen" event](#destroy--destroychildren-event)
   * ["before:add:child" / "add:child" event](#beforeaddchild--addchild-event)
   * ["before:remove:child event](#beforeremovechild-event)
   * ["remove:child" event](#removechild-event)
@@ -700,22 +700,22 @@ myCol.sort()
 
 ### "before:destroy" event
 
-Triggered just before destroying the view. A "before:destroy:collection" /
-`onBeforeDestroyCollection` event will also be fired
+Triggered just before destroying the view. A "before:destroy:childen" /
+`onBeforeDestroyChildren` event will also be fired
 
 ```js
 var MyView = Marionette.CollectionView.extend({...});
 
 var myView = new MyView();
 
-myView.on("before:destroy:collection", function(){
+myView.on("before:destroy:childen", function(){
   alert("the collection view is about to be destroyed");
 });
 
 myView.destroy();
 ```
 
-### "destroy" / "destroy:collection" event
+### "destroy" / "destroy:childen" event
 
 Triggered just after destroying the view, both with corresponding
 method calls.
@@ -725,7 +725,7 @@ var MyView = Marionette.CollectionView.extend({...});
 
 var myView = new MyView();
 
-myView.on("destroy:collection", function(){
+myView.on("destroy:childen", function(){
   alert("the collection view is now destroyed");
 });
 

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -54,8 +54,8 @@ will provide features such as `onShow` callbacks, etc. Please see
   * ["before:remove:child event](#beforeremovechild-event)
   * ["remove:child" event](#removechild-event)
   * ["childview:\*" event bubbling from child views](#childview-event-bubbling-from-child-views)
-  * ["before:render:collection" event](#beforerendercollection-event)
-  * ["render:collection" event](#rendercollection-event)
+  * ["before:render:children" event](#beforerenderchildren-event)
+  * ["render:children" event](#renderchildren-event)
   * ["before:render:empty" event](#beforerenderempty-event)
   * ["render:empty" event](#renderempty-event)
   * ["before:remove:empty" event](#beforeremoveempty-event)
@@ -609,7 +609,7 @@ view instance (see [above](#callback-methods)).
 
 
 Triggers just prior to the view being rendered. Also triggered as
-"collection:before:render" / `onCollectionBeforeRender`.
+"before:render:children" / `onBeforeRenderChildren`.
 
 ```js
 var MyView = Marionette.CollectionView.extend({...});
@@ -625,7 +625,7 @@ myView.render();
 
 ### "render" event
 
-A "render:collection" / `onRenderCollection` event will also be fired. This allows you to
+A "render:children" / `onRenderChildren` event will also be fired. This allows you to
 add more than one callback to execute after the view is rendered,
 and allows parent views and other parts of the application to
 know that the view was rendered.
@@ -639,7 +639,7 @@ myView.on("render", function(){
   alert("the collection view was rendered!");
 });
 
-myView.on("collection:rendered", function(){
+myView.on("render:children", function(){
   alert("the collection view was rendered!");
 });
 
@@ -829,13 +829,13 @@ will appear that says: I said, 'do something!'
 It's also possible to attach the event manually using the usual
 `view.on('childview:do:something')`.
 
-### before:render:collection event
+### before:render:children event
 
-The `before:render:collection` event is triggered before the `collectionView`'s children have been rendered and buffered. It differs from the `collectionsView`'s `before:render` in that it is __only__ emitted if the `collection` is not empty.
+The `before:render:children` event is triggered before the `collectionView`'s children have been rendered and buffered. It differs from the `collectionsView`'s `before:render` in that it is __only__ emitted if the `collection` is not empty.
 
-### render:collection event
+### render:children event
 
-The `render:collection` event is triggered after a `collectionView`'s children have been rendered and buffered. It differs from the `collectionViews`'s `render` event in that it happens __only__ if the `collection` is not not empty.
+The `render:children` event is triggered after a `collectionView`'s children have been rendered and buffered. It differs from the `collectionViews`'s `render` event in that it happens __only__ if the `collection` is not not empty.
 
 ### "before:render:empty" event
 

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -230,8 +230,8 @@ During the course of rendering a composite, several events will
 be triggered. These events are triggered with the [Marionette.triggerMethod](./marionette.functions.md#marionettetriggermethod)
 function, which calls a corresponding "on{EventName}" method on the view.
 
-* "before:render:collection" / `onBeforeRenderCollection` - before the collection of models is rendered
-* "render:collection" / `onRenderCollection` - after the collection of models has been rendered
+* "before:render:children" / `onBeforeRenderChildren` - before the collection of models is rendered
+* "render:children" / `onRenderChildren` - after the collection of models has been rendered
 * "before:render" / `onBeforeRender` - before anything has been rendered
 * "render" / `onRender` - after everything has been rendered
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -633,9 +633,9 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
   destroy: function() {
     if (this._isDestroyed) { return this; }
 
-    this.triggerMethod('before:destroy:collection');
+    this.triggerMethod('before:destroy:children');
     this.destroyChildren({checkEmpty: false});
-    this.triggerMethod('destroy:collection');
+    this.triggerMethod('destroy:children');
 
     return Marionette.AbstractView.prototype.destroy.apply(this, arguments);
   },

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -277,11 +277,11 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     if (this.isEmpty(this.collection, {processedModels: models})) {
       this.showEmptyView();
     } else {
-      this.triggerMethod('before:render:collection', this);
+      this.triggerMethod('before:render:children', this);
       this.startBuffering();
       this.showCollection(models);
       this.endBuffering();
-      this.triggerMethod('render:collection', this);
+      this.triggerMethod('render:children', this);
     }
   },
 

--- a/test/unit/collection-view.filter.spec.js
+++ b/test/unit/collection-view.filter.spec.js
@@ -35,8 +35,8 @@ describe('collection view - filter', function() {
       collection: this.collection,
       onBeforeRemoveChild: this.sinon.stub(),
       onRemoveChild: this.sinon.stub(),
-      onBeforeRenderCollection: this.sinon.stub(),
-      onRenderCollection: this.sinon.stub()
+      onBeforeRenderChildren: this.sinon.stub(),
+      onRenderChildren: this.sinon.stub()
     });
   });
 
@@ -166,8 +166,8 @@ describe('collection view - filter', function() {
         this.filter.reset();
         this.newFailModel = this.failModel.clone();
         this.sinon.spy(this.collectionView, 'showEmptyView');
-        this.collectionView.onBeforeRenderCollection.reset();
-        this.collectionView.onRenderCollection.reset();
+        this.collectionView.onBeforeRenderChildren.reset();
+        this.collectionView.onRenderChildren.reset();
         this.collection.reset([this.newFailModel]);
       });
 
@@ -184,12 +184,12 @@ describe('collection view - filter', function() {
         expect(this.collectionView.$el).to.contain.$text('empty');
       });
 
-      it('should not call onBeforeRenderCollection', function() {
-        expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
+      it('should not call onBeforeRenderChildren', function() {
+        expect(this.collectionView.onBeforeRenderChildren).not.to.have.been.called;
       });
 
-      it('should not call onRenderCollection', function() {
-        expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
+      it('should not call onRenderChildren', function() {
+        expect(this.collectionView.onBeforeRenderChildren).not.to.have.been.called;
       });
     });
 
@@ -235,12 +235,12 @@ describe('collection view - filter', function() {
       expect(this.collectionView.$el).to.contain.$text('empty');
     });
 
-    it('should not call onBeforeRenderCollection', function() {
-      expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
+    it('should not call onBeforeRenderChildren', function() {
+      expect(this.collectionView.onBeforeRenderChildren).not.to.have.been.called;
     });
 
-    it('should not call onRenderCollection', function() {
-      expect(this.collectionView.onBeforeRenderCollection).not.to.have.been.called;
+    it('should not call onRenderChildren', function() {
+      expect(this.collectionView.onBeforeRenderChildren).not.to.have.been.called;
     });
   });
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -96,8 +96,8 @@ describe('collection view', function() {
         onRender:                 function() { return this.isRendered(); },
         onBeforeAddChild:         this.sinon.stub(),
         onAddChild:               this.sinon.stub(),
-        onBeforeRenderCollection: this.sinon.stub(),
-        onRenderCollection:       this.sinon.stub(),
+        onBeforeRenderChildren: this.sinon.stub(),
+        onRenderChildren:       this.sinon.stub(),
         onChildViewRender:        this.sinon.stub()
       });
 
@@ -130,12 +130,12 @@ describe('collection view', function() {
       expect(this.collectionView.attachHtml.callCount).to.equal(2);
     });
 
-    it('should only call onRenderCollection once', function() {
-      expect(this.collectionView.onRenderCollection).to.have.been.calledOnce;
+    it('should only call onRenderChildren once', function() {
+      expect(this.collectionView.onRenderChildren).to.have.been.calledOnce;
     });
 
-    it('should only call onBeforeRenderCollection once', function() {
-      expect(this.collectionView.onBeforeRenderCollection).to.have.been.calledOnce;
+    it('should only call onBeforeRenderChildren once', function() {
+      expect(this.collectionView.onBeforeRenderChildren).to.have.been.calledOnce;
     });
 
     it('should append the html for each childView', function() {
@@ -180,12 +180,12 @@ describe('collection view', function() {
       expect(this.collectionView.trigger).to.have.been.calledWith('before:render', this.collectionView);
     });
 
-    it('should trigger a "before:render:collection" event', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('before:render:collection', this.collectionView);
+    it('should trigger a "before:render:children" event', function() {
+      expect(this.collectionView.trigger).to.have.been.calledWith('before:render:children', this.collectionView);
     });
 
-    it('should trigger a "render:collection" event', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('render:collection', this.collectionView);
+    it('should trigger a "render:children" event', function() {
+      expect(this.collectionView.trigger).to.have.been.calledWith('render:children', this.collectionView);
     });
 
     it('should trigger a "render" event', function() {
@@ -281,19 +281,19 @@ describe('collection view', function() {
       this.collection = new Backbone.Collection([{foo: 'bar'}, {foo: 'baz'}]);
 
       var CollectionView = this.CollectionView.extend({
-        onRenderCollection: function() {
-          suite.onRenderCollectionHTML = this.el.innerHTML;
+        onRenderChildren: function() {
+          suite.onRenderChildrenHTML = this.el.innerHTML;
         }
       });
       this.collectionView = new CollectionView({
         collection: this.collection,
       });
-      sinon.spy(this.collectionView, 'onRenderCollection');
+      sinon.spy(this.collectionView, 'onRenderChildren');
       this.collectionView.render();
     });
 
     it('should find the expected number of childen', function() {
-      expect(this.onRenderCollectionHTML).to.equal('<span>bar</span><span>baz</span>');
+      expect(this.onRenderChildrenHTML).to.equal('<span>bar</span><span>baz</span>');
     });
   });
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -741,7 +741,7 @@ describe('collection view', function() {
       this.sinon.spy(this.collectionView, 'trigger');
       this.sinon.spy(this.collectionView, 'checkEmpty');
 
-      this.collectionView.bind('destroy:collection', this.destroyHandler);
+      this.collectionView.bind('destroy:children', this.destroyHandler);
 
       this.collectionView.destroy();
 
@@ -804,11 +804,11 @@ describe('collection view', function() {
     });
 
     it('should trigger a "before:destroy" event', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('before:destroy:collection');
+      expect(this.collectionView.trigger).to.have.been.calledWith('before:destroy:children');
     });
 
     it('should trigger a "destroy"', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('destroy:collection');
+      expect(this.collectionView.trigger).to.have.been.calledWith('destroy:children');
     });
 
     it('should call the handlers add to the destroyed event', function() {

--- a/test/unit/composite-view.spec.js
+++ b/test/unit/composite-view.spec.js
@@ -266,11 +266,11 @@ describe('composite view', function() {
     });
 
     it('should trigger a before:render event for the collection', function() {
-      expect(this.compositeView.trigger).to.have.been.calledWith('before:render:collection', this.compositeView);
+      expect(this.compositeView.trigger).to.have.been.calledWith('before:render:children', this.compositeView);
     });
 
     it('should trigger a render event for the collection', function() {
-      expect(this.compositeView.trigger).to.have.been.calledWith('render:collection', this.compositeView);
+      expect(this.compositeView.trigger).to.have.been.calledWith('render:children', this.compositeView);
     });
 
     it('should trigger a render event for the composite view', function() {


### PR DESCRIPTION
Resolves #1309

I think this is the correct naming strategy.  It is what the function is called, which will likely be made [public](https://github.com/marionettejs/backbone.marionette/issues/2695)

Addressing previous concerns..  the difference with the collectionview's children vs children views of a view, would be that views are not responsible for rendering their children in the same way that collectionview's are, so I don't think there will be confusion anymore than our current situation, being that a simple view doesn't currently throw `render:collection` even though it can certainly render a collection.