### PR TITLE
Fixing View.childEvents to support using a function which returns a hash (Issue #2793)

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -304,6 +304,10 @@ Marionette.View = Backbone.View.extend({
 
     // call the parent view's childEvents handler
     var childEvents = Marionette.getOption(layoutView, 'childEvents');
+
+    // since childEvents can be an object or a function use Marionette._getValue
+    // to handle the abstaction for us.
+    childEvents = Marionette._getValue(childEvents, layoutView);
     var normalizedChildEvents = layoutView.normalizeMethods(childEvents);
 
     if (normalizedChildEvents && _.isFunction(normalizedChildEvents[eventName])) {

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -313,6 +313,12 @@ describe('base view', function() {
 
       this.layoutViewOnBoomHandler = this.sinon.spy();
       this.layoutView.onBoom = this.layoutViewOnBoomHandler;
+
+      this.childEventsFunction = _.bind(function() {
+        return {
+          'boom': this.layoutViewOnBoomHandler
+        };
+      }, this);
     });
 
     describe('when there is not a containing layout', function() {
@@ -351,6 +357,24 @@ describe('base view', function() {
           .and.to.have.been.calledOn(this.layoutView)
           .and.CalledOnce;
       });
+
     });
+
+    describe('when childEvents was passed as a function', function() {
+      beforeEach(function() {
+        // use the function definition of childEvents instead of the hash
+        this.layoutView.childEvents = this.childEventsFunction;
+        this.layoutView.showChildView('child', this.childView);
+        this.childView.triggerMethod('boom', 'foo', 'bar');
+      });
+
+      it('invokes the layout childEvents handler', function() {
+        expect(this.layoutViewOnBoomHandler)
+          .to.have.been.calledWith(this.childView, 'foo', 'bar')
+          .and.to.have.been.calledOn(this.layoutView)
+          .and.CalledOnce;
+      });
+    });
+
   });
 });


### PR DESCRIPTION
This it the fix for [Issue 2793](https://github.com/marionettejs/backbone.marionette/issues/2793). The implementation change was trivial (thanks @andrei-placinta-sociomantic for making it easy). I also added a single test case to test this new logic. Let me know if you think I should add more tests.
