### PR TITLE
Update rollup to v.0.26.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "jquery": "^2.1.4",
     "jsdom": "^8.0.2",
     "mocha": "^2.4.5",
-    "rollup": "^0.25.4",
+    "rollup": "^0.26.1",
     "rollup-plugin-babel": "^2.3.9",
     "rollup-plugin-commonjs": "^2.2.1",
     "rollup-plugin-json": "^2.0.0",


### PR DESCRIPTION
Versions prior to v1 don’t update the minor version with the `^`. So this update needs to be done manually. 

New version fixes bad sourcemap errors: https://github.com/rollup/rollup/issues/618.