### PR TITLE
Consistently return instance for Region#empty

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -223,7 +223,7 @@ Marionette.Region = Marionette.Object.extend({
     var preventDestroy  = !!emptyOptions.preventDestroy;
     // If there is no view in the region
     // we should not remove anything
-    if (!view) { return; }
+    if (!view) { return this; }
 
     view.off('destroy', this.empty, this);
     this.triggerMethod('before:empty', view);

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -799,6 +799,12 @@ describe('region', function() {
       expect(this.myRegion.empty).to.have.returned(this.myRegion);
     });
 
+    it('should return the region even when there was not a view to destroy', function() {
+      // The first empty() should have removed the view, this empty() call would be when there isn't a view
+      this.myRegion.empty();
+      expect(this.myRegion.empty.secondCall).to.have.returned(this.myRegion);
+    });
+
     it('should not have a view', function() {
       expect(this.myRegion.hasView()).to.equal(false);
     });


### PR DESCRIPTION
The empty method for Region is supposed to return itself when done. It works as expected when there is a view but returns undefined when there isn't. This breaks the ability to chain the method.