### PR TITLE
Fixed CollectionView::filter example

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -985,7 +985,7 @@ and a falsey value if it should not.
   cv.render();
 
   // change the filter
-  cv.filter = function (child, index, collection) {
+  cv.options.filter = function (child, index, collection) {
     return child.get('value') % 2 !== 0;
   };
 
@@ -993,9 +993,7 @@ and a falsey value if it should not.
   cv.render();
 
   // remove the filter
-  // note that using `delete cv.filter` will cause the prototype's filter to be used
-  // which may be undesirable
-  cv.filter = null;
+  cv.options.filter = null;
 
   // renders all views
   cv.render();


### PR DESCRIPTION
The example with CollectionView's filter was not working because in the function Marionette.getOption the 'options' property has precedence over the target's own properties.