### PR TITLE
child event proxy consistency

### DIFF
--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -42,6 +42,7 @@ export default {
   delegateEvents: function(eventsArg) {
 
     this._proxyBehaviorViewProperties();
+    this._buildEventProxies();
 
     var viewEvents = this._getEvents(eventsArg);
 
@@ -203,12 +204,19 @@ export default {
   // import the `triggerMethod` to trigger events with corresponding
   // methods if the method exists
   triggerMethod: function(...args) {
-    var ret = triggerMethod.call(this, ...args);
+    var ret = triggerMethod.apply(this, args);
 
     this._triggerEventOnBehaviors(...args);
     this._triggerEventOnParentLayout(...args);
 
     return ret;
+  },
+
+  // Cache `childViewEvents` and `childViewTriggers`
+  _buildEventProxies: function() {
+    this._childViewEvents = this.getValue(this.getOption('childViewEvents'));
+
+    this._childViewTriggers = this.getValue(this.getOption('childViewTriggers'));
   },
 
   _triggerEventOnParentLayout: function(eventName, ...args) {
@@ -221,23 +229,17 @@ export default {
     var eventPrefix = layoutView.getOption('childViewEventPrefix');
     var prefixedEventName = eventPrefix + ':' + eventName;
 
-    layoutView.triggerMethod(prefixedEventName, this, ...args);
+    layoutView.triggerMethod(prefixedEventName, ...args);
 
-    // call the parent view's childViewEvents handler
-    var childViewEvents = layoutView.getOption('childViewEvents');
+    // use the parent view's childViewEvents handler
+    var childViewEvents = layoutView.normalizeMethods(layoutView._childViewEvents);
 
-    // since childViewEvents can be an object or a function use getValue
-    // to handle the abstaction for us.
-    childViewEvents = layoutView.getValue(childViewEvents);
-    var normalizedChildEvents = layoutView.normalizeMethods(childViewEvents);
-
-    if (!!normalizedChildEvents && _.isFunction(normalizedChildEvents[eventName])) {
-      normalizedChildEvents[eventName].call(layoutView, this, ...args);
+    if (!!childViewEvents && _.isFunction(childViewEvents[eventName])) {
+      childViewEvents[eventName].apply(layoutView, args);
     }
 
-    // call the parent view's proxyEvent handlers
-    var childViewTriggers = layoutView.getOption('childViewTriggers');
-    childViewTriggers = layoutView.getValue(childViewTriggers);
+    // use the parent view's proxyEvent handlers
+    var childViewTriggers = layoutView._childViewTriggers;
 
     // Call the event with the proxy name on the parent layout
     if (childViewTriggers && _.isString(childViewTriggers[eventName])) {

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -88,31 +88,24 @@ export default {
   // Internal method to create an event handler for a given `triggerDef` like
   // 'click:foo'
   _buildViewTrigger: function(triggerDef) {
-    var options = _.defaults({}, triggerDef, {
-      preventDefault: true,
-      stopPropagation: true
-    });
+    if (_.isString(triggerDef)) {
+      triggerDef = { event: triggerDef };
+    }
 
-    var eventName = _.isObject(triggerDef) ? options.event : triggerDef;
+    const eventName = triggerDef.event;
+    const shouldPreventDefault = triggerDef.preventDefault !== false;
+    const shouldStopPropagation = triggerDef.stopPropagation !== false;
 
     return function(e) {
-      if (e) {
-        if (e.preventDefault && options.preventDefault) {
-          e.preventDefault();
-        }
-
-        if (e.stopPropagation && options.stopPropagation) {
-          e.stopPropagation();
-        }
+      if (shouldPreventDefault) {
+        e.preventDefault();
       }
 
-      var args = {
-        view: this,
-        model: this.model,
-        collection: this.collection
-      };
+      if (shouldStopPropagation) {
+        e.stopPropagation();
+      }
 
-      this.triggerMethod(eventName, args);
+      this.triggerMethod(eventName, this);
     };
   },
 

--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -53,7 +53,7 @@ function triggerMethodOn(context, ...args) {
 }
 
 // triggerMethodMany invokes triggerMethod on many targets from a source
-// it's useful for standardizing a pattern where we propogate an event from a source
+// it's useful for standardizing a pattern where we propagate an event from a source
 // to many targets.
 //
 // For each target we want to follow the pattern

--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -31,7 +31,7 @@ function triggerMethod(event, ...args) {
   // call the onMethodName if it exists
   if (_.isFunction(method)) {
     // pass all args, except the event name
-    result = method.call(this, ...args);
+    result = method.apply(this, args);
   }
 
   // trigger the event

--- a/test/unit/bind-entity-events.spec.js
+++ b/test/unit/bind-entity-events.spec.js
@@ -101,7 +101,7 @@ describe('Marionette.bindEntityEvents', function() {
           var suite = this;
           expect(function() {
             Marionette.bindEntityEvents(suite.target, suite.entity, {'baz': 'doesNotExist'});
-          }).to.throw('Error: Method "doesNotExist" was configured as an event handler, but does not exist.');
+          }).to.throw('Method "doesNotExist" was configured as an event handler, but does not exist.');
         });
       });
     });

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -193,15 +193,15 @@ describe('collection view', function() {
     it('should call "onBeforeAddChild" for each childView instance', function() {
       var v1 = this.collectionView.children.findByIndex(0);
       var v2 = this.collectionView.children.findByIndex(1);
-      expect(this.collectionView.onBeforeAddChild).to.have.been.calledWith(v1);
-      expect(this.collectionView.onBeforeAddChild).to.have.been.calledWith(v2);
+      expect(this.collectionView.onBeforeAddChild).to.have.been.calledWith(this.collectionView, v1);
+      expect(this.collectionView.onBeforeAddChild).to.have.been.calledWith(this.collectionView, v2);
     });
 
     it('should call "onAddChild" for each childView instance', function() {
       var v1 = this.collectionView.children.findByIndex(0);
       var v2 = this.collectionView.children.findByIndex(1);
-      expect(this.collectionView.onAddChild).to.have.been.calledWith(v1);
-      expect(this.collectionView.onAddChild).to.have.been.calledWith(v2);
+      expect(this.collectionView.onAddChild).to.have.been.calledWith(this.collectionView, v1);
+      expect(this.collectionView.onAddChild).to.have.been.calledWith(this.collectionView, v2);
     });
 
     it('should call "onBeforeAddChild" for all childView instances', function() {
@@ -676,7 +676,7 @@ describe('collection view', function() {
     });
 
     it('should pass the removed view to onBeforeRemoveChild', function() {
-      expect(this.collectionView.onBeforeRemoveChild).to.have.been.calledWithExactly(this.childView);
+      expect(this.collectionView.onBeforeRemoveChild).to.have.been.calledWithExactly(this.collectionView, this.childView);
     });
 
     it('should execute onRemoveChild', function() {
@@ -684,7 +684,7 @@ describe('collection view', function() {
     });
 
     it('should pass the removed view to _onCollectionRemove', function() {
-      expect(this.collectionView.onRemoveChild).to.have.been.calledWithExactly(this.childView);
+      expect(this.collectionView.onRemoveChild).to.have.been.calledWithExactly(this.collectionView, this.childView);
     });
 
     it('should execute onBeforeRemoveChild before _onCollectionRemove', function() {
@@ -964,11 +964,11 @@ describe('collection view', function() {
     });
 
     it('should bubble up through the parent collection view', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('childview:some:event', this.childView, 'test', this.model);
+      expect(this.collectionView.trigger).to.have.been.calledWith('childview:some:event', 'test', this.model);
     });
 
-    it('should provide the child view that triggered the event, including other relevant parameters', function() {
-      expect(this.someEventSpy).to.have.been.calledWith(this.childView, 'test', this.model);
+    it('should provide the relevant parameters', function() {
+      expect(this.someEventSpy).to.have.been.calledWith('test', this.model);
     });
   });
 
@@ -993,11 +993,11 @@ describe('collection view', function() {
     });
 
     it('should bubble up through the parent collection view', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('myPrefix:some:event', this.childView, 'test', this.model);
+      expect(this.collectionView.trigger).to.have.been.calledWith('myPrefix:some:event', 'test', this.model);
     });
 
-    it('should provide the child view that triggered the event, including other relevant parameters', function() {
-      expect(this.someEventSpy).to.have.been.calledWith(this.childView, 'test', this.model);
+    it('should provide the relevant parameters', function() {
+      expect(this.someEventSpy).to.have.been.calledWith('test', this.model);
     });
   });
 
@@ -1024,12 +1024,8 @@ describe('collection view', function() {
       });
 
       it('should bubble up through the parent collection view', function() {
-        // As odd as it seems, the events are triggered with two arguments,
-        // the first being the child view which triggered the event
-        // and the second being the event's owner.  It just so happens to be the
-        // same view.
-        expect(this.beforeSpy).to.have.been.calledWith(this.childView, this.childView);
-        expect(this.renderSpy).to.have.been.calledWith(this.childView, this.childView);
+        expect(this.beforeSpy).to.have.been.calledWith(this.childView);
+        expect(this.renderSpy).to.have.been.calledWith(this.childView);
       });
     });
 
@@ -1310,11 +1306,11 @@ describe('collection view', function() {
     });
 
     it('should bubble up through the parent collection view', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('childview:some:event', this.childView, 'test', this.model);
+      expect(this.collectionView.trigger).to.have.been.calledWith('childview:some:event', 'test', this.model);
     });
 
-    it('should provide the child view that triggered the event, including other relevant parameters', function() {
-      expect(this.someEventSpy).to.have.been.calledWith(this.childView, 'test', this.model);
+    it('should provide the relevant parameters', function() {
+      expect(this.someEventSpy).to.have.been.calledWith('test', this.model);
     });
   });
 
@@ -1340,11 +1336,11 @@ describe('collection view', function() {
     });
 
     it('should bubble up through the parent collection view', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('childview:some:event', this.childView, 'test', this.model);
+      expect(this.collectionView.trigger).to.have.been.calledWith('childview:some:event', 'test', this.model);
     });
 
-    it('should provide the child view that triggered the event, including other relevant parameters', function() {
-      expect(this.onSomeEventSpy).to.have.been.calledWith(this.childView, 'test', this.model);
+    it('should provide the relevant parameters', function() {
+      expect(this.onSomeEventSpy).to.have.been.calledWith('test', this.model);
     });
   });
 
@@ -1371,11 +1367,11 @@ describe('collection view', function() {
     });
 
     it('should bubble up through the parent collection view', function() {
-      expect(this.collectionView.trigger).to.have.been.calledWith('childview:some:event', this.childView, 'test', this.model);
+      expect(this.collectionView.trigger).to.have.been.calledWith('childview:some:event', 'test', this.model);
     });
 
-    it('should provide the child view that triggered the event, including other relevant parameters', function() {
-      expect(this.someEventSpy).to.have.been.calledWith(this.childView, 'test', this.model);
+    it('should provide the other relevant parameters', function() {
+      expect(this.someEventSpy).to.have.been.calledWith('test', this.model);
     });
   });
 

--- a/test/unit/utils/view.spec.js
+++ b/test/unit/utils/view.spec.js
@@ -342,21 +342,21 @@ describe('view mixin', function() {
 
       it('emits the event on the layout', function() {
         expect(this.layoutEventHandler)
-          .to.have.been.calledWith(this.childView, 'foo', 'bar')
+          .to.have.been.calledWith('foo', 'bar')
           .and.to.have.been.calledOn(this.layoutView)
           .and.CalledOnce;
       });
 
       it('invokes the layout on handler', function() {
         expect(this.layoutEventOnHandler)
-          .to.have.been.calledWith(this.childView, 'foo', 'bar')
+          .to.have.been.calledWith('foo', 'bar')
           .and.to.have.been.calledOn(this.layoutView)
           .and.CalledOnce;
       });
 
       it('invokes the layout childViewEvents handler', function() {
         expect(this.layoutViewOnBoomHandler)
-          .to.have.been.calledWith(this.childView, 'foo', 'bar')
+          .to.have.been.calledWith('foo', 'bar')
           .and.to.have.been.calledOn(this.layoutView)
           .and.CalledOnce;
       });
@@ -366,13 +366,14 @@ describe('view mixin', function() {
       beforeEach(function() {
         // use the function definition of childViewEvents instead of the hash
         this.layoutView.childViewEvents = this.childEventsFunction;
+        this.layoutView.delegateEvents();
         this.layoutView.showChildView('child', this.childView);
         this.childView.triggerMethod('boom', 'foo', 'bar');
       });
 
       it('invokes the layout childViewEvents handler', function() {
         expect(this.layoutViewOnBoomHandler)
-          .to.have.been.calledWith(this.childView, 'foo', 'bar')
+          .to.have.been.calledWith('foo', 'bar')
           .and.to.have.been.calledOn(this.layoutView)
           .and.CalledOnce;
       });
@@ -382,12 +383,12 @@ describe('view mixin', function() {
       beforeEach(function() {
         this.superView.showChildView('layout', this.layoutView);
         this.layoutView.showChildView('child', this.childView);
-        this.childView.triggerMethod('whack', this.childView, 'foo', 'bar');
+        this.childView.triggerMethod('whack', 'foo', 'bar');
       });
 
       it('invokes the super trigger handler', function() {
         expect(this.superViewOnRattleHandler)
-          .to.have.been.calledWith(this.layoutView, this.childView, 'foo', 'bar')
+          .to.have.been.calledWith('foo', 'bar')
           .to.have.been.calledOn(this.superView)
           .and.CalledOnce;
       });

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -301,6 +301,7 @@ describe('layoutView', function() {
       this.layoutView.childViewEvents = {
         'content:rendered': this.childEventsHandler
       };
+      this.layoutView.delegateEvents();
       this.layoutView.render();
 
       // create a child view which triggers an event on render

--- a/test/unit/view.triggers.spec.js
+++ b/test/unit/view.triggers.spec.js
@@ -31,16 +31,8 @@ describe('view triggers', function() {
       expect(this.fooHandlerStub).to.have.been.calledOnce;
     });
 
-    it('should include the view in the event args', function() {
-      expect(this.fooHandlerStub.lastCall.args[0]).to.contain({view: this.view});
-    });
-
-    it('should include the views model in the event args', function() {
-      expect(this.fooHandlerStub.lastCall.args[0]).to.contain({model: this.model});
-    });
-
-    it('should include the views collection in the event args', function() {
-      expect(this.fooHandlerStub.lastCall.args[0]).to.contain({collection: this.collection});
+    it('should include the view in the event', function() {
+      expect(this.fooHandlerStub.lastCall.args[0]).to.contain(this.view);
     });
   });
 
@@ -87,7 +79,7 @@ describe('view triggers', function() {
     });
   });
 
-  describe('triggers should stop propigation and events by default', function() {
+  describe('triggers should stop propagation and events by default', function() {
     beforeEach(function() {
       this.View = Marionette.View.extend({triggers: this.triggersHash});
       this.view = new this.View();
@@ -96,7 +88,7 @@ describe('view triggers', function() {
       this.view.$el.trigger(this.fooEvent);
     });
 
-    it('should stop propigation by default', function() {
+    it('should stop propagation by default', function() {
       expect(this.fooEvent.isPropagationStopped()).to.be.true;
     });
 


### PR DESCRIPTION
This is POC following https://github.com/marionettejs/backbone.marionette/pull/2845

* Added `childViewTriggers` to `CollectionView`
* Removed the proxied `childView` from proxied events
* made sure internal `triggerMethod`s passed the view
* moved the `childViewEvents` and `childViewTrigger` hash builds into a cache triggered by `delegateEvents`
* fixed a couple of `.call(...args)`