### PR TITLE
Move serializeModel out of viewmixin

### DIFF
--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -75,6 +75,17 @@ var CompositeView = CollectionView.extend({
     return this.serializeModel();
   },
 
+  // Duplicated from View#serializeModel
+  // Prepares the special `model` property of a view
+  // for being displayed in the template. By default
+  // we simply clone the attributes. Override this if
+  // you need a custom transformation for your view's model
+  serializeModel: function() {
+    if (!this.model) { return {}; }
+    return _.clone(this.model.attributes);
+  },
+
+
   // Renders the model and the collection.
   render: function() {
     this._ensureViewIsIntact();

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -60,15 +60,6 @@ export default {
     this.attachElContent(html);
   },
 
-  // Prepares the special `model` property of a view
-  // for being displayed in the template. By default
-  // we simply clone the attributes. Override this if
-  // you need a custom transformation for your view's model
-  serializeModel: function() {
-    if (!this.model) { return {}; }
-    return _.clone(this.model.attributes);
-  },
-
   // Mix in template context methods. Looks for a
   // `templateContext` attribute, which can either be an
   // object literal, or a function that returns an object

--- a/src/view.js
+++ b/src/view.js
@@ -48,6 +48,16 @@ var View = Backbone.View.extend({
     };
   },
 
+  // Prepares the special `model` property of a view
+  // for being displayed in the template. By default
+  // we simply clone the attributes. Override this if
+  // you need a custom transformation for your view's model
+  serializeModel: function() {
+    if (!this.model) { return {}; }
+    return _.clone(this.model.attributes);
+  },
+
+
   // Serialize a collection by cloning each of
   // its model's attributes
   serializeCollection: function() {


### PR DESCRIPTION
Now that @jasonLaster started cleaning up the `ViewMixin`, I noticed `serializeModel` felt out of place there.  it makes more sense in context of `View`.. and the only reason it was in the base was to share it with `CompositeView` since that is deprecated, it is cleaner to go ahead and move it to the two use-cases.