### PR TITLE
emptyView can accept a function that returns a view

### DIFF
--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -2,7 +2,6 @@
 // --------------
 
 import _               from 'underscore';
-import Backbone        from 'backbone';
 import deprecate       from './utils/deprecate';
 import MarionetteError from './error';
 import CollectionView  from './collection-view';
@@ -58,7 +57,7 @@ const CompositeView = CollectionView.extend({
   // has been defined. As happens in CollectionView, `childView` can
   // be a function (which should return a view class).
   _getChildView(child) {
-    const childView = this.childView;
+    let childView = this.childView;
 
     // for CompositeView, if `childView` is not specified, we'll get the same
     // composite view class rendered for each child in the collection
@@ -66,17 +65,18 @@ const CompositeView = CollectionView.extend({
     // finally check if it's a function (which we assume that returns a view class)
     if (!childView) {
       return this.constructor;
-    } else if (childView.prototype instanceof Backbone.View || childView === Backbone.View) {
-      return childView;
-    } else if (_.isFunction(childView)) {
-      return childView.call(this, child);
-    } else {
+    }
+
+    childView = this._getView(childView, child);
+
+    if (!childView) {
       throw new MarionetteError({
         name: 'InvalidChildViewError',
         message: '"childView" must be a view class or a function that returns a view class'
       });
     }
 
+    return childView;
   },
 
   // Return the serialized model

--- a/test/unit/collection-view.empty-view.spec.js
+++ b/test/unit/collection-view.empty-view.spec.js
@@ -257,14 +257,16 @@ describe('collectionview - emptyView', function() {
     });
   });
 
-  describe('when emptyView is specified with getEmptyView option', function() {
+  describe('when emptyView is specified as a function', function() {
     beforeEach(function() {
-      this.getEmptyViewStub = this.sinon.stub();
-      this.OtherEmptyView = Backbone.Marionette.View.extend();
+      this.OtherEmptyView = Marionette.View.extend({
+        template: _.template('other empty')
+      });
+      this.emptyViewStub = this.sinon.stub().returns(this.OtherEmptyView);
 
-      this.CollectionView = Backbone.Marionette.CollectionView.extend({
+      this.CollectionView = Marionette.CollectionView.extend({
         childView: this.View,
-        getEmptyView: this.getEmptyViewStub
+        emptyView: this.emptyViewStub
       });
     });
 
@@ -279,7 +281,7 @@ describe('collectionview - emptyView', function() {
       });
 
       it('renders other empty view instance', function() {
-        expect(this.getEmptyViewStub).to.have.been.called;
+        expect(this.collectionView.$el).to.have.$html('<div>other empty</div>');
       });
     });
   });


### PR DESCRIPTION
In reviewing the documentation for v3's `CollectionView` this seemed to be fairly inconsistent.  It is also a moderately small change.  I'm fiddling with the `CollectionView` docs now on another branch, and if this is accepted I can make the doc updates there or it can be done in a subsequent PR.

This removes the need for `getEmptyView`

This makes they `emptyView` API match the `childView`