### PR TITLE
Refactor: Add default ES6 options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - "stable"
 matrix:
   include:
-    - env: UNDERSCORE=1.7 BACKBONE=1.2.1
-    - env: UNDERSCORE=1.7 BACKBONE=1.2.3
     - env: UNDERSCORE=1.8 BACKBONE=1.2.3
     - env: LODASH=3.0 BACKBONE=1.2.3
     - env: LODASH=3.1 BACKBONE=1.2.1

--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "backbone": "1.2.1 - 1.2.3",
-    "underscore": "1.7 - 1.8.3",
+    "underscore": "1.8 - 1.8.3",
     "backbone.babysitter": "^0.1.0",
     "backbone.radio": "^1.0.0",
     "jquery": "^1.8.0 || ^2.0.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "backbone.babysitter": "^0.1.0",
     "backbone.radio": "^1.0.0",
     "backbone": "1.2.1 - 1.2.3",
-    "underscore": "1.7 - 1.8.3"
+    "underscore": "1.8 - 1.8.3"
   },
   "devDependencies": {
     "babel-core": "^5.0.0",

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -27,8 +27,8 @@ import { triggerMethod }       from './trigger-method';
 
 var AppRouter = Backbone.Router.extend({
 
-  constructor: function(options) {
-    this.options = options || {};
+  constructor: function(options = {}) {
+    this.options = options;
 
     Backbone.Router.apply(this, arguments);
 

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -18,7 +18,7 @@ var Behavior = MNObject.extend({
     // wants to directly talk up the chain
     // to the view.
     this.view = view;
-    this.defaults = _.result(this, 'defaults') || {};
+    this.defaults = _.clone(_.result(this, 'defaults', {}));
     this.options  = _.extend({}, this.defaults, options);
     // Construct an internal UI hash using
     // the behaviors UI hash and then the view UI hash.

--- a/src/behaviors.js
+++ b/src/behaviors.js
@@ -43,7 +43,7 @@ var methods = {
 
     _.each(behaviors, function(b, i) {
       var _events = {};
-      var behaviorEvents = _.clone(_.result(b, 'events')) || {};
+      var behaviorEvents = _.clone(_.result(b, 'events', {}));
 
       // Normalize behavior events hash to allow
       // a user to use the @ui. syntax.
@@ -153,7 +153,7 @@ _.extend(BehaviorTriggersBuilder.prototype, {
 
   // Internal method to build all trigger handlers for a given behavior
   _buildTriggerHandlersForBehavior: function(behavior, i) {
-    var triggersHash = _.clone(_.result(behavior, 'triggers')) || {};
+    var triggersHash = _.clone(_.result(behavior, 'triggers', {}));
 
     triggersHash = normalizeUIKeys(triggersHash, getBehaviorsUI(behavior));
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -168,8 +168,7 @@ var CollectionView = Backbone.View.extend({
   // An efficient rendering used for filtering. Instead of modifying
   // the whole DOM for the collection view, we are only adding or
   // removing the related childrenViews.
-  setFilter: function(filter, options) {
-    options = options || {};
+  setFilter: function(filter, options = {}) {
     var viewCanBeRendered = this._isRendered && !this._isDestroyed;
     // The same filter or a `prevent` option won't render the filter.
     // Nevertheless, a `prevent` option will modify the value.

--- a/src/region.js
+++ b/src/region.js
@@ -16,11 +16,11 @@ import { triggerMethodOn, triggerMethodMany } from './trigger-method';
 var Region = MNObject.extend({
   cidPrefix: 'mnr',
 
-  constructor: function(options) {
+  constructor: function(options = {}) {
 
     // set options temporarily so that we can get `el`.
     // options will be overriden by Object.constructor
-    this.options = options || {};
+    this.options = options;
     this.el = this.getOption('el');
 
     // Handle when this.el is passed in as a $ wrapped element.

--- a/src/regions-mixin.js
+++ b/src/regions-mixin.js
@@ -8,7 +8,7 @@ export default {
 
   // Internal method to initialize the regions that have been defined in a
   // `regions` attribute on this View.
-  _initRegions: function(options) {
+  _initRegions: function() {
 
     // init regions hash
     this.regions =  this.regions || {};

--- a/src/view-mixin.js
+++ b/src/view-mixin.js
@@ -78,8 +78,7 @@ export default {
   // object literal, or a function that returns an object
   // literal. All methods and attributes from this object
   // are copies to the object passed in.
-  mixinTemplateContext: function(target) {
-    target = target || {};
+  mixinTemplateContext: function(target = {}) {
     var templateContext = this.getOption('templateContext');
     templateContext = _getValue(templateContext, this);
     return _.extend(target, templateContext);
@@ -106,7 +105,7 @@ export default {
     if (!this.triggers) { return; }
 
     // Allow `triggers` to be configured as a function
-    var triggers = this.normalizeUIKeys(_.result(this, 'triggers'));
+    var triggers = this.normalizeUIKeys(_.result(this, 'triggers', {}));
 
     // Configure the triggers, prevent default
     // action and stop propagation of DOM events
@@ -131,9 +130,9 @@ export default {
     var combinedEvents = {};
 
     // look up if this view has behavior events
-    var behaviorEvents = _.result(this, 'behaviorEvents') || {};
+    var behaviorEvents = _.result(this, 'behaviorEvents', {});
     var triggers = this.configureTriggers();
-    var behaviorTriggers = _.result(this, 'behaviorTriggers') || {};
+    var behaviorTriggers = _.result(this, 'behaviorTriggers', {});
 
     // behavior events will be overriden by view events and or triggers
     _.extend(combinedEvents, behaviorEvents, events, triggers, behaviorTriggers);


### PR DESCRIPTION
This is mostly, just another syntatic cleanup. I added ES6 default
options and _.result default options.

It's worth pointing out that in the process I found a couple places
where we were not cloning the prototype property, which left the
opportunity open to mutate it. This is *not* a desirable behavior.

Also, I believe `|| {}` is mostly removed from the codebase, except
places where we need to do some local property accessing for passed in
options.