### PR TITLE
Behaviors ui override master

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -252,6 +252,58 @@ Marionette.Behavior.extend({
 });
 ```
 
+### ui
+
+Same thing as documented in Marionette.View, `ui` hash let you maps UI elements to their jQuery selectors.
+Thus a behavior can have its own selectors and as in a view, you will be able to attach events to these ui elements.
+
+```js
+var Foo = Marionette.Behavior.extend({
+  ui: {
+    foo: '.foo'
+  },
+
+  events: {
+    'click @ui.foo': 'onFooClick'
+  },
+
+  onFooClick: function () {
+    console.log('foo');
+  }
+});
+```
+Behaviors are small unit logics that you can reuse and share between views. To push forward their usage, a view can override the selectors defined by the applied behaviors. Using the example above, if a view a want to map `foo` to another selector, it is as easy as adding the `foo` key under view `ui` hash with the corresponding selector.
+
+Given the example below:
+
+```js
+var FirstView = Marionette.View.extend({
+  ui: {
+    "foo": ".foo-btn"
+  },
+
+  behaviors: {
+    Foo: {
+      // no options
+    }
+  }
+});
+
+var SecondView = Marionette.View.extend({
+  behaviors: {
+    Foo: {
+      // no options
+    }
+  }
+});
+
+var firstView = new FirstView();
+var secondView = new SecondView();
+```
+
+This means that for the `firstView`, the `Foo` behavior will react to a click on `.foo-btn` while for the `secondView`, the `Foo` behavior will react to a click on the predefined `.foo` selector.
+
+
 ### defaults
 `defaults` can be a `hash` or `function` to define the default options for your `Behavior`. The default options will be overridden depending on what you set as the options per `Behavior`. (This works just like a `Backbone.Model`.)
 

--- a/src/behaviors.js
+++ b/src/behaviors.js
@@ -41,10 +41,21 @@ Marionette.Behaviors = (function(Marionette, _) {
       _.each(behaviors, function(b, i) {
         var _events = {};
         var behaviorEvents = _.clone(_.result(b, 'events')) || {};
+        var behaviorUI = b._uiBindings || _.result(b, 'ui');
+
+        // Construct an internal UI hash first using
+        // the behaviors UI hash and then the view UI hash.
+        // This allows the user to use UI hash elements
+        // defined in the parent view as well as those
+        // defined in the given behavior.
+        // This order will help the reuse and share of a behavior
+        // between multiple views, while letting a view override a
+        // selector under an UI key.
+        var ui = _.extend({}, behaviorUI, viewUI);
 
         // Normalize behavior events hash to allow
         // a user to use the @ui. syntax.
-        behaviorEvents = Marionette.normalizeUIKeys(behaviorEvents, getBehaviorsUI(b));
+        behaviorEvents = Marionette.normalizeUIKeys(behaviorEvents, ui);
 
         var j = 0;
         _.each(behaviorEvents, function(behaviour, key) {

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -343,6 +343,33 @@ describe('Behaviors', function() {
       });
     });
 
+    describe('view should be able to override predefined behavior ui', function () {
+      beforeEach(function() {
+        var AnotherView = Marionette.View.extend({
+          template: _.template('<div class="zip"></div><div class="bar"></div>'),
+          ui: {
+            bar: '.bar',
+            foo: '.zip'  // overrive foo selector behavior
+          },
+          behaviors: { foo: {} }
+        });
+
+        this.view = new AnotherView();
+        this.view.render();
+
+        this.view.$el.find('.zip').click();
+        this.view.$el.find('.bar').click();
+      });
+
+      it('should handle behavior ui click event', function() {
+        expect(this.onFooClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+      });
+
+      it('should handle view ui click event', function() {
+        expect(this.onBarClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+      });
+    });
+
     describe('within a view', function() {
       beforeEach(function() {
         this.view = new this.View();


### PR DESCRIPTION
The idea of this small change is to think the behaviors as small unit that can be reused for different views in a same project or shared between project. I've used the major branch on some project without any issues. 

This change was previously merged in major with the PR #2308  

As stated in the comment it was discussed in #2265 with explanations in #2266