### PR TITLE
Updated view code to better match es6 paradigms

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -9,7 +9,7 @@ import getOption          from './utils/getOption';
 import normalizeMethods   from './utils/normalizeMethods';
 import deprecate          from './utils/deprecate';
 
-import MonitorViewEvents  from './monitor-view-events';
+import monitorViewEvents  from './monitor-view-events';
 import MarionetteObject   from './object';
 import Renderer           from './renderer';
 import TemplateCache      from './template-cache';
@@ -74,7 +74,7 @@ Marionette.triggerMethod = proxy(triggerMethod);
 Marionette.triggerMethodOn = triggerMethodOn;
 Marionette.isEnabled = isEnabled;
 Marionette.setEnabled = setEnabled;
-Marionette.MonitorViewEvents = MonitorViewEvents;
+Marionette.monitorViewEvents = monitorViewEvents;
 
 Marionette.Behaviors = {};
 Marionette.Behaviors.behaviorsLookup = behaviorsLookup;

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -6,7 +6,7 @@ import Backbone           from 'backbone';
 import ChildViewContainer from 'backbone.babysitter';
 import MarionetteError    from './error';
 import ViewMixin          from './mixins/view';
-import MonitorViewEvents  from './monitor-view-events';
+import monitorViewEvents  from './monitor-view-events';
 import destroyBackboneView from './utils/destroyBackboneView';
 import { triggerMethodOn } from './trigger-method';
 
@@ -29,7 +29,7 @@ const CollectionView = Backbone.View.extend({
 
     this._setOptions(options);
 
-    MonitorViewEvents(this);
+    monitorViewEvents(this);
 
     this._initBehaviors();
     this.once('render', this._initialEvents);
@@ -461,7 +461,7 @@ const CollectionView = Backbone.View.extend({
   _buildChildView(child, ChildViewClass, childViewOptions) {
     const options = _.extend({model: child}, childViewOptions);
     const childView = new ChildViewClass(options);
-    MonitorViewEvents(childView);
+    monitorViewEvents(childView);
     return childView;
   },
 
@@ -618,7 +618,7 @@ const CollectionView = Backbone.View.extend({
       }
 
       // use the parent view's proxyEvent handlers
-      var childViewTriggers = this._childViewTriggers;
+      const childViewTriggers = this._childViewTriggers;
 
       // Call the event with the proxy name on the parent layout
       if (childViewTriggers && _.isString(childViewTriggers[eventName])) {

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -13,7 +13,8 @@ import View            from './view';
 // Used for rendering a branch-leaf, hierarchical structure.
 // Extends directly from CollectionView and also renders an
 // a child view as `modelView`, for the top leaf
-var CompositeView = CollectionView.extend({
+// @deprecated
+const CompositeView = CollectionView.extend({
 
   // Setting up the inheritance chain which allows changes to
   // Marionette.CollectionView.prototype.constructor which allows overriding
@@ -102,7 +103,7 @@ var CompositeView = CollectionView.extend({
 
   // You might need to override this if you've overridden attachHtml
   attachBuffer(compositeView, buffer) {
-    var $container = this.getChildViewContainer(compositeView);
+    const $container = this.getChildViewContainer(compositeView);
     $container.append(buffer);
   },
 
@@ -110,7 +111,7 @@ var CompositeView = CollectionView.extend({
   // Overidden from CollectionView to ensure view is appended to
   // childViewContainer
   _insertAfter(childView) {
-    var $container = this.getChildViewContainer(this, childView);
+    const $container = this.getChildViewContainer(this, childView);
     $container.append(childView.el);
   },
 
@@ -118,7 +119,7 @@ var CompositeView = CollectionView.extend({
   // Overidden from CollectionView to ensure reordered views
   // are appended to childViewContainer
   _appendReorderedChildren(children) {
-    var $container = this.getChildViewContainer(this);
+    const $container = this.getChildViewContainer(this);
     $container.append(children);
   },
 
@@ -129,11 +130,11 @@ var CompositeView = CollectionView.extend({
       return containerView.$childViewContainer;
     }
 
-    var container;
-    var childViewContainer = getOption.call(containerView, 'childViewContainer');
+    let container;
+    const childViewContainer = getOption.call(containerView, 'childViewContainer');
     if (childViewContainer) {
 
-      var selector = getValue.call(containerView, childViewContainer);
+      const selector = getValue.call(containerView, childViewContainer);
 
       if (selector.charAt(0) === '@' && containerView.ui) {
         container = containerView.ui[selector.substr(4)];
@@ -166,7 +167,7 @@ var CompositeView = CollectionView.extend({
 
 // To prevent duplication but allow the best View organization
 // Certain View methods are mixed directly into the deprecated CompositeView
-var MixinFromView = _.pick(View.prototype, 'serializeModel', 'getTemplate', '_renderTemplate', 'attachElContent');
+const MixinFromView = _.pick(View.prototype, 'serializeModel', 'getTemplate', '_renderTemplate', 'attachElContent');
 _.extend(CompositeView.prototype, MixinFromView);
 
 export default CompositeView;

--- a/src/monitor-view-events.js
+++ b/src/monitor-view-events.js
@@ -24,7 +24,7 @@ function unsetIsAttached(view) {
 
 // Monitor a view's state, propagating attach/detach events to children and firing dom:refresh
 // whenever a rendered view is attached or an attached view is rendered.
-function MonitorViewEvents(view) {
+function monitorViewEvents(view) {
   if (view._areViewEventsMonitored) { return; }
 
   view._areViewEventsMonitored = true;
@@ -65,4 +65,4 @@ function MonitorViewEvents(view) {
   });
 }
 
-export default MonitorViewEvents;
+export default monitorViewEvents;

--- a/src/region.js
+++ b/src/region.js
@@ -6,7 +6,7 @@ import Backbone from 'backbone';
 import isNodeAttached from './utils/isNodeAttached';
 import MarionetteObject from './object';
 import MarionetteError from './error';
-import MonitorViewEvents from './monitor-view-events';
+import monitorViewEvents from './monitor-view-events';
 import destroyBackboneView from './utils/destroyBackboneView';
 import { triggerMethodOn } from './trigger-method';
 
@@ -45,7 +45,7 @@ const Region = MarionetteObject.extend({
 
     this.triggerMethod('before:show', this, view, options);
 
-    MonitorViewEvents(view);
+    monitorViewEvents(view);
 
     this.empty(options);
 

--- a/src/view.js
+++ b/src/view.js
@@ -5,19 +5,19 @@ import _                  from 'underscore';
 import Backbone           from 'backbone';
 import ViewMixin          from './mixins/view';
 import RegionsMixin       from './mixins/regions';
-import MonitorViewEvents  from './monitor-view-events';
+import monitorViewEvents  from './monitor-view-events';
 import Renderer           from './renderer';
 
 // The standard view. Includes view events, automatic rendering
 // of Underscore templates, nested views, and more.
-var View = Backbone.View.extend({
+const View = Backbone.View.extend({
 
   constructor(options) {
     this.render = _.bind(this.render, this);
 
     this._setOptions(options);
 
-    MonitorViewEvents(this);
+    monitorViewEvents(this);
 
     this._initBehaviors();
     this._initRegions();
@@ -92,7 +92,7 @@ var View = Backbone.View.extend({
   // Internal method to render the template with the serialized data
   // and template context via the `Marionette.Renderer` object.
   _renderTemplate() {
-    var template = this.getTemplate();
+    const template = this.getTemplate();
 
     // Allow template-less views
     if (template === false) {
@@ -100,10 +100,10 @@ var View = Backbone.View.extend({
     }
 
     // Add in entity data and template context
-    var data = this.mixinTemplateContext(this.serializeData());
+    const data = this.mixinTemplateContext(this.serializeData());
 
     // Render and add to el
-    var html = Renderer.render(template, data, this);
+    const html = Renderer.render(template, data, this);
     this.attachElContent(html);
   },
 


### PR DESCRIPTION
Updated the views to have consistency to use let instead of var or const

Next should probably update all of the uses of const to have the variables be all CAPS

(same as #2917 but off the correct branch)

Also de-capitalized `MonitorViewEvents` as it is not a class but a function.