### PR TITLE
#2760 - Add DEV_MODE

### DIFF
--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -1,5 +1,7 @@
 /* global console */
 
+Marionette.DEV_MODE = false;
+
 var deprecate = Marionette.deprecate = function(message, test) {
   if (_.isObject(message)) {
     message = (
@@ -7,6 +9,10 @@ var deprecate = Marionette.deprecate = function(message, test) {
       'Please use ' + message.next + ' instead.' +
       (message.url ? ' See: ' + message.url : '')
     );
+  }
+
+  if (!Marionette.DEV_MODE) {
+    return;
   }
 
   if ((test === undefined || !test) && !deprecate._cache[message]) {

--- a/test/unit/utils/deprecate.spec.js
+++ b/test/unit/utils/deprecate.spec.js
@@ -1,10 +1,15 @@
 describe('Marionette.deprecate', function() {
   beforeEach(function() {
+    Marionette.DEV_MODE = true;
     this.sinon.spy(Marionette.deprecate, '_warn');
     this.sinon.stub(Marionette.deprecate, '_console', {
       warn: this.sinon.stub()
     });
     Marionette.deprecate._cache = {};
+  });
+
+  afterEach(function() {
+    Marionette.DEV_MODE = false;
   });
 
   describe('Marionette.deprecate._warn', function() {
@@ -95,6 +100,17 @@ describe('Marionette.deprecate', function() {
       expect(Marionette.deprecate._warn)
         .to.have.been.calledOnce
         .and.calledWith('Deprecation warning: baz');
+    });
+  });
+
+  describe('when calling in production mode', function() {
+    beforeEach(function() {
+      Marionette.DEV_MODE = false;
+      Marionette.deprecate('baz');
+    });
+
+    it('should `console.warn` the message', function() {
+      expect(Marionette.deprecate._warn).to.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
Fixes #2760 

This will make it safe to add `Marionette.deprecate('foo bar');` calls in the code w/o polluting production