### PR TITLE
When a view is attached to an existing element, `isRendered()` should reflect `true`

### DIFF
--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -613,7 +613,6 @@ describe('layoutView', function() {
           }
         });
         this.layoutViewInstance = new this.View();
-        this.layoutViewInstance.render();
         var $specNode = $('.region-hash-no-template-spec');
         this.$inScopeRegion =  $specNode.find('.some-layout-view .region-one');
         this.$outOfScopeRegion = $specNode.children('.region-one');

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -11,6 +11,27 @@ describe('item view', function() {
     this.templateStub = this.sinon.stub().returns(this.template);
   });
 
+  describe('when instantiating a view with a DOM element', function() {
+    beforeEach(function() {
+      this.setFixtures('<div id="foo">bar</div>');
+      this.view = new Marionette.View({
+        el: '#foo'
+      });
+    });
+
+    it('should be rendered', function() {
+      expect(this.view.isRendered()).to.be.true;
+    });
+
+    it('should be attached', function() {
+      expect(this.view.isAttached()).to.be.true;
+    });
+
+    it('should contain the DOM content', function() {
+      expect(this.view.el.innerHTML).to.contain('bar');
+    });
+  });
+
   describe('when rendering without a valid template', function() {
     beforeEach(function() {
       this.view = new Marionette.View();


### PR DESCRIPTION
Resolves #2859

The view.child-views.spec change was necessary as now that the rendered flag is set correctly, on a re-render the regions get re-init'd  But init'd regions don't have an $el until the first show. There are potentially other improvements to be made for this instance, but this PR improves the use-case from this test already.  No need to "render" a template: false view.