### PR TITLE
[docs-fix] showChildView

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -90,8 +90,8 @@ var LayoutView = Marionette.LayoutView.extend({
      Section: 'section'
    },
    onShow: function() {
-      this.Header.show(new Header());
-      this.Section.show(new Section());
+      this.showChildView('Header', new Header());
+      this.showChildView('Section', new Section());
    }
 });
 ```


### PR DESCRIPTION
As mentioned in http://marionettejs.com/docs/v2.4.4/marionette.layoutview.html#basic-usage reference a region with the `showChildView` method.