### PR TITLE
Make tests for LayoutView 'when destroying' selfcontained

### DIFF
--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -19,6 +19,8 @@
     "expect"             : true,
     "beforeEach"         : true,
     "afterEach"          : true,
+    "before"             : true,
+    "after"              : true,
     "spyOn"              : true,
     "sinon"              : true,
     "setFixtures"        : true,

--- a/test/unit/layout-view.spec.js
+++ b/test/unit/layout-view.spec.js
@@ -213,77 +213,92 @@ describe('layoutView', function() {
   });
 
   describe('when destroying', function() {
-    beforeEach(function() {
-      this.layoutViewManager = new this.LayoutView(this.viewOptions);
-      $('<span id="parent">').append(this.layoutViewManager.el);
-      this.layoutViewManager.render();
+    var oldLayoutView = this.LayoutView;
 
-      this.regionOne = this.layoutViewManager.regionOne;
-      this.regionTwo = this.layoutViewManager.regionTwo;
+    before(function() {
+      this.setup = function(viewOptions) {
+        this.layoutViewManager = new this.LayoutView(viewOptions);
+        $('<span id="parent">').append(this.layoutViewManager.el);
+        this.layoutViewManager.render();
 
-      var View = Marionette.ItemView.extend({
-        template: false,
-        destroy: function() {
-          this.hadParent = this.$el.closest('#parent').length > 0;
-          return View.__super__.destroy.call(this);
-        }
-      });
+        this.regionOne = this.layoutViewManager.regionOne;
+        this.regionTwo = this.layoutViewManager.regionTwo;
 
-      this.regionOneView = new View();
-      this.regionOne.show(this.regionOneView);
+        var View = Marionette.ItemView.extend({
+          template: false,
+          destroy: function() {
+            this.hadParent = this.$el.closest('#parent').length > 0;
+            return View.__super__.destroy.call(this);
+          }
+        });
 
-      this.sinon.spy(this.regionOne, 'empty');
-      this.sinon.spy(this.regionTwo, 'empty');
+        this.regionOneView = new View();
+        this.regionOne.show(this.regionOneView);
 
-      this.sinon.spy(this.layoutViewManager, 'destroy');
-      this.layoutViewManager.destroy();
-      this.layoutViewManager.destroy();
+        this.sinon.spy(this.regionOne, 'empty');
+        this.sinon.spy(this.regionTwo, 'empty');
+
+        this.sinon.spy(this.layoutViewManager, 'destroy');
+        this.layoutViewManager.destroy();
+        this.layoutViewManager.destroy();
+      };
+    });
+
+    after(function() {
+      this.LayoutView = oldLayoutView;
     });
 
     it('should empty the region managers', function() {
+      this.setup();
       expect(this.regionOne.empty).to.have.been.calledOnce;
       expect(this.regionTwo.empty).to.have.been.calledOnce;
     });
 
     it('should delete the region managers', function() {
+      this.setup();
       expect(this.layoutViewManager.regionOne).to.be.undefined;
       expect(this.layoutViewManager.regionTwo).to.be.undefined;
     });
 
     it('should return the view', function() {
+      this.setup();
       expect(this.layoutViewManager.destroy).to.have.always.returned(this.layoutViewManager);
     });
 
     it('should not remove itself from the DOM before destroying child regions by default', function() {
+      this.setup();
       expect(this.regionOneView.hadParent).to.be.true;
-      this.viewOptions = {
-        destroyImmediate: true
-      };
     });
 
     it('should remove itself from the DOM before destroying child regions if flag set via options', function() {
+      this.setup({
+        destroyImmediate: true
+      });
       expect(this.regionOneView.hadParent).to.be.false;
-      this.viewOptions = null;
-      this.LayoutView.prototype.options.destroyImmediate = true;
     });
 
     it('should remove itself from the DOM before destroying child regions if flag set on proto options', function() {
+      this.LayoutView.prototype.options.destroyImmediate = true;
+      this.setup();
       expect(this.regionOneView.hadParent).to.be.false;
+    });
+
+    it('should remove itself from the DOM before destroying child regions if flag set on proto', function() {
       _.extend(this.LayoutView.prototype, {
         options: null,
         destroyImmediate: true
       });
-    });
-
-    it('should remove itself from the DOM before destroying child regions if flag set on proto', function() {
+      this.setup();
       expect(this.regionOneView.hadParent).to.be.false;
     });
 
     it('should be marked destroyed', function() {
+      this.setup();
       expect(this.layoutViewManager).to.have.property('isDestroyed', true);
     });
 
     it('should be marked not rendered', function() {
+      this.setup();
       expect(this.layoutViewManager).to.have.property('isRendered', false);
     });
   });


### PR DESCRIPTION
There were a series of tests in the LayoutView tests, that setup information for the next upcoming test, this makes the test dependant on each other, which then makes difficult to move tests around or removing any of those.

On top of that they are harder to understand from where the setup information is coming.