### PR TITLE
Renderer.render() only accepts two params.

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -2,13 +2,7 @@
 
 # Marionette.View
 
-An `View` is a view that represents a single item. That item may be a
-`Backbone.Model` or may be a `Backbone.Collection`. Whichever it is though, it
-will be treated as a single item.
-
-View extends directly from Marionette.AbstractView. Please see
-[the Marionette.AbstractView documentation](marionette.abstractview.md)
-for more information on available features and functionality.
+An `View` is a view that, most of the time, represents a single item. That item may be a`Backbone.Model` or may be a `Backbone.Collection`. Whichever it is though, itwill be treated as a single item. It’s also possible to create Views that do not represent items, but just contain regions (which can be filled with views as well).View extends directly from `Backbone.View`, which means you’re free to use Backbone’s methods in your Marionette Views.
 
 Additionally, interactions with Marionette.Region
 will provide features such as `onShow` callbacks, etc. Please see

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -2,7 +2,13 @@
 
 # Marionette.View
 
-An `View` is a view that, most of the time, represents a single item. That item may be a`Backbone.Model` or may be a `Backbone.Collection`. Whichever it is though, itwill be treated as a single item. It’s also possible to create Views that do not represent items, but just contain regions (which can be filled with views as well).View extends directly from `Backbone.View`, which means you’re free to use Backbone’s methods in your Marionette Views.
+An `View` is a view that represents a single item. That item may be a
+`Backbone.Model` or may be a `Backbone.Collection`. Whichever it is though, it
+will be treated as a single item.
+
+View extends directly from Marionette.AbstractView. Please see
+[the Marionette.AbstractView documentation](marionette.abstractview.md)
+for more information on available features and functionality.
 
 Additionally, interactions with Marionette.Region
 will provide features such as `onShow` callbacks, etc. Please see

--- a/src/view.js
+++ b/src/view.js
@@ -103,7 +103,7 @@ const View = Backbone.View.extend({
     const data = this.mixinTemplateContext(this.serializeData());
 
     // Render and add to el
-    const html = Renderer.render(template, data, this);
+    const html = Renderer.render(template, data);
     this.attachElContent(html);
   },
 


### PR DESCRIPTION
`Marionette.View` passes three parameters, where the third one seems unused.