### PR TITLE
Added a warning to the top of all pages #3002

### DIFF
--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -1,3 +1,6 @@
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
+
 # Backbone Radio
 
 The Backbone Radio provides easy support for a number of messaging patterns for

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,6 @@
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
+
 # Installing Marionette
 
 As with all JavaScript libraries, there are a number of ways to get started with
@@ -10,18 +13,18 @@ a Marionette application. In this section we'll cover the most common ways.
 together into a single bundle to be delivered to your browser's `<script>` tag.
 It works particularly well with Marionette and jQuery.
 
-[Here](https://github.com/marionettejs/marionette-integrations/tree/master/webpack) 
+[Here](https://github.com/marionettejs/marionette-integrations/tree/master/webpack)
 we prepared simple marionettejs skeleton with Webpack.
 
 
 ## Quick start using NPM and Brunch
 
-[Brunch][brunch] is fast front-end web app build tool with simple declarative config, 
-seamless incremental compilation for rapid development, an opinionated pipeline 
+[Brunch][brunch] is fast front-end web app build tool with simple declarative config,
+seamless incremental compilation for rapid development, an opinionated pipeline
 and workflow, and core support for source maps.
 
 [Here](https://github.com/marionettejs/marionette-integrations/tree/master/brunch)
-we prepared simple marionettejs skeleton with Brunch. 
+we prepared simple marionettejs skeleton with Brunch.
 
 
 ## Quick start using NPM and Browserify
@@ -31,7 +34,7 @@ modules into your application, so you can `require` them as you would import
 dependencies in any other language.
 
 [Here](https://github.com/marionettejs/marionette-integrations/tree/master/browserify)
-we prepared simple marionettejs skeleton with Browserify. 
+we prepared simple marionettejs skeleton with Browserify.
 
 
 [browserify]: http://browserify.org/

--- a/docs/marionette.abstractview.md
+++ b/docs/marionette.abstractview.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.abstractview.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.AbstractView
 

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.application.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.Application
 

--- a/docs/marionette.approuter.md
+++ b/docs/marionette.approuter.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.approuter.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.AppRouter
 

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.behavior.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.Behavior
 

--- a/docs/marionette.behaviors.md
+++ b/docs/marionette.behaviors.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.behaviors.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.Behaviors
 

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.collectionview.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.CollectionView
 

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.compositeview.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.CompositeView
 

--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.functions.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette functions
 

--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.object.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.Object
 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.region.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Regions
 

--- a/docs/marionette.regionmanager.md
+++ b/docs/marionette.regionmanager.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.regionmanager.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.RegionManager
 

--- a/docs/marionette.renderer.md
+++ b/docs/marionette.renderer.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.renderer.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.Renderer
 

--- a/docs/marionette.templatecache.md
+++ b/docs/marionette.templatecache.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.templatecache.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.TemplateCache
 

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -1,4 +1,5 @@
-## [View the new docs](http://marionettejs.com/docs/marionette.view.html)
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
 
 # Marionette.View
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,3 +2,6 @@
 
 All of the documentation for Marionette can be found on the website at
 ##### [marionettejs.com/docs/current](http://marionettejs.com/docs/current)
+
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**


### PR DESCRIPTION
I’ve added a short notice to the top of every page in the docs - we
could use some nice styling but that’s not my strong point. It’ll be
worthwhile having a strategy like this going forward as many frameworks
provide warnings like this.