### PR TITLE
Remove unneeded error handler

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -81,10 +81,6 @@ function bundle(type) {
 function buildLib(type, dest) {
   return bundle(type).then(gen => {
     return file(name + '.js', gen.code, {src: true})
-      .on('error', function(err) {
-        console.log(err);
-        this.emit('end');
-      })
       .pipe(plumber())
       .pipe(sourcemaps.init({loadMaps: true}))
       .pipe(sourcemaps.write('./'))


### PR DESCRIPTION
After a conversation with @paulfalgout, this code is a hold over from days that generator-babel-boilerplate used browserify. https://github.com/babel/generator-babel-boilerplate/blob/v3.0.0/gulpfile.js#L112

```
 .on('error', function(err) {
   console.log(err);
   this.emit('end');
 })
```
(Found: https://github.com/marionettejs/backbone.marionette/blob/next/gulp/build.js#L84)

I've tested it several ways and I've found that rollup will handle any bundling errors, stopping the process before the built files are written to the `dist/`.