### PR TITLE
Remove extra variable passing from 'isEmpty'  call on collection-view

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -240,7 +240,7 @@ const CollectionView = Backbone.View.extend({
     this._destroyChildren({checkEmpty: false});
 
     const models = this._filteredSortedModels();
-    if (this.isEmpty(this.collection, {processedModels: models})) {
+    if (this.isEmpty({processedModels: models})) {
       this._showEmptyView();
     } else {
       this.triggerMethod('before:render:children', this);
@@ -490,7 +490,7 @@ const CollectionView = Backbone.View.extend({
   },
 
   // check if the collection is empty or optionally whether an array of pre-processed models is empty
-  isEmpty(collection, options) {
+  isEmpty(options) {
     let models;
     if (_.result(options, 'processedModels')) {
       models = options.processedModels;
@@ -503,7 +503,7 @@ const CollectionView = Backbone.View.extend({
 
   // If empty, show the empty view
   _checkEmpty() {
-    if (this.isEmpty(this.collection)) {
+    if (this.isEmpty()) {
       this._showEmptyView();
     }
   },

--- a/test/unit/collection-view.empty-view.spec.js
+++ b/test/unit/collection-view.empty-view.spec.js
@@ -325,10 +325,6 @@ describe('collectionview - emptyView', function() {
       it('should reference each of the rendered view items', function() {
         expect(this.collectionView.children).to.have.lengthOf(1);
       });
-
-      it('should pass the collection as an argument to isEmpty', function() {
-        expect(this.isEmptyStub).to.have.been.calledWith(this.collection);
-      });
     });
 
     describe('with a filter', function() {


### PR DESCRIPTION
Removed the passing of the collection into the `isEmpty` as it was not used from the parameters.