### PR TITLE
Make internal triggerMethods consistent

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -49,8 +49,8 @@ var Application = MarionetteObject.extend({
 
   // kick off all of the application's processes.
   start: function(options) {
-    this.triggerMethod('before:start', options);
-    this.triggerMethod('start', options);
+    this.triggerMethod('before:start', this, options);
+    this.triggerMethod('start', this, options);
   }
 
 });

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -105,13 +105,13 @@ export default {
   },
 
   _addRegion: function(region, name) {
-    this.triggerMethod('before:add:region', name, region);
+    this.triggerMethod('before:add:region', this, name, region);
 
     region._parent = this;
 
     this._regions[name] = region;
 
-    this.triggerMethod('add:region', name, region);
+    this.triggerMethod('add:region', this, name, region);
   },
 
   // Remove a single region from the View, by name
@@ -133,7 +133,7 @@ export default {
   },
 
   _removeRegion: function(region, name) {
-    this.triggerMethod('before:remove:region', name, region);
+    this.triggerMethod('before:remove:region', this, name, region);
 
     region.empty();
     region.stopListening();
@@ -141,7 +141,7 @@ export default {
     delete this.regions[name];
     delete this._regions[name];
 
-    this.triggerMethod('remove:region', name, region);
+    this.triggerMethod('remove:region', this, name, region);
   },
 
   // Empty all regions in the region manager, but

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -123,7 +123,7 @@ var ViewMixin = {
     if (this._isDestroyed) { return this; }
     const shouldTriggerDetach = !!this._isAttached;
 
-    this.triggerMethod('before:destroy', ...args);
+    this.triggerMethod('before:destroy', this, ...args);
     if (shouldTriggerDetach) {
       this.triggerMethod('before:detach', this);
     }
@@ -147,7 +147,7 @@ var ViewMixin = {
 
     this._isDestroyed = true;
     this._isRendered = false;
-    this.triggerMethod('destroy', ...args);
+    this.triggerMethod('destroy', this, ...args);
 
     this.stopListening();
 

--- a/src/object.js
+++ b/src/object.js
@@ -39,9 +39,10 @@ _.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, RadioMixin, {
   destroy: function(...args) {
     if (this._isDestroyed) { return this; }
 
-    this.triggerMethod('before:destroy', ...args);
+    this.triggerMethod('before:destroy', this, ...args);
+
     this._isDestroyed = true;
-    this.triggerMethod('destroy', ...args);
+    this.triggerMethod('destroy', this, ...args);
     this.stopListening();
 
     return this;

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -30,7 +30,7 @@ describe('marionette application', function() {
     });
 
     it('should pass the startup option to the callback', function() {
-      expect(this.startStub).to.have.been.calledOnce.and.calledWith(this.fooOptions);
+      expect(this.startStub).to.have.been.calledOnce.and.calledWith(this.app, this.fooOptions);
     });
 
     it('should have a cidPrefix', function() {

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -115,11 +115,11 @@ describe('marionette object', function() {
 
     it('should pass the arguments down to the onBeforeDestroy method', function() {
       expect(this.beforeDestroyHandler)
-      .to.have.been.calledWithExactly(destroyArgs);
+      .to.have.been.calledWithExactly(this.object, destroyArgs);
     });
 
     it('should pass the arguments down to the onDestroy method', function() {
-      expect(this.onDestroyHandler).to.have.been.calledWithExactly(destroyArgs);
+      expect(this.onDestroyHandler).to.have.been.calledWithExactly(this.object, destroyArgs);
     });
   });
 });

--- a/test/unit/utils/view.spec.js
+++ b/test/unit/utils/view.spec.js
@@ -60,7 +60,7 @@ describe('view mixin', function() {
     it('should call an onDestroy method with any arguments passed to destroy', function() {
       expect(this.onDestroyStub)
         .to.have.been.calledOnce
-        .and.calledWith(this.argumentOne, this.argumentTwo);
+        .and.calledWith(this.view, this.argumentOne, this.argumentTwo);
     });
 
     it('should remove the view', function() {
@@ -149,7 +149,7 @@ describe('view mixin', function() {
     });
 
     it('should trigger the destroy event', function() {
-      expect(this.destroyStub).to.have.been.calledOnce.and.calledWith(this.argumentOne, this.argumentTwo);
+      expect(this.destroyStub).to.have.been.calledOnce.and.calledWith(this.view, this.argumentOne, this.argumentTwo);
     });
 
     it('should remove the view', function() {

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -652,12 +652,12 @@ describe('layoutView', function() {
       expect(this.beforeAddRegionSpy)
         .to.have.been.calledOnce
         .and.calledOn(this.layout)
-        .and.calledWith(this.regionName);
+        .and.calledWith(this.layout, this.regionName);
 
       expect(this.addRegionSpy)
         .to.have.been.calledOnce
         .and.calledOn(this.layout)
-        .and.calledWith(this.regionName);
+        .and.calledWith(this.layout, this.regionName);
     });
 
     it('should trigger correct region remove events', function() {
@@ -666,12 +666,12 @@ describe('layoutView', function() {
       expect(this.beforeRegionRemoveSpy)
         .to.have.been.calledOnce
         .and.calledOn(this.layout)
-        .and.calledWith(this.regionName);
+        .and.calledWith(this.layout, this.regionName);
 
       expect(this.removeRegionSpy)
         .to.have.been.calledOnce
         .and.calledOn(this.layout)
-        .and.calledWith(this.regionName);
+        .and.calledWith(this.layout, this.regionName);
     });
   });
 

--- a/test/unit/view.dynamic-regions.spec.js
+++ b/test/unit/view.dynamic-regions.spec.js
@@ -50,13 +50,13 @@ describe('itemView - dynamic regions', function() {
     });
 
     it('should trigger a before:add:region event', function() {
-      expect(this.beforeAddHandler).to.have.been.calledWith('foo');
-      expect(this.onBeforeAddSpy).to.have.been.calledWith('foo');
+      expect(this.beforeAddHandler).to.have.been.calledWith(this.layoutView, 'foo');
+      expect(this.onBeforeAddSpy).to.have.been.calledWith(this.layoutView, 'foo');
     });
 
     it('should trigger a add:region event', function() {
-      expect(this.addHandler).to.have.been.calledWith('foo', this.region);
-      expect(this.onAddSpy).to.have.been.calledWith('foo', this.region);
+      expect(this.addHandler).to.have.been.calledWith(this.layoutView, 'foo', this.region);
+      expect(this.onAddSpy).to.have.been.calledWith(this.layoutView, 'foo', this.region);
     });
   });
 
@@ -189,13 +189,13 @@ describe('itemView - dynamic regions', function() {
     });
 
     it('should trigger a before:remove:region event', function() {
-      expect(this.onBeforeRemoveSpy).to.have.been.calledWith('foo');
-      expect(this.beforeRemoveHandler).to.have.been.calledWith('foo');
+      expect(this.onBeforeRemoveSpy).to.have.been.calledWith(this.layoutView, 'foo');
+      expect(this.beforeRemoveHandler).to.have.been.calledWith(this.layoutView, 'foo');
     });
 
     it('should trigger a remove:region event', function() {
-      expect(this.onRemoveSpy).to.have.been.calledWith('foo', this.region);
-      expect(this.removeHandler).to.have.been.calledWith('foo', this.region);
+      expect(this.onRemoveSpy).to.have.been.calledWith(this.layoutView, 'foo', this.region);
+      expect(this.removeHandler).to.have.been.calledWith(this.layoutView, 'foo', this.region);
     });
 
     it('should remove the region', function() {


### PR DESCRIPTION
Now every `triggerMethod`'s first argument is `this` internally.

This was almost true already.