### PR TITLE
Monitor for child already attached

### DIFF
--- a/src/monitor-view-events.js
+++ b/src/monitor-view-events.js
@@ -5,22 +5,32 @@ import { triggerMethodOn } from './trigger-method';
 import _ from 'underscore';
 
 // Trigger method on children unless a pure Backbone.View
-function triggerMethodChildren(view, event, beforeEachTrigger) {
+function triggerMethodChildren(view, event, shouldTrigger) {
   if (!view._getImmediateChildren) { return; }
   _.each(view._getImmediateChildren(), child => {
-    if (beforeEachTrigger) {
-      beforeEachTrigger(child);
-    }
+    if (!shouldTrigger(child)) { return; }
     triggerMethodOn(child, event, child);
   });
 }
 
-function setIsAttached(view) {
-  view._isAttached = true;
+function shouldTriggerAttach(view) {
+  return !view._isAttached;
 }
 
-function unsetIsAttached(view) {
+function shouldAttach(view) {
+  if (!shouldTriggerAttach(view)) { return false; }
+  view._isAttached = true;
+  return true;
+}
+
+function shouldTriggerDetach(view) {
+  return view._isAttached;
+}
+
+function shouldDetach(view) {
+  if (!shouldTriggerDetach(view)) { return false; }
   view._isAttached = false;
+  return true;
 }
 
 // Monitor a view's state, propagating attach/detach events to children and firing dom:refresh
@@ -31,20 +41,20 @@ function monitorViewEvents(view) {
   view._areViewEventsMonitored = true;
 
   function handleBeforeAttach() {
-    triggerMethodChildren(view, 'before:attach');
+    triggerMethodChildren(view, 'before:attach', shouldTriggerAttach);
   }
 
   function handleAttach() {
-    triggerMethodChildren(view, 'attach', setIsAttached);
+    triggerMethodChildren(view, 'attach', shouldAttach);
     triggerDOMRefresh();
   }
 
   function handleBeforeDetach() {
-    triggerMethodChildren(view, 'before:detach');
+    triggerMethodChildren(view, 'before:detach', shouldTriggerDetach);
   }
 
   function handleDetach() {
-    triggerMethodChildren(view, 'detach', unsetIsAttached);
+    triggerMethodChildren(view, 'detach', shouldDetach);
   }
 
   function handleRender() {

--- a/test/unit/on-attach.spec.js
+++ b/test/unit/on-attach.spec.js
@@ -185,6 +185,36 @@ describe('onAttach', function() {
       });
     });
 
+    describe('When showing a View with a single level of nested views in onAttach', function() {
+      let parentView;
+      let mainView;
+      let footerView;
+
+      beforeEach(function() {
+        const ParentView = View.extend({
+          onAttach: function() {
+            mainView = new ChildView();
+            footerView = new ChildView();
+            this.showChildView('main', mainView);
+            this.showChildView('footer', footerView);
+          }
+        });
+
+        parentView = new ParentView();
+        region.show(parentView);
+      });
+
+      it('should trigger onBeforeAttach & onAttach on the mainView', function() {
+        expectTriggerMethod(mainView.onBeforeAttach, mainView, false, mainView.onAttach);
+        expectTriggerMethod(mainView.onAttach, mainView, true);
+      });
+
+      it('should trigger onBeforeAttach & onAttach on the footerView', function() {
+        expectTriggerMethod(footerView.onBeforeAttach, footerView, false, footerView.onAttach);
+        expectTriggerMethod(footerView.onAttach, footerView, true);
+      });
+    });
+
     describe('When showing a View with two levels of nested views', function() {
       let grandparentView;
       let parentView;


### PR DESCRIPTION
#Helps to resolve https://jsfiddle.net/599dtsb7/6/ where child views attached during `onAttach` get their `attach` events triggered twice.

Solution: https://jsfiddle.net/599dtsb7/8/

This still needs:
- [x] Tests
- [ ] ~~Documentation? (I had previously recommended against using onAttach)~~
- [x] Research failing tests

~~Unfortunately this broke other tests which is concerning.  I'm not sure why this change would break any expected behaviors. Hopefully this will just show light on tests that weren't exactly what we expected vs simply moving this bug down the chain~~

Turns out I just legit had a bug.