### PR TITLE
Moving parent binding to before child rendering in Region.show() (#Issue 2786)

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -89,9 +89,12 @@ Marionette.Region = Marionette.Object.extend({
       // we can not reuse it.
       view.once('destroy', this.empty, this);
 
-      this._renderView(view);
-
+      // make this region the view's parent,
+      // It's important that this parent binding happens before rendering
+      // so that any events the child may trigger during render can also be
+      // triggered on the child's ancestor views
       view._parent = this;
+      this._renderView(view);
 
       if (isChangingView) {
         this.triggerMethod('before:swap', view, this, options);

--- a/test/unit/layout-view.spec.js
+++ b/test/unit/layout-view.spec.js
@@ -288,16 +288,50 @@ describe('layoutView', function() {
     });
   });
 
-  describe('when showing a childView', function() {
+  describe('when showing a childView as a basic Backbone.View', function() {
     beforeEach(function() {
       this.layoutView = new this.LayoutView();
       this.layoutView.render();
+
+      // create a basic Backbone child view
       this.childView = new Backbone.View();
       this.layoutView.showChildView('regionOne', this.childView);
     });
 
     it('shows the childview in the region', function() {
       expect(this.layoutView.getChildView('regionOne')).to.equal(this.childView);
+    });
+  });
+
+  describe('when showing a childView as a ItemView', function() {
+    beforeEach(function() {
+      this.layoutView = new this.LayoutView();
+      this.childEventsHandler = this.sinon.spy();
+
+      // add child events to listen for
+      this.layoutView.childEvents = {
+        'content:rendered': this.childEventsHandler
+      };
+      this.layoutView.render();
+
+      // create a child view which triggers an event on render
+      var ChildView = Backbone.Marionette.ItemView.extend({
+        template: false,
+        onRender: function() {
+          this.triggerMethod('content:rendered');
+        }
+      });
+      this.childView = new ChildView();
+
+      this.layoutView.showChildView('regionOne', this.childView);
+    });
+
+    it('shows the childview in the region', function() {
+      expect(this.layoutView.getChildView('regionOne')).to.equal(this.childView);
+    });
+
+    it('childEvents are triggered', function() {
+      expect(this.childEventsHandler).to.have.been.calledOnce;
     });
   });
 


### PR DESCRIPTION
This is a potential fix for [Issue 2786](https://github.com/marionettejs/backbone.marionette/issues/2786). I modified an existing test in `layout-view.spec.js` to explicitly mention it can work with basic `Backbone.View`'s. I also added a similar test case to the one in the issue using a `Marionette.ItemView` since it supports the 'onRender` and `triggerMethod` methods.

Let me know if the tests look ok or you need something done differently.