### PR TITLE
Backbone radio docs

### DIFF
--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -77,9 +77,11 @@ access to this API.
   * [Assigning Channels to Objects](#assigning-channels-to-objects)
 * [Event](#event)
   * [Listening to Events on Objects](#listening-to-events-on-objects)
+  * [When to use Events](#when-to-use-events)
 * [Request](#request)
   * [Returning Values from Reply](#returning-values-from-reply)
   * [Listening to Requests on Objects](#listening-to-requests-on-objects)
+  * [When to use Requests](#when-to-use-requests)
 
 ## Channel
 
@@ -214,6 +216,20 @@ var Star = Mn.Object.extend({
 This gives us a clear definition of how this object interacts with the `star`
 radio channel.
 
+### When to use Events
+
+The Event is a simple notification that _something happened_ and you may or may
+not want other objects in your application to react to that. A few key
+principles to bear in mind are:
+
+* If you don't know what could act on the event, or don't care, use an `Event`
+* If you find yourself calling it an action that occurred, use an `Event`
+* If it's fine for many objects to perform an action, use an `Event`
+* If you don't mind that no objects react, use an `Event`
+
+If your use case isn't covered here, consider whether you want to
+[use a request](#when-to-use-requests) instead.
+
 ## Request
 
 The Request API provides a uniform way for unrelated parts of the system to
@@ -333,7 +349,7 @@ We now have a clear API for communicating with the `NotificationView` across the
 application. Don't forget to define the `channelName` on your `Object`
 definition.
 
-We can also return values from these handlers:
+As with a normal request/reply, we can return values from these bound handlers:
 
 ```javascript
 var Mn = require('backbone.marionette');
@@ -354,3 +370,12 @@ var App = Mn.Application.extend({
 As above, define your `channelName` attribute, then simply add the `reply`
 handler to `radioRequests` to bind it to your `Object` (`Application` in this
 case).
+
+### When to use Requests
+
+A Request is, as you might guess, a request for information or for something to
+happen. You will probably want to use requests when:
+
+* You call the request an action to perform e.g. `show:notification`
+* You want to get the return value of the request
+* You want to call _exactly one_ function

--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -72,7 +72,9 @@ In addition to this documentation, the Radio documentation can be found on
 * [Channel](#channel)
   * [Assigning Channels to Objects](#assigning-channels-to-objects)
 * [Event](#event)
+  * [Listening to Events on Objects](#listening-to-events-on-objects)
 * [Request](#request)
+  * [Listening to Requests on Objects](#listening-to-requests-on-objects)
 
 ## Channel
 
@@ -130,10 +132,14 @@ var ChannelView = Mn.View.extend({
 The `Radio Event` works almost exactly the same way as regular `Backbone Events`
 like model/collection events. They also expose exactly the same API:
 
-* `radio.on('event', callback, context)` - when `event` fires, call `callback`
-* `radio.off('event')` - stop listening to event
-* `radio.trigger('event', ..args)` - fires `event` and passes  args into the
+* `channel.on('event', callback, context)` - when `event` fires, call `callback`
+* `channel.off('event')` - stop listening to event
+* `channel.trigger('event', ..args)` - fires `event` and passes  args into the
   resulting `callback`
+
+Events are typically used to alert other parts of the system that something
+happened. For example, a user login expired or the user performed a specific
+action.
 
 As the Radio can be imported anywhere, we can use it as a global event
 aggregator as such:
@@ -141,7 +147,45 @@ aggregator as such:
 ```javascript
 var Radio = require('backbone.radio');
 
+var myChannel = Radio.channel('star');
 
+myChannel.on('left:building', function(person) {
+  console.log(person.get('name') + ' has left the building!');
+});
+
+var elvis = new Backbone.Model({name: 'Elvis'});
+myChannel.trigger('left:building', elvis);
+
+myChannel.off('left:building');
 ```
 
+Just like Backbone Events, the Radio respects the `listenTo` handler as well:
+
+```javascript
+var Mn = require('backbone.marionette');
+var Radio = require('backbone.radio');
+
+
+var Star = Mn.Object.extend({
+  initialize: function() {
+    var starChannel = Radio.channel('star');
+
+    this.listenTo(starChannel, 'left:building', this.leftBuilding);
+  },
+
+  leftBuilding: function(person) {
+    console.log(person.get('name') + ' has left the building!');
+  }
+});
+```
+
+As with Backbone, this will bind `this` to our `Star` instance.
+
+### Listening to Events on Objects
+
+The `Marionette.Object` class provides bindings to provide automatic event
+listeners on your object instances.
+
 ## Request
+
+### Listening to Requests on Objects

--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -6,7 +6,6 @@ Backbone and Marionette. This is provided through two basic constructs:
 * Events - trigger events on a global object
 * Requests - a global request/reply implementation
 
-
 Radio takes these two constructs and adds the channel implementation - providing
 namespaces for events and requests. In short, Radio is a global, namespaced,
 message bus system designed to allow two otherwise unrelated objects to
@@ -67,6 +66,11 @@ notifyChannel.trigger('user:logged:in', userModel);
 In addition to this documentation, the Radio documentation can be found on
 [Github](https://github.com/marionettejs/backbone.radio).
 
+In addition to the standard documentation, the Radio has been integrated in
+Marionette 3 to provide clearer interfaces to the existing API. This is detailed
+in the documentation below. As always, anything that extends from
+`Marionette.Object` has access to this API.
+
 ## Documentation Index
 
 * [Channel](#channel)
@@ -74,6 +78,7 @@ In addition to this documentation, the Radio documentation can be found on
 * [Event](#event)
   * [Listening to Events on Objects](#listening-to-events-on-objects)
 * [Request](#request)
+  * [Returning Values from Reply](#returning-values-from-reply)
   * [Listening to Requests on Objects](#listening-to-requests-on-objects)
 
 ## Channel
@@ -179,13 +184,173 @@ var Star = Mn.Object.extend({
 });
 ```
 
-As with Backbone, this will bind `this` to our `Star` instance.
+As with Backbone, this will bind `this` to our `Star` instance. See the
+[Backbone documentation](http://backbonejs.org/#Events) for the full list of
+Event handling methods.
 
 ### Listening to Events on Objects
 
 The `Marionette.Object` class provides bindings to provide automatic event
-listeners on your object instances.
+listeners on your object instances. This works with a bound `channelName` to let
+us provide listeners using the `radioEvents` attributes.
+
+```javascript
+var Mn = require('backbone.marionette');
+
+
+var Star = Mn.Object.extend({
+  channelName: 'star',
+
+  radioEvents: {
+    'left:building': 'leftBuilding'
+  },
+
+  leftBuilding: function(person) {
+    console.log(person.get('name') + ' has left the building!');
+  }
+});
+```
+
+This gives us a clear definition of how this object interacts with the `star`
+radio channel.
 
 ## Request
 
+The Request API provides a uniform way for unrelated parts of the system to
+communicate with each other. For example, displaying notifications in response
+to system activity. To attach a listener to a request channel, use `reply` or
+`replyOnce` to attach a listener that immediately detaches after one call.
+
+As with request, any arguments passed in `channel.request` will be passed into
+the callback.
+
+```javascript
+var Mn = require('backbone.marionette');
+var Radio = require('backbone.radio');
+
+var channel = Radio.channel('notify');
+
+var NotificationView = Mn.View.extend({
+  initialize: function() {
+    channel.reply('show:success', this.showSuccessMessage);
+    channel.reply('show:error', this.showErrorMessage);
+  },
+
+  showSuccessMessage: function(msg) {
+    // ...
+  },
+
+  showErrorMessage: function(msg) {
+    // ...
+  }
+});
+```
+
+So, for example, when a model sync fails:
+
+```javascript
+var Mn = require('backbone.marionette');
+var Radio = require('backbone.radio');
+
+var channel = Radio.channel('notify');
+
+var ModelView = Mn.View.extend({
+  modelEvents: {
+    error: 'showErrorMessage'
+  },
+
+  showErrorMessage: function() {
+    channel.request('show:error', 'An error occurred contacting the server');
+  }
+});
+```
+
+Now, whenever the model attached to this view is unable to sync with the server,
+we can display an error message to the user.
+
+### Returning Values from Reply
+
+The Request API is also able to return values, making it extremely useful for
+accessing objects that would be otherwise difficult to access. As an example,
+let's assume we attach the currently logged-in user to the `Application` object
+and we want to know if they're still logged-in.
+
+```javascript
+var Mn = require('backbone.marionette');
+var Radio = require('backbone.radio');
+
+var channel = Radio.channel('user');
+
+var App = Mn.Application.extend({
+  initialize: function() {
+    channel.reply('user:logged:in', this.isLoggedIn);
+  },
+
+  isLoggedIn: function() {
+    return this.model.getLoggedIn();
+  }
+});
+```
+
+Then, from another view, instead of trying to find the User model. we simply
+`request` it:
+
+```javascript
+var Radio = require('backbone.radio');
+
+var channel = Radio.channel('user');
+
+var loggedIn = channel.request('user:logged:in');  // App.model.getLoggedIn()
+```
+
 ### Listening to Requests on Objects
+
+Marionette 3 integrates Request/Reply directly onto its `Object` class through
+`radioRequests`. This will simplify the `NotificationView` quite a bit:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var NotificationView = Mn.View.extend({
+  channelName: 'notify',
+
+  radioRequests: {
+    'show:success': 'showSuccessMessage',
+    'show:error': 'showErrorMessage'
+  },
+
+  showSuccessMessage: function(msg) {
+    // ...
+  },
+
+  showErrorMessage: function(msg) {
+    // ...
+  }
+});
+```
+
+We now have a clear API for communicating with the `NotificationView` across the
+application. Don't forget to define the `channelName` on your `Object`
+definition.
+
+We can also return values from these handlers:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var App = Mn.Application.extend({
+  channelName: 'user',
+
+  radioRequests: {
+    'user:logged:in': 'isLoggedIn'
+  },
+
+  isLoggedIn: function() {
+    return this.model.getLoggedIn();
+  }
+});
+```
+
+As above, define your `channelName` attribute, then simply add the `reply`
+handler to `radioRequests` to bind it to your `Object` (`Application` in this
+case).

--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -68,8 +68,8 @@ In addition to this documentation, the Radio documentation can be found on
 
 In addition to the standard documentation, the Radio has been integrated in
 Marionette 3 to provide clearer interfaces to the existing API. This is detailed
-in the documentation below. As always, anything that extends from
-`Marionette.Object` has access to this API.
+in the documentation below. Anything that extends from `Marionette.Object` has
+access to this API.
 
 ## Documentation Index
 

--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -20,11 +20,14 @@ var Mn = require('backbone.marionette');
 var NotificationView = Mn.View.extend({
   channelName: 'notify',
 
-  initialize: function() {
-    var notifyChannel = this.getChannel();
+  radioRequests: {
+    'show:success': 'showSuccessMessage',
+    'show:error': 'showErrorMessage'
+  },
 
-    this.listenTo(notifyChannel, 'show:success', this.showSuccessMessage);
-    this.listenTo(notifyChannel, 'show:error', this.showErrorMessage);
+  radioEvents: {
+    'user:logged:in': 'showProfileButton',
+    'user:logged:out': 'hideProfileButton'
   },
 
   showSuccessMessage: function(message) {
@@ -32,6 +35,14 @@ var NotificationView = Mn.View.extend({
   },
 
   showErrorMessage: function(message) {
+    // ...
+  },
+
+  showProfileButton: function(user) {
+    // ...
+  },
+
+  hideProfileButton: function(user) {
     // ...
   }
 });
@@ -41,11 +52,16 @@ In an unrelated module:
 
 ```javascript
 var Radio = require('backbone.radio');
+var User = require('./models/user');
 
 var notifyChannel = Radio.channel('notify');
+var userModel = new User();
 
 // The following will call NotificationView.showErrorMessage(message)
-notifyChannel.trigger('show:error', 'A generic error occurred!');
+notifyChannel.request('show:error', 'A generic error occurred!');
+
+// The following will call NotificationView.showProfileButton(user)
+notifyChannel.trigger('user:logged:in', userModel);
 ```
 
 In addition to this documentation, the Radio documentation can be found on

--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -1,0 +1,63 @@
+# Backbone Radio
+
+The Backbone Radio provides easy support for a number of messaging patterns for
+Backbone and Marionette. This is provided through two basic constructs:
+
+* Events - trigger events on a global object
+* Requests - a global request/reply implementation
+
+
+Radio takes these two constructs and adds the channel implementation - providing
+namespaces for events and requests. In short, Radio is a global, namespaced,
+message bus system designed to allow two otherwise unrelated objects to
+communicate and share information.
+
+Let's look at a simplified example in Marionette:
+
+```javascript
+var Mn = require('backbone.marionette');
+var Radio = require('backbone.radio');
+
+var notifyChannel = Radio.channel('notify');
+
+var NotificationView = Mn.View.extend({
+  initialize: function() {
+    this.listenTo(notifyChannel, 'show:success', this.showSuccessMessage);
+    this.listenTo(notifyChannel, 'show:error', this.showErrorMessage);
+  },
+
+  showSuccessMessage: function(message) {
+    // ...
+  },
+
+  showErrorMessage: function(message) {
+    // ...
+  }
+});
+```
+
+In an unrelated module:
+
+```javascript
+var Radio = require('backbone.radio');
+
+var notifyChannel = Radio.channel('notify');
+
+// The following will call NotificationView.showErrorMessage(message)
+notifyChannel.trigger('show:error', 'A generic error occurred!');
+```
+
+In addition to this documentation, the Radio documentation can be found on
+[Github](https://github.com/marionettejs/backbone.radio).
+
+## Documentation Index
+
+* [Event](#event)
+* [Request](#request)
+* [Channel](#channel)
+
+## Event
+
+## Request
+
+## Channel

--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -14,9 +14,9 @@ communicate and share information.
 Let's look at a simplified example in Marionette:
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 
-var NotificationView = Mn.View.extend({
+var NotificationHandler = Marionette.Object.extend({
   channelName: 'notify',
 
   radioRequests: {
@@ -56,10 +56,10 @@ var User = require('./models/user');
 var notifyChannel = Radio.channel('notify');
 var userModel = new User();
 
-// The following will call NotificationView.showErrorMessage(message)
+// The following will call Notification.showErrorMessage(message)
 notifyChannel.request('show:error', 'A generic error occurred!');
 
-// The following will call NotificationView.showProfileButton(user)
+// The following will call Notification.showProfileButton(user)
 notifyChannel.trigger('user:logged:in', userModel);
 ```
 
@@ -118,9 +118,9 @@ use the `channelName` attribute. We then retrieve the channel instance with
 `getChannel()`:
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 
-var ChannelView = Mn.View.extend({
+var ChannelHandler = Marionette.Object.extend({
   channelName: 'basic',
 
   initialize: function() {
@@ -169,11 +169,11 @@ myChannel.off('left:building');
 Just like Backbone Events, the Radio respects the `listenTo` handler as well:
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 var Radio = require('backbone.radio');
 
 
-var Star = Mn.Object.extend({
+var Star = Marionette.Object.extend({
   initialize: function() {
     var starChannel = Radio.channel('star');
 
@@ -197,10 +197,10 @@ listeners on your object instances. This works with a bound `channelName` to let
 us provide listeners using the `radioEvents` attributes.
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 
 
-var Star = Mn.Object.extend({
+var Star = Marionette.Object.extend({
   channelName: 'star',
 
   radioEvents: {
@@ -241,12 +241,12 @@ As with request, any arguments passed in `channel.request` will be passed into
 the callback.
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 var Radio = require('backbone.radio');
 
 var channel = Radio.channel('notify');
 
-var NotificationView = Mn.View.extend({
+var Notification = Marionette.Object.extend({
   initialize: function() {
     channel.reply('show:success', this.showSuccessMessage);
     channel.reply('show:error', this.showErrorMessage);
@@ -265,12 +265,12 @@ var NotificationView = Mn.View.extend({
 So, for example, when a model sync fails:
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 var Radio = require('backbone.radio');
 
 var channel = Radio.channel('notify');
 
-var ModelView = Mn.View.extend({
+var ModelView = Marionette.View.extend({
   modelEvents: {
     error: 'showErrorMessage'
   },
@@ -281,7 +281,7 @@ var ModelView = Mn.View.extend({
 });
 ```
 
-Now, whenever the model attached to this view is unable to sync with the server,
+Now, whenever the model attached to this View is unable to sync with the server,
 we can display an error message to the user.
 
 ### Returning Values from Reply
@@ -292,12 +292,12 @@ let's assume we attach the currently logged-in user to the `Application` object
 and we want to know if they're still logged-in.
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 var Radio = require('backbone.radio');
 
 var channel = Radio.channel('user');
 
-var App = Mn.Application.extend({
+var App = Marionette.Application.extend({
   initialize: function() {
     channel.reply('user:logged:in', this.isLoggedIn);
   },
@@ -322,12 +322,12 @@ var loggedIn = channel.request('user:logged:in');  // App.model.getLoggedIn()
 ### Listening to Requests on Objects
 
 Marionette 3 integrates Request/Reply directly onto its `Object` class through
-`radioRequests`. This will simplify the `NotificationView` quite a bit:
+`radioRequests`. This will simplify the `Notification` quite a bit:
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 
-var NotificationView = Mn.View.extend({
+var Notification = Marionette.Object.extend({
   channelName: 'notify',
 
   radioRequests: {
@@ -345,16 +345,16 @@ var NotificationView = Mn.View.extend({
 });
 ```
 
-We now have a clear API for communicating with the `NotificationView` across the
+We now have a clear API for communicating with the `Notification` across the
 application. Don't forget to define the `channelName` on your `Object`
 definition.
 
 As with a normal request/reply, we can return values from these bound handlers:
 
 ```javascript
-var Mn = require('backbone.marionette');
+var Marionette = require('backbone.marionette');
 
-var App = Mn.Application.extend({
+var App = Marionette.Application.extend({
   channelName: 'user',
 
   radioRequests: {

--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -16,12 +16,13 @@ Let's look at a simplified example in Marionette:
 
 ```javascript
 var Mn = require('backbone.marionette');
-var Radio = require('backbone.radio');
-
-var notifyChannel = Radio.channel('notify');
 
 var NotificationView = Mn.View.extend({
+  channelName: 'notify',
+
   initialize: function() {
+    var notifyChannel = this.getChannel();
+
     this.listenTo(notifyChannel, 'show:success', this.showSuccessMessage);
     this.listenTo(notifyChannel, 'show:error', this.showErrorMessage);
   },
@@ -52,12 +53,79 @@ In addition to this documentation, the Radio documentation can be found on
 
 ## Documentation Index
 
+* [Channel](#channel)
+  * [Assigning Channels to Objects](#assigning-channels-to-objects)
 * [Event](#event)
 * [Request](#request)
-* [Channel](#channel)
+
+## Channel
+
+The `channel` is the biggest reason to use `Radio` as our event aggregator - it
+provides a clean point for dividing global events. To retrieve a channel, use
+`Radio.channel(channelName)`:
+
+```javascript
+var Radio = require('backbone.radio');
+
+var myChannel = Radio.channel('basic');
+
+myChannel.on('some:event', function() {
+  // ...
+});
+```
+
+The channel is accessible everywhere in your application. Simply import Radio
+and call `channel()` to add listeners, fire callbacks, or send requests.
+
+```javascript
+var Radio = require('backbone.radio');
+
+var someChannel = Radio.channel('basic');  // Exactly the same channel as above
+
+someChannel.trigger('some:event');  // Will fire the function call above
+```
+
+### Assigning Channels to Objects
+
+As of Marionette 3, it is now possible to assign Radio channels directly to
+instances of `Marionette.Object` and assign listeners. To assign a channel, we
+use the `channelName` attribute. We then retrieve the channel instance with
+`getChannel()`:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var ChannelView = Mn.View.extend({
+  channelName: 'basic',
+
+  initialize: function() {
+    var channel = this.getChannel();
+    this.listenTo(channel, 'log', this.logMsg);
+  },
+
+  showAlertMessage: function(msg) {
+    console.log(msg);
+  }
+})
+```
 
 ## Event
 
-## Request
+The `Radio Event` works almost exactly the same way as regular `Backbone Events`
+like model/collection events. They also expose exactly the same API:
 
-## Channel
+* `radio.on('event', callback, context)` - when `event` fires, call `callback`
+* `radio.off('event')` - stop listening to event
+* `radio.trigger('event', ..args)` - fires `event` and passes  args into the
+  resulting `callback`
+
+As the Radio can be imported anywhere, we can use it as a global event
+aggregator as such:
+
+```javascript
+var Radio = require('backbone.radio');
+
+
+```
+
+## Request


### PR DESCRIPTION
I've started outlining the Radio documentation with a really quick example. I think we should outline the basic API here but I'm not sure whether we should include the full documentation, structure, diagrams, etc. for Radio here too or if we can leave it all in the docs in Radio itself.

As always, I'm happy to get some early feedback and I can incorporate it as I work through the docs. 

See #2647 