### PR TITLE
Fix issue with serializeCollection

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -51,7 +51,7 @@ Marionette.View = Marionette.AbstractView.extend({
   // its model's attributes
   serializeCollection: function() {
     if (!this.collection) { return {}; }
-    return _.pluck(this.collection.invoke('clone'), 'attributes');
+    return this.collection.map(function(model) { return _.clone(model.attributes); });
   },
 
   // Render the view, defaulting to underscore.js templates.


### PR DESCRIPTION
Calling clone on each model in the collection is actually re-initializing the models.  Fine I suppose in many cases, but if you were doing something expensive in initialize, or using a library like `backbone.uniquemodel` suddenly you're creating new models in memory you don't need.  And that could lead to all sorts of problems.

`Collection.map` and `_.clone` are going to be cheaper and it's what [backbone is doing](https://github.com/jashkenas/backbone/blob/1.2.3/backbone.js#L791)