### PR TITLE
Adding region aliases into childEvents hash

### DIFF
--- a/src/abstract-view.js
+++ b/src/abstract-view.js
@@ -340,20 +340,8 @@ Marionette.AbstractView = Backbone.View.extend({
       return;
     }
 
-    // invoke triggerMethod on parent view
-    var eventPrefix = Marionette.getOption(layoutView, 'childViewEventPrefix');
-    var prefixedEventName = eventPrefix + ':' + eventName;
-    var callArgs = [this].concat(args);
-
-    Marionette._triggerMethod(layoutView, [prefixedEventName].concat(callArgs));
-
-    // call the parent view's childEvents handler
-    var childEvents = Marionette.getOption(layoutView, 'childEvents');
-    var normalizedChildEvents = layoutView.normalizeMethods(childEvents);
-
-    if (!!normalizedChildEvents && _.isFunction(normalizedChildEvents[eventName])) {
-      normalizedChildEvents[eventName].apply(layoutView, callArgs);
-    }
+    // let the layoutView trigger its childEvents
+    layoutView.triggerChildEvents(eventName, this, args);
   },
 
   // This method returns any views that are immediate

--- a/src/view.js
+++ b/src/view.js
@@ -177,7 +177,7 @@ Marionette.View = Marionette.AbstractView.extend({
   },
   showChildView: function(regionName, view, options) {
     var region = this.getRegion(regionName);
-    // this._unbindRegionEvents(regionName, view);
+    this._unbindRegionEvents(regionName, view);
     this._bindRegionEvents(regionName, view);
 
     return region.show.apply(region, _.rest(arguments));


### PR DESCRIPTION
Preliminary enhancement for supporting region aliases in the `View.childEvents` hash, as requested in [Issue 2763](https://github.com/marionettejs/backbone.marionette/issues/2783).
- Moved layout specific logic out of `AbstractView` and into `View` object, and simply calling `layoutView.triggerChildEvents(eventName, this, args);` from inside `AbstractView._triggerEventOnParentLayout`; to me this seems to separate the logic a little better, and also provides a hook for subclasses to override if needed.
- Added region alias detection to determine if the current view is the one specified in the `childEvents` hash, non-region aliases should behave the same as in earlier releases.
