### PR TITLE
[docs] fix event name

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -616,7 +616,7 @@ myView.on("render", function(){
   alert("the collection view was rendered!");
 });
 
-myView.on("collection:rendered", function(){
+myView.on("render:collection", function(){
   alert("the collection view was rendered!");
 });
 


### PR DESCRIPTION
I noticed my listener for "collection:rendered" wasn't working. Looks like the example event name is wrong?  "collection:rendered" doesn't exist anywhere in the source