### PR TITLE
Check options for replaceElement / allowMissingEl

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -37,7 +37,7 @@ const Region = MarionetteObject.extend({
   // method for you. Reads content directly from the `el` attribute. The `preventDestroy`
   // option can be used to prevent a view from the old view being destroyed on show.
   show(view, options) {
-    if (!this._ensureElement()) {
+    if (!this._ensureElement(options)) {
       return;
     }
     this._ensureView(view);
@@ -84,9 +84,9 @@ const Region = MarionetteObject.extend({
     }
   },
 
-  _attachView(view) {
+  _attachView(view, options = {}) {
     const shouldTriggerAttach = !view._isAttached && isNodeAttached(this.el);
-    const shouldReplaceEl = !!this.getOption('replaceElement');
+    const shouldReplaceEl = typeof options.replaceElement === 'undefined' ? !!this.getOption('replaceElement') : !!options.replaceElement;
 
     if (shouldTriggerAttach) {
       triggerMethodOn(view, 'before:attach', view);
@@ -102,14 +102,16 @@ const Region = MarionetteObject.extend({
     this.currentView = view;
   },
 
-  _ensureElement() {
+  _ensureElement(options = {}) {
     if (!_.isObject(this.el)) {
       this.$el = this.getEl(this.el);
       this.el = this.$el[0];
     }
 
     if (!this.$el || this.$el.length === 0) {
-      if (this.getOption('allowMissingEl')) {
+      const allowMissingEl = typeof options.allowMissingEl === 'undefined' ? !!this.getOption('allowMissingEl') : !!options.allowMissingEl;
+
+      if (allowMissingEl) {
         return false;
       } else {
         throw new MarionetteError(`An "el" must exist in DOM for this region ${this.cid}`);

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -239,7 +239,7 @@ describe('region', function() {
       beforeEach(function() {
         this.MyRegion = Backbone.Marionette.Region.extend({
           el: '#region',
-          onShow: function() {},
+          onShow: function() {}
         });
 
         this.MyView2 = Backbone.View.extend({
@@ -1042,6 +1042,28 @@ describe('region', function() {
 
     it('should call "render" on the view', function() {
       expect(this.view.render).to.have.been.calledOnce;
+    });
+  });
+
+  describe('when calling "_ensureElement"', function() {
+    beforeEach(function() {
+      this.region = new Backbone.Marionette.Region({
+        el: '#region'
+      });
+    });
+
+    it('should prefer passed options over initial options', function() {
+      this.region.options.allowMissingEl = false;
+      
+      expect(this.region._ensureElement({allowMissingEl: true})).to.be.false;
+    });
+    
+    it('should fallback to initial options when not passed options', function() {
+      this.region.options.allowMissingEl = false;
+      
+      expect(function(){
+        this.region._ensureElement();
+      }.bind(this)).to.throw;
     });
   });
 });


### PR DESCRIPTION
Previously, the Region object was only able to find `replaceElement` and `allowMissingEl` options if they were passed as constructor params. Now, the options object passed to `show` is also valid.

If both are provided, `show` takes precedence as it seems to make sense to override default values with method options.

I chose to continue using the same formatting seen in `_removeView` for handling check for options value.

Resolves #2957 