### PR TITLE
collectionView should only destroyChildren once rendered

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -271,8 +271,10 @@ const CollectionView = Backbone.View.extend({
   // Internal method. Separated so that CompositeView can have more control over events
   // being triggered, around the rendering process
   _renderChildren() {
-    this._destroyEmptyView();
-    this._destroyChildren({checkEmpty: false});
+    if (this._isRendered) {
+      this._destroyEmptyView();
+      this._destroyChildren({checkEmpty: false});
+    }
 
     const models = this._filteredSortedModels();
     if (this.isEmpty({processedModels: models})) {

--- a/test/unit/composite-view.spec.js
+++ b/test/unit/composite-view.spec.js
@@ -372,7 +372,7 @@ describe('composite view', function() {
 
     it('should destroy all of the child collection child views', function() {
       expect(this.compositeView._destroyChildren).to.have.been.called;
-      expect(this.compositeView._destroyChildren.callCount).to.equal(2);
+      expect(this.compositeView._destroyChildren.callCount).to.equal(1);
     });
 
     it('should re-render the collections items', function() {


### PR DESCRIPTION
While going through the `collectionView` docs I noticed `destroy:children` was getting triggered on the first render.  This is an unnecessary action as there will never be anything to destroy if nothing is rendered.

The composite view test that was modified helps prove the previous functionality was overkill.