### PR TITLE
buildChildView, removeChildView and introduce addChildView

### DIFF
--- a/test/unit/collection-view.filter.spec.js
+++ b/test/unit/collection-view.filter.spec.js
@@ -71,7 +71,7 @@ describe('collection view - filter', function() {
       this.collection.add(this.passModel);
       this.collection.add(this.failModel);
       this.collectionView = new this.CollectionView();
-      this.sinon.spy(this.collectionView, '_removeChildView');
+      this.sinon.spy(this.collectionView, 'removeChildView');
       this.collectionView.render();
     });
 
@@ -123,7 +123,7 @@ describe('collection view - filter', function() {
       });
 
       it('should remove the child view', function() {
-        expect(this.collectionView._removeChildView).to.have.been.calledOnce
+        expect(this.collectionView.removeChildView).to.have.been.calledOnce
           .and.calledOn(this.collectionView)
           .and.calledWith(this.passView);
       });


### PR DESCRIPTION
`_addChild` `_buildChildView` and `_removeChildView` were made private for v3.

I've personally run into issues with needing `buildChildView` to show different views with different models than in the collection itself.  (essentially it uses the model in the collection to know which model type to get and show with a view)

I've also heard feedback that `addChild` would be missed.  However `_addChild` is doing a lot, and using it seems overly complex when you simply need to add a view as a child to the collectionView.