### PR TITLE
Introduce a "rootEl" property on the application object

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -1,19 +1,58 @@
 // Application
 // -----------
-
-import MNObject from './object';
+import _                from 'underscore';
+import MarionetteObject from './object';
+import Region           from './region';
 
 // A container for a Marionette application.
-var Application = MNObject.extend({
+var Application = MarionetteObject.extend({
   cidPrefix: 'mna',
 
+  constructor: function(options) {
+    options = options || {};
+
+    this._initRegion(options);
+
+    MarionetteObject.prototype.constructor.apply(this, arguments);
+  },
+
+  regionClass: Region,
+
+  _initRegion: function(options) {
+    var region = options.region || this.region;
+    var RegionClass = options.regionClass || this.regionClass;
+
+    // if the region is a string expect an el or selector
+    // and instantiate a region
+    if (_.isString(region)) {
+      this._region = new RegionClass({
+        el: region
+      });
+      return;
+    }
+
+    this._region = region;
+  },
+
+  getRegion: function() {
+    return this._region;
+  },
+
+  showView: function(view, options) {
+    var region = this.getRegion();
+    return region.show.apply(region, arguments);
+  },
+
+  getView: function() {
+    return this.getRegion().currentView;
+  },
+
   // kick off all of the application's processes.
-  // initializes all of the regions that have been added
-  // to the app, and runs all of the initializer functions
   start: function(options) {
     this.triggerMethod('before:start', options);
     this.triggerMethod('start', options);
   }
+
 });
 
 export default Application;


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2279

Also https://github.com/marionettejs/backbone.marionette/issues/2326

Alternate to https://github.com/marionettejs/backbone.marionette/pull/2757

I think we want the rootEl to be a `Marionette.Region`.. otherwise we could be duplicating much of the region related code relating to a view's lifecycle and introducing new areas for regression.

