### PR TITLE
delete view._parent after destroying view

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -220,8 +220,6 @@ const Region = MarionetteObject.extend({
       this._removeView(view, options);
     }
 
-    delete view._parent;
-
     this.triggerMethod('empty', this, view);
     return this;
   },
@@ -239,11 +237,12 @@ const Region = MarionetteObject.extend({
     } else {
       destroyBackboneView(view);
     }
+    delete view._parent;
   },
 
   _detachView(view) {
     const shouldTriggerDetach = !!view._isAttached;
-
+    delete view._parent;
     if (shouldTriggerDetach) {
       triggerMethodOn(view, 'before:detach', view);
     }

--- a/src/region.js
+++ b/src/region.js
@@ -218,6 +218,7 @@ const Region = MarionetteObject.extend({
 
     if (!view._isDestroyed) {
       this._removeView(view, options);
+      delete view._parent;
     }
 
     this.triggerMethod('empty', this, view);
@@ -237,12 +238,10 @@ const Region = MarionetteObject.extend({
     } else {
       destroyBackboneView(view);
     }
-    delete view._parent;
   },
 
   _detachView(view) {
     const shouldTriggerDetach = !!view._isAttached;
-    delete view._parent;
     if (shouldTriggerDetach) {
       triggerMethodOn(view, 'before:detach', view);
     }

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -351,14 +351,13 @@ describe('layoutView', function() {
 
   describe('when destroying a childView as a View', function() {
     beforeEach(function() {
-      this.layoutView = new this.View();
       this.childEventsHandler = this.sinon.spy();
+      this.layoutView = new this.View({
+        childViewEvents: {
+          'destroy': this.childEventsHandler
+        }
+      });
 
-      // add child events to listen for
-      this.layoutView.childViewEvents = {
-        'destroy': this.childEventsHandler
-      };
-      this.layoutView.delegateEvents();
       this.layoutView.render();
 
       // create a child view which triggers an event on render

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -349,6 +349,33 @@ describe('layoutView', function() {
     });
   });
 
+  describe('when destroying a childView as a View', function() {
+    beforeEach(function() {
+      this.layoutView = new this.View();
+      this.childEventsHandler = this.sinon.spy();
+
+      // add child events to listen for
+      this.layoutView.childViewEvents = {
+        'destroy': this.childEventsHandler
+      };
+      this.layoutView.delegateEvents();
+      this.layoutView.render();
+
+      // create a child view which triggers an event on render
+      var ChildView = Marionette.View.extend({
+        template: false
+      });
+      this.childView = new ChildView();
+
+      this.layoutView.showChildView('regionOne', this.childView);
+      this.childView.destroy();
+    });
+
+    it('childViewEvents "destroy" method is triggered', function() {
+      expect(this.childEventsHandler).to.have.been.calledOnce;
+    });
+  });
+
   describe('when re-rendering an already rendered layoutView', function() {
     beforeEach(function() {
       this.ViewBoundRender = this.View.extend({


### PR DESCRIPTION
### Proposed changes
 - `delete view._parent` should be after `destroy` because when [destroy](https://github.com/marionettejs/backbone.marionette/blob/next/src/mixins/view.js#L172) is calling, it's calling region `empty` method which is deleting [view._parent](https://github.com/marionettejs/backbone.marionette/blob/next/src/region.js#L223).
So when `_triggerEventOnParentLayout` was called childView doesn't have parent so all [this](_triggerEventOnParentLayout) logic which is responsible for `childViewEvents` wasn't run.

Link to the issue:
#3045 