### PR TITLE
Refactor Region#reset and call it in Region#destroy

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -17,7 +17,7 @@ var Region = MarionetteObject.extend({
 
   constructor: function(options) {
     this._setOptions(options);
-    this.el = this.getOption('el');
+    this._initEl = this.el = this.getOption('el');
 
     // Handle when this.el is passed in as a $ wrapped element.
     this.el = this.el instanceof Backbone.$ ? this.el[0] : this.el;
@@ -354,11 +354,16 @@ var Region = MarionetteObject.extend({
     this.empty();
 
     if (this.$el) {
-      this.el = this.$el.selector;
+      this.el = this._initEl;
     }
 
     delete this.$el;
     return this;
+  },
+
+  destroy: function() {
+    this.reset();
+    return MarionetteObject.prototype.destroy.apply(this, arguments);
   }
 
 });

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -1183,6 +1183,29 @@ describe('region', function() {
     });
   });
 
+  describe('when destroying a region', function() {
+    beforeEach(function() {
+      this.setFixtures('<div id="region"></div>');
+
+      this.region = new Backbone.Marionette.Region({
+        el: '#region'
+      });
+
+      this.sinon.spy(this.region, 'reset');
+
+      this.sinon.spy(this.region, 'destroy');
+      this.region.destroy();
+    });
+
+    it('should reset the region', function() {
+      expect(this.region.reset).to.have.been.called;
+    });
+
+    it('should return the region', function() {
+      expect(this.region.destroy).to.have.returned(this.region);
+    });
+  });
+
   describe('when destroying a Mn view in a region', function() {
     beforeEach(function() {
       this.setFixtures('<div id="region"></div>');


### PR DESCRIPTION
I think this might be as simple as caching the initial value?

I know we had talked about removing it https://github.com/marionettejs/backbone.marionette/issues/1852 https://github.com/marionettejs/backbone.marionette/issues/2680, but it seems like we want that functionality, at least for now for layout.

reset currently breaks non-jQuery and upcoming jQuery v3  https://github.com/marionettejs/backbone.marionette/issues/2668 and https://github.com/marionettejs/backbone.marionette/pull/2850

@ianmstew @marionettejs/marionette-core think this is a solution?

With this I went ahead and resolved https://github.com/marionettejs/backbone.marionette/issues/2379