### PR TITLE
Fix dependencies and html test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "underscore": "1.8 - 1.8.3"
   },
   "devDependencies": {
-    "babel-core": "^6.4.5",
+    "babel-core": "^6.7.0",
     "babel-eslint": "^4.1.7",
+    "babel-polyfill": "^6.6.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-register": "^6.4.3",
@@ -53,6 +54,7 @@
     "chai": "^3.4.0",
     "chai-jq": "0.0.9",
     "dox": "git://github.com/jasonLaster/dox.git#marked",
+    "eslint": "2.2.0",
     "glob": "^7.0.0",
     "gulp": "^3.9.0",
     "gulp-coveralls": "^0.1.4",

--- a/test/runner.html
+++ b/test/runner.html
@@ -6,7 +6,7 @@
   <link rel='stylesheet' href='../node_modules/mocha/mocha.css' />
 
   <!-- Polyfill (required by Babel) -->
-  <script src='../node_modules/babel-core/browser-polyfill.js'></script>
+  <script src='../node_modules/babel-polyfill/dist/polyfill.js'></script>
 
   <!-- Testing libraries -->
   <script src='../node_modules/mocha/mocha.js'></script>


### PR DESCRIPTION
Locked eslint per https://github.com/eslint/eslint/issues/5476

Added two babel dependencies for node < 5 so the test runner can find the files in node_modules