### PR TITLE
Region empty edge-case fix

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -199,12 +199,13 @@ const Region = MarionetteObject.extend({
       this._restoreEl();
     }
 
+    delete this.currentView;
+
     if (!view._isDestroyed) {
       this._removeView(view, options);
     }
 
-    delete this.currentView._parent;
-    delete this.currentView;
+    delete view._parent;
 
     this.triggerMethod('empty', this, view);
     return this;

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -1066,4 +1066,29 @@ describe('region', function() {
       }.bind(this)).to.throw;
     });
   });
+
+  // This is a terrible example of an edge-case where something related to the view's destroy
+  // may also want to empty the same region.
+  describe('when emptying a region destroys a view that empties the same region', function() {
+    it('should only empty once', function() {
+      this.setFixtures('<div id="region"></div>');
+
+      var MyRegion = Marionette.Region.extend({
+        el: '#region',
+        onEmpty: this.sinon.stub(),
+      });
+
+      var region = new MyRegion();
+      var MyView = Marionette.View.extend({
+        template: false,
+        onDestroy: function() {
+          region.empty();
+        }
+      });
+      region.show(new MyView());
+      region.empty();
+
+      expect(region.onEmpty).to.have.been.calledOnce;
+    });
+  });
 });


### PR DESCRIPTION
An edge-case in which something related to a view's destroy might also empty the view's region will force region empty to happen twice. This will prevent that edge case.