### PR TITLE
Added support for passing down arguments to Marionette.Object.destroy

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -20,9 +20,11 @@ _.extend(Marionette.Object.prototype, Backbone.Events, {
   //this is a noop method intended to be overridden by classes that extend from this base
   initialize: function() {},
 
-  destroy: function() {
-    this.triggerMethod('before:destroy');
-    this.triggerMethod('destroy');
+  destroy: function(options) {
+    options = options || {};
+
+    this.triggerMethod('before:destroy', options);
+    this.triggerMethod('destroy', options);
     this.stopListening();
 
     return this;

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -52,7 +52,9 @@ describe('marionette object', function() {
 
       this.sinon.spy(this.object, 'destroy');
       this.beforeDestroyHandler = sinon.spy();
+      this.onDestroyHandler = sinon.spy();
       this.object.on('before:destroy', this.beforeDestroyHandler);
+      this.object.on('destroy', this.onDestroyHandler);
       this.object.destroy();
     });
 
@@ -62,6 +64,40 @@ describe('marionette object', function() {
 
     it('should return the object', function() {
       expect(this.object.destroy).to.have.returned(this.object);
+    });
+
+    it('should pass an empty object options down to the onBeforeDestroy method', function() {
+      expect(this.beforeDestroyHandler).to.have.been.calledWith({});
+    });
+
+    it('should pass an empty object options down to the onDestroy method', function() {
+      expect(this.onDestroyHandler).to.have.been.calledWith({});
+    });
+  });
+
+  describe('when destroying a object with arguments', function() {
+
+    var destroyArgs = {
+      foo: 'bar'
+    };
+
+    beforeEach(function() {
+      this.object = new Marionette.Object();
+
+      this.sinon.spy(this.object, 'destroy');
+      this.beforeDestroyHandler = sinon.spy();
+      this.onDestroyHandler = sinon.spy();
+      this.object.on('before:destroy', this.beforeDestroyHandler);
+      this.object.on('destroy', this.onDestroyHandler);
+      this.object.destroy(destroyArgs);
+    });
+
+    it('should pass the arguments down to the onBeforeDestroy method', function() {
+      expect(this.beforeDestroyHandler).to.have.been.calledWithExactly(destroyArgs);
+    });
+
+    it('should pass the arguments down to the onDestroy method', function() {
+      expect(this.onDestroyHandler).to.have.been.calledWithExactly(destroyArgs);
     });
   });
 });


### PR DESCRIPTION
When calling a Marionette.View's destroy method, you can pass options, which in turn are passed down to the view's `onBeforeDestroy` and `onDestroy` handlers.

I was quite surprised to see that this behaviour is not consistent with Marionette.Object's destroy method. Since this is a pretty useful pattern, I added that feature to Marionette.Object. This way we have consistency in behaviour across the board when destroying objects. The fix is pretty straight-forward.