### PR TITLE
Move View specific functionality to view

### DIFF
--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -8,6 +8,7 @@ import getValue        from './utils/getValue';
 import getOption       from './utils/getOption';
 import MarionetteError from './error';
 import CollectionView  from './collection-view';
+import View            from './view';
 
 // Used for rendering a branch-leaf, hierarchical structure.
 // Extends directly from CollectionView and also renders an
@@ -75,16 +76,6 @@ var CompositeView = CollectionView.extend({
     return this.serializeModel();
   },
 
-  // Duplicated from View#serializeModel
-  // Prepares the special `model` property of a view
-  // for being displayed in the template. By default
-  // we simply clone the attributes. Override this if
-  // you need a custom transformation for your view's model
-  serializeModel: function() {
-    if (!this.model) { return {}; }
-    return _.clone(this.model.attributes);
-  },
-
   // Renders the model and the collection.
   render: function() {
     this._ensureViewIsIntact();
@@ -107,24 +98,6 @@ var CompositeView = CollectionView.extend({
     if (this._isRendered || this._isRendering) {
       CollectionView.prototype._renderChildren.call(this);
     }
-  },
-
-  // Attaches the content of the root.
-  // This method can be overridden to optimize rendering,
-  // or to render in a non standard way.
-  //
-  // For example, using `innerHTML` instead of `$el.html`
-  //
-  // ```js
-  // attachElContent: function(html) {
-  //   this.el.innerHTML = html;
-  //   return this;
-  // }
-  // ```
-  attachElContent: function(html) {
-    this.$el.html(html);
-
-    return this;
   },
 
   // You might need to override this if you've overridden attachHtml
@@ -190,5 +163,10 @@ var CompositeView = CollectionView.extend({
     }
   }
 });
+
+// To prevent duplication but allow the best View organization
+// Certain View methods are mixed directly into the deprecated CompositeView
+var MixinFromView = _.pick(View.prototype, 'serializeModel', 'getTemplate', '_renderTemplate', 'attachElContent');
+_.extend(CompositeView.prototype, MixinFromView);
 
 export default CompositeView;

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -26,32 +26,6 @@ export default {
     return !!this._isRendered;
   },
 
-  // Get the template for this view
-  // instance. You can set a `template` attribute in the view
-  // definition or pass a `template: "whatever"` parameter in
-  // to the constructor options.
-  getTemplate: function() {
-    return this.getOption('template');
-  },
-
-  // Internal method to render the template with the serialized data
-  // and template context via the `Marionette.Renderer` object.
-  _renderTemplate: function() {
-    var template = this.getTemplate();
-
-    // Allow template-less views
-    if (template === false) {
-      return;
-    }
-
-    // Add in entity data and template context
-    var data = this.mixinTemplateContext(this.serializeData());
-
-    // Render and add to el
-    var html = Renderer.render(template, data, this);
-    this.attachElContent(html);
-  },
-
   // Mix in template context methods. Looks for a
   // `templateContext` attribute, which can either be an
   // object literal, or a function that returns an object

--- a/src/view.js
+++ b/src/view.js
@@ -9,6 +9,7 @@ import BehaviorsMixin     from './mixins/behaviors';
 import UIMixin            from './mixins/ui';
 import CommonMixin        from './mixins/common';
 import MonitorDOMRefresh  from './dom-refresh';
+import Renderer           from './renderer';
 
 // The standard view. Includes view events, automatic rendering
 // of Underscore templates, nested views, and more.
@@ -89,6 +90,32 @@ var View = Backbone.View.extend({
     this.triggerMethod('render', this);
 
     return this;
+  },
+
+  // Internal method to render the template with the serialized data
+  // and template context via the `Marionette.Renderer` object.
+  _renderTemplate: function() {
+    var template = this.getTemplate();
+
+    // Allow template-less views
+    if (template === false) {
+      return;
+    }
+
+    // Add in entity data and template context
+    var data = this.mixinTemplateContext(this.serializeData());
+
+    // Render and add to el
+    var html = Renderer.render(template, data, this);
+    this.attachElContent(html);
+  },
+
+  // Get the template for this view
+  // instance. You can set a `template` attribute in the view
+  // definition or pass a `template: "whatever"` parameter in
+  // to the constructor options.
+  getTemplate: function() {
+    return this.getOption('template');
   },
 
   // Attaches the content of a given view.


### PR DESCRIPTION
Related to https://github.com/marionettejs/backbone.marionette/pull/2841

Seems like there are some very View specific things that are in the shared to support `CompositeView`  This moves all of that to the `View` and then to avoid further duplication, mixes in the methods from `View` into `CompositeView`