### PR TITLE
Make normalizeMethods util more consistent

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -7,6 +7,7 @@ import ChildViewContainer   from 'backbone.babysitter';
 import isNodeAttached       from './utils/isNodeAttached';
 import _getValue            from './utils/_getValue';
 import getOption            from './utils/getOption';
+import normalizeMethods     from './utils/normalizeMethods';
 import MarionetteError      from './error';
 import ViewMixin            from './mixins/view';
 import BehaviorsMixin       from './mixins/behaviors';
@@ -707,7 +708,7 @@ var CollectionView = Backbone.View.extend({
     // prepending "childview:" to the event name
     this.listenTo(view, 'all', function(rootEvent, ...args) {
 
-      var childViewEvents = this.normalizeMethods(_.result(this, 'childViewEvents'));
+      var childViewEvents = normalizeMethods(this, _.result(this, 'childViewEvents'));
       var childEventName = prefix + ':' + rootEvent;
 
       // call collectionView childViewEvent if defined

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -264,7 +264,7 @@ export default {
     // since childViewEvents can be an object or a function use Marionette._getValue
     // to handle the abstaction for us.
     childViewEvents = _getValue(childViewEvents, layoutView);
-    var normalizedChildEvents = layoutView.normalizeMethods(childViewEvents);
+    var normalizedChildEvents = normalizeMethods(layoutView, childViewEvents);
 
     if (!!normalizedChildEvents && _.isFunction(normalizedChildEvents[eventName])) {
       normalizedChildEvents[eventName].apply(layoutView, callArgs);
@@ -295,10 +295,6 @@ export default {
       parent = parent._parent;
     }
   },
-
-  // Imports the "normalizeMethods" to transform hashes of
-  // events=>function references/names to a hash of events=>function references
-  normalizeMethods: normalizeMethods,
 
   // A handy way to merge passed-in options onto the instance
   mergeOptions: mergeOptions,

--- a/src/utils/normalizeMethods.js
+++ b/src/utils/normalizeMethods.js
@@ -3,18 +3,19 @@ import _ from 'underscore';
 // Marionette.normalizeMethods
 // ----------------------
 
+// For a target object:
 // Pass in a mapping of events => functions or function names
 // and return a mapping of events => functions
-var normalizeMethods = function(hash) {
+var normalizeMethods = function(target, hash) {
   return _.reduce(hash, function(normalizedHash, method, name) {
     if (!_.isFunction(method)) {
-      method = this[method];
+      method = target[method];
     }
     if (method) {
       normalizedHash[name] = method;
     }
     return normalizedHash;
-  }, {}, this);
+  }, {});
 };
 
 export default normalizeMethods;

--- a/test/unit/normalize-methods.spec.js
+++ b/test/unit/normalize-methods.spec.js
@@ -10,7 +10,7 @@ describe('normalizeMethods', function() {
       'foo': 'foo',
       'bar': 'bar'
     };
-    this.normalizedHash = this.view.normalizeMethods(this.hash);
+    this.normalizedHash = Marionette.normalizeMethods(this.view, this.hash);
   });
 
   describe('when normalizeMethods is called with a hash of functions and strings', function() {


### PR DESCRIPTION
normalizeMethods is currently attached to Marionette, but as it uses `this` internally it isn't super useful.  Most of our utilities that are attached to Marionette get the context passed in, and for the local use cases we proxy the method.
In this case I believe we've attached normalizeMethods to things mostly for internal use, and that it isn't super useful day to day.  If you do need it, it's a very simple utility to employ with the target.
This reduces the overall API and I believe makes the utility more useful globally.