### PR TITLE
Adding fix for filtering out views in CollectionView.reorder()

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -192,8 +192,8 @@ Marionette.CollectionView = Marionette.View.extend({
 
       // remove any views that have been filtered out
       _.each(filteredOutModels, function(model) {
-        var viewToRemve = this.children.findByModel(model);
-        this.removeChildView(viewToRemve);
+        var viewToRemove = this.children.findByModel(model);
+        this.removeChildView(viewToRemove);
         this.checkEmpty();
       }, this);
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -169,6 +169,9 @@ Marionette.CollectionView = Marionette.View.extend({
       return !children.findByModel(model);
     });
 
+    // determine which models have been filtered out
+    var filteredOutModels = _.difference(this.collection.models, models);
+
     // If the models we're displaying have changed due to filtering
     // We need to add and/or remove child views
     // So render as normal
@@ -186,6 +189,14 @@ Marionette.CollectionView = Marionette.View.extend({
       // appending the elements will effectively reorder them
       this.triggerMethod('before:reorder');
       this._appendReorderedChildren(els);
+
+      // remove any views that have been filtered out
+      _.each(filteredOutModels, function(model) {
+        var viewToRemve = this.children.findByModel(model);
+        this.removeChildView(viewToRemve);
+        this.checkEmpty();
+      }, this);
+
       this.triggerMethod('reorder');
     }
   },

--- a/test/unit/collection-view.filter.spec.js
+++ b/test/unit/collection-view.filter.spec.js
@@ -28,6 +28,10 @@ describe('collection view - filter', function() {
       return !spec.filter(child);
     });
 
+    this.noFilter = this.sinon.spy(function() {
+      return true;
+    });
+
     this.CollectionView = Backbone.Marionette.CollectionView.extend({
       emptyView: this.EmptyView,
       childView: this.ChildView,
@@ -379,6 +383,24 @@ describe('collection view - filter', function() {
       it('renders the views in the correct order', function() {
         expect(this.collectionView.$el).to.contain.$text('24');
       });
+    });
+
+    describe('when the filter results in a subset of children models', function() {
+      beforeEach(function() {
+        this.collectionView.filter = this.noFilter;
+        this.collectionView.render();
+        this.collection.sort();
+      });
+
+      it('only renders views that pass the filter', function() {
+        this.collectionView.filter = this.inverseFilter;
+        this.collectionView.reorder();
+        expect(this.collectionView.children.findByModel(this.model1)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model2)).to.exist;
+        expect(this.collectionView.children.findByModel(this.model3)).not.to.exist;
+        expect(this.collectionView.children.findByModel(this.model4)).to.exist;
+      });
+
     });
 
     describe('when the filter changes between sorts and the collection hasn\'t changed order', function() {


### PR DESCRIPTION
Based on my finding in this [Issue](https://github.com/marionettejs/backbone.marionette/issues/2797) I have created a pull request to address the issue.

The previous `CollectionView.reorder()` did not remove any previous views that might have been filtered out after calling `._filteredSortedModels()`. This patch will identify the models that have been removed and manually remove them using the `.removeChildView()` method. 

I added some test cases to cover this logic.