### PR TITLE
Fix typo

### DIFF
--- a/docs/marionette.layoutview.md
+++ b/docs/marionette.layoutview.md
@@ -124,7 +124,7 @@ var MyLayoutView = Marionette.LayoutView.extend({
 
   childEvents: function() {
     return {
-      render: this.onChildRender
+      render: this.onChildRendered
     }
   },
 


### PR DESCRIPTION
Hi, I found a typo in Marionette.LayoutView document.

![2015-12-04 18 51 47](https://cloud.githubusercontent.com/assets/10515/11586720/4df36614-9ab8-11e5-8f43-f2a65db97f72.png)
