### PR TITLE
Simplify triggerMethod

### DIFF
--- a/src/abstract-view.js
+++ b/src/abstract-view.js
@@ -345,7 +345,7 @@ Marionette.AbstractView = Backbone.View.extend({
     var prefixedEventName = eventPrefix + ':' + eventName;
     var callArgs = [this].concat(args);
 
-    Marionette._triggerMethod(layoutView, prefixedEventName, callArgs);
+    Marionette._triggerMethod(layoutView, [prefixedEventName].concat(callArgs));
 
     // call the parent view's childEvents handler
     var childEvents = Marionette.getOption(layoutView, 'childEvents');

--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -13,12 +13,8 @@ Marionette._triggerMethod = (function() {
     return eventName.toUpperCase();
   }
 
-  return function(context, event, args) {
-    var noEventArg = arguments.length < 3;
-    if (noEventArg) {
-      args = event;
-      event = args[0];
-    }
+  return function(context, args) {
+    var event = args[0];
 
     // get the method name from the event name
     var methodName = 'on' + event.replace(splitter, getEventName);
@@ -28,13 +24,11 @@ Marionette._triggerMethod = (function() {
     // call the onMethodName if it exists
     if (_.isFunction(method)) {
       // pass all args, except the event name
-      result = method.apply(context, noEventArg ? _.rest(args) : args);
+      result = method.apply(context, _.rest(args));
     }
 
-    // trigger the event, if a trigger method exists
-    if (_.isFunction(context.trigger)) {
-      context.trigger.apply(context, noEventArg ? args : [event].concat(_.drop(args, 0)));
-    }
+    // trigger the event
+    context.trigger.apply(context, args);
 
     return result;
   };


### PR DESCRIPTION
Now due to how we use `_triggerMethod` internally `noEventArg` is always true (according to our test suite and as far as I can tell) So removing that condition simplifies things quite a bit.

Additionally we're checking to see if `trigger` exists.  I don't know of a use case in which `triggerMethod` should ever be called on something that doesn't also have `Backbone.Events` but considering we're are looking into merging this into `trigger` for `Marionette.Events` it seems like an unnecessary check on a fairly hot function.

Additionally, I haven't removed it, but I think returning the result of the onMethod is an anti-pattern and we should remove it.  Events are by nature one to many, and we have that situation here as well where behaviors might listen to the same event, but cannot return a value.
~~If we want to do something like this it should follow more of the request pattern.  Perhaps piggybacking off of https://github.com/marionettejs/backbone.marionette/issues/2515~~  Except since you already have the obj you're triggering on, you can just call the function.