### PR TITLE
Allow to use Marionette with Backbone 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - env: UNDERSCORE=1.4.4 BACKBONE=1.1.0
     - env: UNDERSCORE=1.5 BACKBONE=1.1
     - env: UNDERSCORE=1.7 BACKBONE=1.2.3
+    - env: UNDERSCORE=1.8 BACKBONE=1.3.0
     - node_js: "0.10"
       env: UNDERSCORE=1.8 BACKBONE=1.2.3
     - env: LODASH=2.4 BACKBONE=1.1

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "backbone.babysitter": "^0.1.0",
     "backbone.wreqr": "^1.0.0",
-    "backbone": "1.0.0 - 1.2.3",
+    "backbone": "1.0.0 - 1.3.0",
     "underscore": "1.4.4 - 1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Backbone 1.3 is out! According to [the changelog](https://github.com/jashkenas/backbone/blob/master/index.html#L4304), the new version has only a few fixes and adds two new methods to `Collection`.

It seems that latest Backbone can be safely used with current Marionette.