### PR TITLE
Remove var from code

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -37,8 +37,8 @@ const AppRouter = Backbone.Router.extend({
 
     Backbone.Router.apply(this, arguments);
 
-    var appRoutes = this.appRoutes;
-    var controller = this._getController();
+    const appRoutes = this.appRoutes;
+    const controller = this._getController();
     this.processAppRoutes(controller, appRoutes);
     this.on('route', this._processOnRoute, this);
   },
@@ -46,7 +46,7 @@ const AppRouter = Backbone.Router.extend({
   // Similar to route method on a Backbone Router but
   // method is called on the controller
   appRoute: function(route, methodName) {
-    var controller = this._getController();
+    const controller = this._getController();
     this._addAppRoute(controller, route, methodName);
     return this;
   },
@@ -57,7 +57,7 @@ const AppRouter = Backbone.Router.extend({
     // make sure an onRoute before trying to call it
     if (_.isFunction(this.onRoute)) {
       // find the path that matches the current route
-      var routePath = _.invert(this.appRoutes)[routeName];
+      const routePath = _.invert(this.appRoutes)[routeName];
       this.onRoute(routeName, routePath, routeArgs);
     }
   },
@@ -68,7 +68,7 @@ const AppRouter = Backbone.Router.extend({
   processAppRoutes: function(controller, appRoutes) {
     if (!appRoutes) { return this; }
 
-    var routeNames = _.keys(appRoutes).reverse(); // Backbone requires reverted order of routes
+    const routeNames = _.keys(appRoutes).reverse(); // Backbone requires reverted order of routes
 
     _.each(routeNames, route => {
       this._addAppRoute(controller, route, appRoutes[route]);
@@ -82,7 +82,7 @@ const AppRouter = Backbone.Router.extend({
   },
 
   _addAppRoute: function(controller, route, methodName) {
-    var method = controller[methodName];
+    const method = controller[methodName];
 
     if (!method) {
       throw new MarionetteError('Method "' + methodName + '" was not found on the controller');

--- a/src/application.js
+++ b/src/application.js
@@ -26,8 +26,8 @@ const Application = MarionetteObject.extend({
   regionClass: Region,
 
   _initRegion: function(options) {
-    var region = this.region;
-    var RegionClass = this.regionClass;
+    const region = this.region;
+    const RegionClass = this.regionClass;
 
     // if the region is a string expect an el or selector
     // and instantiate a region
@@ -46,7 +46,7 @@ const Application = MarionetteObject.extend({
   },
 
   showView: function(view, ...args) {
-    var region = this.getRegion();
+    const region = this.getRegion();
     return region.show(view, ...args);
   },
 

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -45,8 +45,8 @@ import {
   triggerMethodOn
 } from './trigger-method';
 
-var previousMarionette = Backbone.Marionette;
-var Marionette = Backbone.Marionette = {};
+const previousMarionette = Backbone.Marionette;
+let Marionette = Backbone.Marionette = {};
 
 // This allows you to run multiple instances of Marionette on the same
 // webapp. After loading the new version, call `noConflict()` to

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -46,7 +46,7 @@ import {
 } from './trigger-method';
 
 const previousMarionette = Backbone.Marionette;
-let Marionette = Backbone.Marionette = {};
+const Marionette = Backbone.Marionette = {};
 
 // This allows you to run multiple instances of Marionette on the same
 // webapp. After loading the new version, call `noConflict()` to

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -102,7 +102,7 @@ const Behavior = MarionetteObject.extend({
   getEvents: function() {
     // Normalize behavior events hash to allow
     // a user to use the @ui. syntax.
-    let behaviorEvents = this.normalizeUIKeys(_.result(this, 'events'));
+    const behaviorEvents = this.normalizeUIKeys(_.result(this, 'events'));
 
     // binds the handler to the behavior and builds a unique eventName
     return _.reduce(behaviorEvents, function(events, behaviorHandler, key) {

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -21,7 +21,7 @@ const ClassOptions = [
   'ui'
 ];
 
-var Behavior = MarionetteObject.extend({
+const Behavior = MarionetteObject.extend({
   cidPrefix: 'mnb',
 
   constructor: function(options, view) {
@@ -102,7 +102,7 @@ var Behavior = MarionetteObject.extend({
   getEvents: function() {
     // Normalize behavior events hash to allow
     // a user to use the @ui. syntax.
-    var behaviorEvents = this.normalizeUIKeys(_.result(this, 'events'));
+    let behaviorEvents = this.normalizeUIKeys(_.result(this, 'events'));
 
     // binds the handler to the behavior and builds a unique eventName
     return _.reduce(behaviorEvents, function(events, behaviorHandler, key) {
@@ -122,7 +122,7 @@ var Behavior = MarionetteObject.extend({
 
     // Normalize behavior triggers hash to allow
     // a user to use the @ui. syntax.
-    var behaviorTriggers = this.normalizeUIKeys(_.result(this, 'triggers'));
+    const behaviorTriggers = this.normalizeUIKeys(_.result(this, 'triggers'));
 
     return this._getViewTriggers(this.view, behaviorTriggers);
   }

--- a/src/bind-entity-events.js
+++ b/src/bind-entity-events.js
@@ -19,10 +19,10 @@ import MarionetteError from './error';
 // Bind/unbind the event to handlers specified as a string of
 // handler names on the target object
 function bindFromStrings(target, entity, evt, methods, actionName) {
-  var methodNames = methods.split(/\s+/);
+  const methodNames = methods.split(/\s+/);
 
   _.each(methodNames, function(methodName) {
-    var method = target[methodName];
+    const method = target[methodName];
     if (!method) {
       throw new MarionetteError(`Method "${methodName}" was configured as an event handler, but does not exist.`);
     }

--- a/src/bind-radio-requests.js
+++ b/src/bind-radio-requests.js
@@ -26,7 +26,7 @@ function iterateReplies(target, channel, bindings, actionName) {
     });
   }
 
-  var normalizedRadioRequests = normalizeMethods.call(target, bindings);
+  const normalizedRadioRequests = normalizeMethods.call(target, bindings);
 
   channel[actionName](normalizedRadioRequests, target);
 }

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -58,7 +58,7 @@ const CompositeView = CollectionView.extend({
   // has been defined. As happens in CollectionView, `childView` can
   // be a function (which should return a view class).
   _getChildView(child) {
-    var childView = this.childView;
+    const childView = this.childView;
 
     // for CompositeView, if `childView` is not specified, we'll get the same
     // composite view class rendered for each child in the collection

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -1,6 +1,6 @@
 // Add Feature flags here
 // e.g. 'class' => false
-var FEATURES = {
+const FEATURES = {
 };
 
 function isEnabled(name) {

--- a/src/error.js
+++ b/src/error.js
@@ -7,7 +7,7 @@ import {version} from '../package.json';
 
 const errorProps = ['description', 'fileName', 'lineNumber', 'name', 'message', 'number'];
 
-let MarionetteError = extend.call(Error, {
+const MarionetteError = extend.call(Error, {
   urlRoot: 'http://marionettejs.com/docs/v' + version + '/',
 
   constructor: function MarionetteError(message, options) {

--- a/src/error.js
+++ b/src/error.js
@@ -5,9 +5,9 @@ import _      from 'underscore';
 import extend from './utils/extend';
 import {version} from '../package.json';
 
-var errorProps = ['description', 'fileName', 'lineNumber', 'name', 'message', 'number'];
+const errorProps = ['description', 'fileName', 'lineNumber', 'name', 'message', 'number'];
 
-var MarionetteError = extend.call(Error, {
+let MarionetteError = extend.call(Error, {
   urlRoot: 'http://marionettejs.com/docs/v' + version + '/',
 
   constructor: function MarionetteError(message, options) {
@@ -18,7 +18,7 @@ var MarionetteError = extend.call(Error, {
       options = {};
     }
 
-    var error = Error.call(this, message);
+    const error = Error.call(this, message);
     _.extend(this, _.pick(error, errorProps), _.pick(options, errorProps));
 
     this.captureStackTrace();

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -33,11 +33,11 @@ function getBehaviorClass(options, key) {
 // This accepts a list of behaviors in either an object or array form
 function parseBehaviors(view, behaviors) {
   return _.chain(behaviors).map(function(options, key) {
-    var BehaviorClass = getBehaviorClass(options, key);
+    const BehaviorClass = getBehaviorClass(options, key);
     //if we're passed a class directly instead of an object
-    var _options = options === BehaviorClass ? {} : options;
-    var behavior = new BehaviorClass(_options, view);
-    var nestedBehaviors = parseBehaviors(view, _.result(behavior, 'behaviors'));
+    const _options = options === BehaviorClass ? {} : options;
+    const behavior = new BehaviorClass(_options, view);
+    const nestedBehaviors = parseBehaviors(view, _.result(behavior, 'behaviors'));
 
     return [behavior].concat(nestedBehaviors);
   }).flatten().value();
@@ -45,7 +45,7 @@ function parseBehaviors(view, behaviors) {
 
 export default {
   _initBehaviors: function() {
-    var behaviors = _.result(this, 'behaviors');
+    const behaviors = _.result(this, 'behaviors');
 
     // Behaviors defined on a view can be a flat object literal
     // or it can be a function that returns an object.
@@ -53,12 +53,12 @@ export default {
   },
 
   _getBehaviorTriggers: function() {
-    var triggers = _invoke(this._behaviors, 'getTriggers');
+    const triggers = _invoke(this._behaviors, 'getTriggers');
     return _.extend({}, ...triggers);
   },
 
   _getBehaviorEvents: function() {
-    var events = _invoke(this._behaviors, 'getEvents');
+    const events = _invoke(this._behaviors, 'getEvents');
     return _.extend({}, ...events);
   },
 
@@ -94,9 +94,9 @@ export default {
   },
 
   _triggerEventOnBehaviors: function(...args) {
-    var behaviors = this._behaviors;
+    const behaviors = this._behaviors;
     // Use good ol' for as this is a very hot function
-    for (var i = 0, length = behaviors && behaviors.length; i < length; i++) {
+    for (let i = 0, length = behaviors && behaviors.length; i < length; i++) {
       triggerMethod.apply(behaviors[i], args);
     }
   }

--- a/src/mixins/delegate-entity-events.js
+++ b/src/mixins/delegate-entity-events.js
@@ -14,18 +14,18 @@ export default {
   _delegateEntityEvents: function(model, collection) {
     this._undelegateEntityEvents(model, collection);
 
-    var modelEvents = _.result(this, 'modelEvents');
+    const modelEvents = _.result(this, 'modelEvents');
     bindEntityEvents.call(this, model, modelEvents);
 
-    var collectionEvents = _.result(this, 'collectionEvents');
+    const collectionEvents = _.result(this, 'collectionEvents');
     bindEntityEvents.call(this, collection, collectionEvents);
   },
 
   _undelegateEntityEvents: function(model, collection) {
-    var modelEvents = _.result(this, 'modelEvents');
+    const modelEvents = _.result(this, 'modelEvents');
     unbindEntityEvents.call(this, model, modelEvents);
 
-    var collectionEvents = _.result(this, 'collectionEvents');
+    const collectionEvents = _.result(this, 'collectionEvents');
     unbindEntityEvents.call(this, collection, collectionEvents);
   }
 };

--- a/src/mixins/radio.js
+++ b/src/mixins/radio.js
@@ -19,18 +19,18 @@ import {
 export default {
 
   _initRadio: function() {
-    var channelName = _.result(this, 'channelName');
+    const channelName = _.result(this, 'channelName');
 
     if (!channelName) {
       return;
     }
 
-    var channel = this._channel = Radio.channel(channelName);
+    const channel = this._channel = Radio.channel(channelName);
 
-    var radioEvents = _.result(this, 'radioEvents');
+    const radioEvents = _.result(this, 'radioEvents');
     this.bindRadioEvents(channel, radioEvents);
 
-    var radioRequests = _.result(this, 'radioRequests');
+    const radioRequests = _.result(this, 'radioRequests');
     this.bindRadioRequests(channel, radioRequests);
 
     this.on('destroy', this._destroyRadio);

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -91,7 +91,7 @@ export default {
   _buildRegionFromObject: function(definition) {
     const RegionClass = definition.regionClass || this.regionClass;
 
-    let options = _.omit(definition, 'regionClass');
+    const options = _.omit(definition, 'regionClass');
 
     _.defaults(options, {
       el: definition.selector,
@@ -151,7 +151,7 @@ export default {
   // Empty all regions in the region manager, but
   // leave them attached
   emptyRegions: function() {
-    let regions = this.getRegions();
+    const regions = this.getRegions();
     _invoke(regions, 'empty');
     return regions;
   },

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -29,7 +29,7 @@ export default {
 
   // Add a single region, by name, to the View
   addRegion: function(name, definition) {
-    var regions = {};
+    const regions = {};
     regions[name] = definition;
     return this.addRegions(regions)[name];
   },
@@ -89,9 +89,9 @@ export default {
   },
 
   _buildRegionFromObject: function(definition) {
-    var RegionClass = definition.regionClass || this.regionClass;
+    const RegionClass = definition.regionClass || this.regionClass;
 
-    var options = _.omit(definition, 'regionClass');
+    let options = _.omit(definition, 'regionClass');
 
     _.defaults(options, {
       el: definition.selector,
@@ -120,7 +120,7 @@ export default {
 
   // Remove a single region from the View, by name
   removeRegion: function(name) {
-    var region = this._regions[name];
+    const region = this._regions[name];
 
     this._removeRegion(region, name);
 
@@ -129,7 +129,7 @@ export default {
 
   // Remove all regions from the View
   removeRegions: function() {
-    var regions = this.getRegions();
+    const regions = this.getRegions();
 
     _.each(this._regions, _.bind(this._removeRegion, this));
 
@@ -151,7 +151,7 @@ export default {
   // Empty all regions in the region manager, but
   // leave them attached
   emptyRegions: function() {
-    var regions = this.getRegions();
+    let regions = this.getRegions();
     _invoke(regions, 'empty');
     return regions;
   },
@@ -176,7 +176,7 @@ export default {
   },
 
   showChildView: function(name, view, ...args) {
-    var region = this.getRegion(name);
+    const region = this.getRegion(name);
     return region.show(view, ...args);
   },
 

--- a/src/mixins/ui.js
+++ b/src/mixins/ui.js
@@ -3,9 +3,9 @@ import _ from 'underscore';
 // a given key for triggers and events
 // swaps the @ui with the associated selector.
 // Returns a new, non-mutated, parsed events hash.
-var normalizeUIKeys = function(hash, ui) {
+const normalizeUIKeys = function(hash, ui) {
   return _.reduce(hash, function(memo, val, key) {
-    var normalizedKey = normalizeUIString(key, ui);
+    const normalizedKey = normalizeUIString(key, ui);
     memo[normalizedKey] = val;
     return memo;
   }, {});
@@ -13,7 +13,7 @@ var normalizeUIKeys = function(hash, ui) {
 
 // utility method for parsing @ui. syntax strings
 // into associated selector
-var normalizeUIString = function(uiString, ui) {
+const normalizeUIString = function(uiString, ui) {
   return uiString.replace(/@ui\.[a-zA-Z_$0-9]*/g, function(r) {
     return ui[r.slice(4)];
   });
@@ -22,7 +22,7 @@ var normalizeUIString = function(uiString, ui) {
 // allows for the use of the @ui. syntax within
 // a given value for regions
 // swaps the @ui with the associated selector
-var normalizeUIValues = function(hash, ui, properties) {
+const normalizeUIValues = function(hash, ui, properties) {
   _.each(hash, function(val, key) {
     if (_.isString(val)) {
       hash[key] = normalizeUIString(val, ui);
@@ -30,7 +30,7 @@ var normalizeUIValues = function(hash, ui, properties) {
       _.extend(val, normalizeUIValues(_.pick(val, properties), ui));
       /* Value is an object, and we got an array of embedded property names to normalize. */
       _.each(properties, function(property) {
-        var propertyVal = val[property];
+        const propertyVal = val[property];
         if (_.isString(propertyVal)) {
           val[property] = normalizeUIString(propertyVal, ui);
         }
@@ -45,20 +45,20 @@ export default {
   // normalize the keys of passed hash with the views `ui` selectors.
   // `{"@ui.foo": "bar"}`
   normalizeUIKeys: function(hash) {
-    var uiBindings = this._getUIBindings();
+    const uiBindings = this._getUIBindings();
     return normalizeUIKeys(hash, uiBindings);
   },
 
   // normalize the values of passed hash with the views `ui` selectors.
   // `{foo: "@ui.bar"}`
   normalizeUIValues: function(hash, properties) {
-    var uiBindings = this._getUIBindings();
+    const uiBindings = this._getUIBindings();
     return normalizeUIValues(hash, uiBindings, properties);
   },
 
   _getUIBindings: function() {
-    var uiBindings = _.result(this, '_uiBindings');
-    var ui = _.result(this, 'ui');
+    const uiBindings = _.result(this, '_uiBindings');
+    const ui = _.result(this, 'ui');
     return uiBindings || ui;
   },
 
@@ -74,7 +74,7 @@ export default {
     }
 
     // get the bindings result, as a function or otherwise
-    var bindings = _.result(this, '_uiBindings');
+    const bindings = _.result(this, '_uiBindings');
 
     // empty the ui so we don't have anything to start with
     this._ui = {};

--- a/src/object.js
+++ b/src/object.js
@@ -16,7 +16,7 @@ const ClassOptions = [
 
 // A Base Class that other Classes should descend from.
 // Object borrows many conventions and utilities from Backbone.
-var MarionetteObject = function(options) {
+let MarionetteObject = function(options) {
   this._setOptions(options);
   this.mergeOptions(options, ClassOptions);
   this.cid = _.uniqueId(this.cidPrefix);

--- a/src/object.js
+++ b/src/object.js
@@ -16,7 +16,7 @@ const ClassOptions = [
 
 // A Base Class that other Classes should descend from.
 // Object borrows many conventions and utilities from Backbone.
-let MarionetteObject = function(options) {
+const MarionetteObject = function(options) {
   this._setOptions(options);
   this.mergeOptions(options, ClassOptions);
   this.cid = _.uniqueId(this.cidPrefix);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -7,7 +7,7 @@ import TemplateCache   from './template-cache';
 
 // Render a template with data by passing in the template
 // selector and the data to render.
-var Renderer = {
+const Renderer = {
 
   // Render a template with data. The `template` parameter is
   // passed to the `TemplateCache` object to retrieve the
@@ -21,7 +21,7 @@ var Renderer = {
       });
     }
 
-    var templateFunc = _.isFunction(template) ? template : TemplateCache.get(template);
+    const templateFunc = _.isFunction(template) ? template : TemplateCache.get(template);
 
     return templateFunc(data);
   }

--- a/src/template-cache.js
+++ b/src/template-cache.js
@@ -7,7 +7,7 @@ import MarionetteError from './error';
 
 // Manage templates stored in `<script>` blocks,
 // caching them for faster access.
-let TemplateCache = function(templateId) {
+const TemplateCache = function(templateId) {
   this.templateId = templateId;
 };
 

--- a/src/template-cache.js
+++ b/src/template-cache.js
@@ -7,7 +7,7 @@ import MarionetteError from './error';
 
 // Manage templates stored in `<script>` blocks,
 // caching them for faster access.
-var TemplateCache = function(templateId) {
+let TemplateCache = function(templateId) {
   this.templateId = templateId;
 };
 
@@ -21,7 +21,7 @@ _.extend(TemplateCache, {
   // retrieves the cached version, or loads it
   // from the DOM.
   get: function(templateId, options) {
-    var cachedTemplate = this.templateCaches[templateId];
+    let cachedTemplate = this.templateCaches[templateId];
 
     if (!cachedTemplate) {
       cachedTemplate = new TemplateCache(templateId);
@@ -39,8 +39,8 @@ _.extend(TemplateCache, {
   // specified templates from the cache:
   // `clear("#t1", "#t2", "...")`
   clear: function(...args) {
-    var i;
-    var length = args.length;
+    let i;
+    const length = args.length;
 
     if (length > 0) {
       for (i = 0; i < length; i++) {
@@ -65,7 +65,7 @@ _.extend(TemplateCache.prototype, {
     }
 
     // Load the template and compile it
-    var template = this.loadTemplate(this.templateId, options);
+    const template = this.loadTemplate(this.templateId, options);
     this.compiledTemplate = this.compileTemplate(template, options);
 
     return this.compiledTemplate;
@@ -77,7 +77,7 @@ _.extend(TemplateCache.prototype, {
   // using a template-loader plugin as described here:
   // https://github.com/marionettejs/backbone.marionette/wiki/Using-marionette-with-requirejs
   loadTemplate: function(templateId, options) {
-    var $template = Backbone.$(templateId);
+    const $template = Backbone.$(templateId);
 
     if (!$template.length) {
       throw new MarionetteError({

--- a/src/trigger-method.js
+++ b/src/trigger-method.js
@@ -5,7 +5,7 @@ import _         from 'underscore';
 import getOption from './utils/getOption';
 
 // split the event name on the ":"
-var splitter = /(^|:)(\w)/gi;
+const splitter = /(^|:)(\w)/gi;
 
 // take the event section ("section1:section2:section3")
 // and turn it in to uppercase name onSection1Section2Section3
@@ -22,9 +22,9 @@ function getEventName(match, prefix, eventName) {
 // call the "onFooBar" method.
 export function triggerMethod(event, ...args) {
   // get the method name from the event name
-  var methodName = 'on' + event.replace(splitter, getEventName);
-  var method = getOption.call(this, methodName);
-  var result;
+  const methodName = 'on' + event.replace(splitter, getEventName);
+  const method = getOption.call(this, methodName);
+  let result;
 
   // call the onMethodName if it exists
   if (_.isFunction(method)) {
@@ -43,6 +43,6 @@ export function triggerMethod(event, ...args) {
 // e.g. `Marionette.triggerMethodOn(view, 'show')`
 // will trigger a "show" event or invoke onShow the view.
 export function triggerMethodOn(context, ...args) {
-  var fnc = _.isFunction(context.triggerMethod) ? context.triggerMethod : triggerMethod;
+  const fnc = _.isFunction(context.triggerMethod) ? context.triggerMethod : triggerMethod;
   return fnc.apply(context, args);
 }

--- a/src/utils/_proxy.js
+++ b/src/utils/_proxy.js
@@ -1,5 +1,5 @@
 //Internal utility for creating context style global utils
-var proxy = function(method) {
+const proxy = function(method) {
   return function(context, ...args) {
     return method.apply(context, args);
   };

--- a/src/utils/_setOptions.js
+++ b/src/utils/_setOptions.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 
 // Internal utility for setting options consistently across Mn
-var _setOptions = function(...args) {
+const _setOptions = function(...args) {
   this.options = _.extend({}, _.result(this, 'options'), ...args);
 };
 

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -4,7 +4,7 @@ import _ from 'underscore';
 
 import Marionette from '../backbone.marionette';
 
-var deprecate = function(message, test) {
+const deprecate = function(message, test) {
   if (_.isObject(message)) {
     message = (
       message.prev + ' is going to be removed in the future. ' +
@@ -25,7 +25,7 @@ var deprecate = function(message, test) {
 
 deprecate._console = typeof console !== 'undefined' ? console : {};
 deprecate._warn = function() {
-  var warn = deprecate._console.warn || deprecate._console.log || function() {};
+  const warn = deprecate._console.warn || deprecate._console.log || function() {};
   return warn.apply(deprecate._console, arguments);
 };
 deprecate._cache = {};

--- a/src/utils/extend.js
+++ b/src/utils/extend.js
@@ -4,6 +4,6 @@
 import Backbone from 'backbone';
 
 // Borrow the Backbone `extend` method so we can use it as needed
-var extend = Backbone.Model.extend;
+const extend = Backbone.Model.extend;
 
 export default extend;

--- a/src/utils/getOption.js
+++ b/src/utils/getOption.js
@@ -3,7 +3,7 @@
 
 // Retrieve an object, function or other value from the
 // object or its `options`, with `options` taking precedence.
-var getOption = function(optionName) {
+const getOption = function(optionName) {
   if (!optionName) { return; }
   if (this.options && (this.options[optionName] !== undefined)) {
     return this.options[optionName];

--- a/src/utils/getUniqueEventName.js
+++ b/src/utils/getUniqueEventName.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 
 // Borrow event splitter from Backbone
-var delegateEventSplitter = /^(\S+)\s*(.*)$/;
+const delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
 function uniqueName(eventName, selector) {
   return [eventName + _.uniqueId('.evt'), selector].join(' ');
@@ -10,8 +10,8 @@ function uniqueName(eventName, selector) {
 // Set event name to be namespaced using a unique index
 // to generate a non colliding event namespace
 // http://api.jquery.com/event.namespace/
-var getUniqueEventName = function(eventName) {
-  var match = eventName.match(delegateEventSplitter);
+const getUniqueEventName = function(eventName) {
+  const match = eventName.match(delegateEventSplitter);
   return uniqueName(match[1], match[2]);
 };
 

--- a/src/utils/isNodeAttached.js
+++ b/src/utils/isNodeAttached.js
@@ -4,7 +4,7 @@
 import Backbone from 'backbone';
 
 // Determine if `el` is a child of the document
-var isNodeAttached = function(el) {
+const isNodeAttached = function(el) {
   return Backbone.$.contains(document.documentElement, el);
 };
 

--- a/src/utils/mergeOptions.js
+++ b/src/utils/mergeOptions.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 
 // Merge `keys` from `options` onto `this`
-var mergeOptions = function(options, keys) {
+const mergeOptions = function(options, keys) {
   if (!options) { return; }
   _.extend(this, _.pick(options, keys));
 };

--- a/src/utils/normalizeMethods.js
+++ b/src/utils/normalizeMethods.js
@@ -5,7 +5,7 @@ import _ from 'underscore';
 
 // Pass in a mapping of events => functions or function names
 // and return a mapping of events => functions
-var normalizeMethods = function(hash) {
+const normalizeMethods = function(hash) {
   return _.reduce(hash, (normalizedHash, method, name) => {
     if (!_.isFunction(method)) {
       method = this[method];


### PR DESCRIPTION
### Proposed changes
 - make Mn consistent with using `var`, `const`, `let`. Somewhere we have only const/let, somewhere var/const, somewhere only var. I propose to refuse `var` at all and use only const/let.

