### PR TITLE
`CollectionView.destroyChildren` now triggers `destroy:children`

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -633,9 +633,7 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
   destroy: function() {
     if (this._isDestroyed) { return this; }
 
-    this.triggerMethod('before:destroy:children');
     this.destroyChildren({checkEmpty: false});
-    this.triggerMethod('destroy:children');
 
     return Marionette.AbstractView.prototype.destroy.apply(this, arguments);
   },
@@ -643,6 +641,7 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
   // Destroy the child views that this collection view
   // is holding on to, if any
   destroyChildren: function(options) {
+    this.triggerMethod('before:destroy:children');
     var destroyOptions = options || {};
     var shouldCheckEmpty = true;
     var childViews = this.children.map(_.identity);
@@ -656,6 +655,8 @@ Marionette.CollectionView = Marionette.AbstractView.extend({
     if (shouldCheckEmpty) {
       this.checkEmpty();
     }
+
+    this.triggerMethod('destroy:children');
     return childViews;
   },
 


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2731