### PR TITLE
Clean up application

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -3,327 +3,73 @@ name: Application
 class: Marionette.Application
 
 description: |
-  Applications are the entry point into most Marionette Applications. 
+  Applications are the entry point into most Marionette Applications.
   For all but the simplest of webapps you'll want to instantiate a new Application to act as the hub for the rest of your code.
 
-  Applications let you accomplish three things. 
-  Firstly, they provide a place to put start up code for your app through its Initializers. 
-  Secondly, they allow you to group your code into logical sections with the Module system. 
-  Lastly, they give you a way to connect Views to the document through its Regions.
-  
+  Applications provide a place to put start up code for your app through its start events.
+
+
   ```js
   var MyApp = new Marionette.Application();
   ```
 
-constructor: 
+constructor:
   description: |
     Creates a new Application.
-    
-    The constructor function calls initialize if it exists, and sets the properties of the Application. 
-    Note that Applications are unique in that their options are automatically attached to the Application instead of a separate options object. 
-    
-    The `options` parameter can take any key/value pair and set it on the application instance.
-    Two special properties that are used in the application are:
-      + regions - regions are set on the app
-      
-    @param {...*} options - Options to be available on the Application instance directly.
-    
-  examples: 
-    -
-      name: Add regions 
-      example: |
-        You can also specify regions per `Application` instance.
-        
-        ```js
-        new Marionette.Application({
-          regions: {
-            fooRegion: '#foo-region'
-          }
-        });
 
-properties:
-  submodules: |
-    The container for the Application's modules. 
-    Modules are stored with their name as the key, and the module itself as the value.
-    
-    @type {Object}
-    
-  regions:
-    description: |
-      Region Options
-      
-    examples: 
-      -
-        name: Add regions as prototype property
-        example: |
-          You can also specify regions as a prototype property.
-          
-          ```js
-          Marionette.Application.extend({
-            regions: {
-              fooRegion: '#foo-region'
-            }
-          });
-          ```
-          
-      -
-        name: Add regions as prototype function 
-        example: |
-          You can also specify regions as a prototype function.
-          
-          The `options` parameter is same as the constructor `options` parameter.
-          
-          ```js
-          Marionette.Application.extend({
-            regions: function(options) {
-              return {
-                fooRegion: '#foo-region'
-              }
-            }
-          });
-          ```
-      
+    The constructor function calls initialize if it exists, and sets the properties of the Application.
+
+    @param {...*} options - Options can take any key/value pair and are passed to the initialize function.
+
+  examples:
+
 functions:
   initialize:
-    description: | 
-      If `initialize` is set in the Application class, it will be called when new regions are instantiated.
-      
+    description: |
+      If `initialize` is set in the Application class, it will be called when the application is instantiated.
+
       @param {Object} options - The constructor's options
-      
+
     examples:
-      - 
+      -
         name: Basic Use
         example: |
           The `initialize` function is a good place to put custom, post instantiation class logic.
-           
+
           ```js
           var MyApp = Marionette.Application.extend({
             initialize: function(options) {
               console.log(options.container);
             }
           });
-          
+
           var myApp = new MyApp({container: '#app'});
           ```
 
-  addInitializer: 
-    description: |
-      Adds an initializer that runs once the Application has started,
-      or immediately if the app has already been started.
-    
-      Initializer callbacks will be executed when you start your application,
-      and are bound to the application object as the context for
-      the callback. In other words, `this` is the `MyApp` object inside
-      of the initializer function.
-      
-      The callback `options` argument is passed from the `start` method (see below).
-      
-      Initializer callbacks are guaranteed to run, no matter when you
-      add them to the app object. If you add them before the app is
-      started, they will run when the `start` method is called. If you
-      add them after the app is started, they will run immediately.
-      
-      @api public
-      @param {} initializer
-    
-    examples:
-      -
-        name: Adding initializers
-        example: |
-          Your application needs to do useful things, like displaying content in your
-          regions, starting up your routers, and more. To accomplish these tasks and
-          ensure that your `Application` is fully configured, you can add initializer
-          callbacks to the application.
-          
-          ```js
-          MyApp.addInitializer(function(options){
-            // do useful stuff here
-            var myView = new MyView({
-              model: options.someModel
-            });
-            MyApp.getRegion("main").show(myView);
-          });
-          
-          MyApp.addInitializer(function(options){
-            new MyAppRouter();
-            Backbone.history.start();
-          });
-          ```
-        
   start:
     description: |
       Start the Application, triggering the Initializers array of callbacks.
-      
+
       @param {...*} options - Options to pass to the `start` triggerMethods and the Initializers functions.
       @api public
-      
+
     examples:
       -
         name: Starting an Application
         example: |
           Once you have your application configured, you can kick everything off by
           calling: `MyApp.start(options)`.
-          
+
           This function takes a single optional parameter. This parameter will be passed
           to each of your initializer functions, as well as the initialize events. This
           allows you to provide extra configuration for various parts of your app throughout the
           initialization sequence.
-          
+
           ```js
           var options = {
             something: "some value",
             another: "#some-selector"
           };
-          
+
           MyApp.start(options);
           ```
-    
-  addRegions: 
-    description: |
-      You can create Regions through the `addRegions` method by passing in an object
-      literal or a function that returns an object literal.
-      
-      For more information on regions, see [the region documentation](./marionette.region.md) 
-      Also, the API that Applications use to manage regions comes from the RegionManager Class, 
-      which is documented [over here](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.regionmanager.md).
-      
-      @api public
-      @param {Object|Function} regions
-    
-    examples:
-      - 
-        name: jQuery Selector
-        example: |
-          The first is to specify a jQuery selector as the value of the region
-          definition. This will create an instance of a Marionette.Region directly,
-          and assign it to the selector:
-          
-          ```js
-          MyApp.addRegions({
-            someRegion: "#some-div",
-            anotherRegion: "#another-div"
-          });
-          ```
-      - 
-        name: Custom Region Class
-        example: |
-          The second is to specify a custom region class, where the region class has
-          already specified a selector:
-          
-          ```js
-          var MyCustomRegion = Marionette.Region.extend({
-            el: "#foo"
-          });
-          
-          MyApp.addRegions(function() {
-            return {
-              someRegion: MyCustomRegion
-            };
-          });
-          ```
-          
-      - 
-        name: Custom Region Class And Selector
-        example: |
-          The third method is to specify a custom region class, and a jQuery selector
-          for this region instance, using an object literal:
-            
-          ```js
-          var MyCustomRegion = Marionette.Region.extend({});
-          
-          MyApp.addRegions({
-          
-            someRegion: {
-              selector: "#foo",
-              regionClass: MyCustomRegion
-            },
-            
-            anotherRegion: {
-              selector: "#bar",
-              regionClass: MyCustomRegion
-            }
-            
-          });
-          ```
-          
-  emptyRegions: |
-    Empties all of the Application's Regions by destroying the View within each Region.
-  
-    @api public
-    
-  removeRegion: 
-    description: |
-      Removes the specified Region from the Application. 
-      Removing a region will properly empty it before removing it from the application object.
-      
-      @param {String} regionName - The name of the Region to be removed.
-      @api public
-      
-    examples: 
-        -
-          name: Remove a region
-          example: |
-            Regions can also be removed with the `removeRegion` method, passing in
-            the name of the region to remove as a string value:
-            
-            ```js
-            MyApp.removeRegion("someRegion");
-            ```
-      
-  getRegion: 
-    description: |
-      Returns a Region by name.
-      
-      @param {String} regionName - The name of the Region to receive.
-      @api public
-
-    examples: 
-      -
-        name: Get Region by name
-        example: |
-          A region can be retrieved by name, using the `getRegion` method:
-          
-          ```js
-          var app = new Marionette.Application();
-          app.addRegions({ r1: "#region1" });
-          
-          // r1 === r1Again; true
-          var r1 = app.getRegion("r1");
-          var r1Again = app.r1;
-          ```
-          
-          This is the preferred method of accessing Regions on the Application instance.
-
-    
-  getRegions: |
-    Returns an array of every Region from the RegionManager
-    
-    @api public
-    
-  module: |
-    Create a module, attached to the application
-    
-    @api public
-    @param {} moduleNames
-    @param {} moduleDefinition
-    
-  getRegionManager: |
-    Returns a new instance of a region manager.
-    
-    Enables easy overriding of the default `RegionManager` for customized region interactions 
-    and business-specific view logic for better control over single regions.
-    
-    @api public
-    
-  _initializeRegions: |
-    Internal method to initialize the regions that have been defined in a
-    `regions` attribute on the application instance
-  
-    @param {} options
-    @api private
-    
-  _initRegionManager: |
-    Instantiates the RegionManager for the Application object, and forwards
-    the events from the RegionManager to the Application itself.
-    
-    @api private

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -22,10 +22,6 @@ By creating an Application you get three important things:
   that makes it easy to understand and debug your application. Using the Application Class
   will automatically hook up your application to that extension.
 
-Note that the Application is undergoing many changes to become more lightweight. While it
-still includes many more features beyond what has been listed here, such as a Radio Channel and Regions,
-these features are now deprecated. Refer to the relevant sections below to learn what to use
-instead of these deprecated features.
 
 ## Documentation Index
 
@@ -142,55 +138,23 @@ var options = {
 MyApp.start(options);
 ```
 
+### Application.mergeOptions
+Merge keys from the `options` object directly onto the Application instance.
+
+```js
+var MyApp = Marionette.Application.extend({
+  initialize: function(options) {
+    this.mergeOptions(options, ['myOption']);
+
+    console.log('The option is:', this.myOption);
+  }
+})
+```
+
+More information at [mergeOptions](./marionette.functions.md#marionettemergeoptions)
+
 ### Application.getOption
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
 
 More information [getOption](./marionette.functions.md#marionettegetoption)
 
-## Adding Initializers
-
-> Warning: deprecated
->
-> This feature is deprecated, and is scheduled to be removed in version 3 of Marionette. Instead
-> of Initializers, you should use events to manage start-up logic. The `start` event is an ideal
-> substitute for Initializers.
->
-> If you were relying on the deferred nature of Initializers in your app, you should instead
-> use Promises. This might look something like the following:
->
-> ```js
-> doAsyncThings().then(app.start);
-> ```
->
-
-Your application needs to do useful things, like displaying content in your
-regions, starting up your routers, and more. To accomplish these tasks and
-ensure that your `Application` is fully configured, you can add initializer
-callbacks to the application.
-
-```js
-MyApp.addInitializer(function(options){
-  // do useful stuff here
-  var myView = new MyView({
-    model: options.someModel
-  });
-  MyApp.rootView.mainRegion.show(myView);
-});
-
-MyApp.addInitializer(function(options){
-  new MyAppRouter();
-  Backbone.history.start();
-});
-```
-
-These callbacks will be executed when you start your application,
-and are bound to the application object as the context for
-the callback. In other words, `this` is the `MyApp` object inside
-of the initializer function.
-
-The `options` argument is passed from the `start` method (see below).
-
-Initializer callbacks are guaranteed to run, no matter when you
-add them to the app object. If you add them before the app is
-started, they will run when the `start` method is called. If you
-add them after the app is started, they will run immediately.

--- a/src/application.js
+++ b/src/application.js
@@ -5,11 +5,6 @@
 Marionette.Application = Marionette.Object.extend({
   cidPrefix: 'mna',
 
-  constructor: function(options) {
-    _.extend(this, options);
-    Marionette.Object.apply(this, arguments);
-  },
-
   // kick off all of the application's processes.
   // initializes all of the regions that have been added
   // to the app, and runs all of the initializer functions

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -9,10 +9,6 @@ describe('marionette application', function() {
       this.app = new Marionette.Application(this.appOptions, 'fooArg');
     });
 
-    it('should merge those options into the app', function() {
-      expect(this.app.fooOption).to.equal(this.fooOption);
-    });
-
     it('should pass all arguments to the initialize method', function() {
       expect(this.initializeStub).to.have.been.calledOn(this.app).and.calledWith(this.appOptions, 'fooArg');
     });


### PR DESCRIPTION
Marionette.Application is the only Object where the passed in options are extended directly on the Object.  This makes the currently documents [Application.mergeOptions](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.application.md#applicationmergeoptions) particularly useless and is a pattern that all other Marionette Objects have moved away from previously.
It should be removed and anything that needs to be attached should be done explicitly in the `initializer` with `mergeOptions`

Additionally there was quite a bit of clean up necessary on the docs.  This was a rough pass to remove any glaring issues.  I'm sure most of the docs could use a once over for vibe and clarity.