### PR TITLE
Warn that events using triggers hash do not have access to DOM evt

### DIFF
--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -166,7 +166,8 @@ var ParentView = Marionette.LayoutView.extend({
   onChildShowMessage: function (childView, message) {
     console.log('A child view fired show:message with ' + message);
   },
-
+  // Methods called from the triggers hash do not have access to DOM events
+  // Any logic requiring the original DOM event should be handled in it's respective view
   onChildSubmitForm: function (childView) {
     console.log('A child view fired submit:form');
   }


### PR DESCRIPTION
I recently came across this specific part of the docs while setting up a layoutView and thought it would be helpful to have a comment above the example trigger hash's method. I have to agree that all logic that uses DOM events should handle said logic in its own view but I think for a lot of developers it seems intuitive that one of the parameters in the function would be the DOM event object.  I didn't go into much detail about why this logic should be encapsulated since it seems implicit.