### PR TITLE
Remove use of deprecated $.selector

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -112,7 +112,7 @@ const Region = MarionetteObject.extend({
       if (this.getOption('allowMissingEl')) {
         return false;
       } else {
-        throw new MarionetteError('An "el" ' + this.$el.selector + ' must exist in DOM');
+        throw new MarionetteError(`An "el" must exist in DOM for this region ${this.cid}`);
       }
     }
     return true;

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -79,7 +79,7 @@ describe('region', function() {
         it('should throw an exception saying an "el" doesnt exist in DOM', function() {
           expect(function() {
             this.region.show(new this.MyView());
-          }.bind(this)).to.throw('An "el" #not-existed-region must exist in DOM');
+          }.bind(this)).to.throw('An "el" must exist in DOM for this region ' + this.region.cid);
         });
 
         it('should not have a view', function() {


### PR DESCRIPTION
Mostly to initiate a discussion on that the thing.

linked to #2668

What is the nature of `this.el` at this point? Still a String? An Object? An Object with a nice `toString`?