### PR TITLE
Calling Backbone.View constructor with arguments (#3027)

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -36,7 +36,9 @@ const CollectionView = Backbone.View.extend({
     this._initChildViewStorage();
     this._bufferedChildren = [];
 
-    Backbone.View.prototype.constructor.call(this, this.options);
+    const args = Array.prototype.slice.call(arguments);
+    args[0] = this.options;
+    Backbone.View.prototype.constructor.apply(this, args);
 
     this.delegateEntityEvents();
   },

--- a/src/view.js
+++ b/src/view.js
@@ -22,7 +22,9 @@ const View = Backbone.View.extend({
     this._initBehaviors();
     this._initRegions();
 
-    Backbone.View.prototype.constructor.call(this, this.options);
+    const args = Array.prototype.slice.call(arguments);
+    args[0] = this.options;
+    Backbone.View.prototype.constructor.apply(this, args);
 
     this.delegateEntityEvents();
   },

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -1451,4 +1451,18 @@ describe('collection view', function() {
       expect(this.childView.$el).to.contain.$text('bar');
     });
   });
+
+  describe('has a valid inheritance chain back to Backbone.View', function() {
+    beforeEach(function() {
+      this.constructor = this.sinon.spy(Backbone.View.prototype, 'constructor');
+    });
+
+    it('calls the parent Backbone.Views constructor function on instantiation with the proper parameters', function() {
+      const options = {foo: 'bar'};
+      const customParam = {foo: 'baz'};
+
+      this.layoutView = new this.CollectionView(options, customParam);
+      expect(this.constructor).to.have.been.calledWith(options, customParam);
+    });
+  });
 });

--- a/test/unit/utils/view.spec.js
+++ b/test/unit/utils/view.spec.js
@@ -209,6 +209,16 @@ describe('view mixin', function() {
       this.myView = new this.MyView();
       expect(this.myView.className).to.equal('.some-class');
     });
+
+    it('should attach the viewOptions to the view if options are on the collectionview', function() {
+      this.MyCollectionView = Marionette.CollectionView.extend({
+        options: {
+          className: '.some-class'
+        }
+      });
+      this.myCollectionView = new this.MyCollectionView();
+      expect(this.myCollectionView.className).to.equal('.some-class');
+    });
   });
 
   describe('should expose its options in the constructor', function() {

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -348,11 +348,14 @@ describe('item view', function() {
   describe('has a valid inheritance chain back to Backbone.View', function() {
     beforeEach(function() {
       this.constructor = this.sinon.spy(Backbone.View.prototype, 'constructor');
-      this.layoutView = new Marionette.View();
     });
 
-    it('calls the parent Backbone.Views constructor function on instantiation', function() {
-      expect(this.constructor).to.have.been.called;
+    it('calls the parent Backbone.Views constructor function on instantiation with the proper parameters', function() {
+      const options = {foo: 'bar'};
+      const customParam = {foo: 'baz'};
+
+      this.layoutView = new Marionette.View(options, customParam);
+      expect(this.constructor).to.have.been.calledWith(options, customParam);
     });
   });
 


### PR DESCRIPTION
### Proposed changes
 - If every type of view were passing arguments to Backbone.View constructor function instead of only the first argument (options), the Views would be more easy to reuse without monkey patching.

Link to the issue:
#3027 