### PR TITLE
Import underscore as dependency

### DIFF
--- a/src/monitor-view-events.js
+++ b/src/monitor-view-events.js
@@ -2,6 +2,7 @@
 // -----------
 
 import { triggerMethodOn } from './trigger-method';
+import _ from 'underscore';
 
 // Trigger method on children unless a pure Backbone.View
 function triggerMethodChildren(view, event, beforeEachTrigger) {


### PR DESCRIPTION
monitor-view-events has a dependency on `underscore` due to `triggerMethodChildren` calling `_.each`.

This PR introduces `underscore` as a dependency so no exception is thrown.