### PR TITLE
Reset removeChildview to be consistent with AddChildView

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -525,7 +525,7 @@ const CollectionView = Backbone.View.extend({
   // in the collection in order to keep the children in sync with the collection.
   removeChildView(view) {
     if (!view || view._isDestroyed) {
-      return;
+      return view;
     }
 
     this.triggerMethod('before:remove:child', this, view);
@@ -543,6 +543,8 @@ const CollectionView = Backbone.View.extend({
 
     // decrement the index of views after this one
     this._updateIndices(view, false);
+
+    return view;
   },
 
   // check if the collection is empty or optionally whether an array of pre-processed models is empty

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -861,11 +861,17 @@ describe('collection view', function() {
 
       this.childView = this.collectionView.children.findByIndex(0);
       this.sinon.spy(this.childView, 'remove');
-      collection.reset();
+
+      this.sinon.spy(this.collectionView, 'removeChildView');
+      this.collectionView.removeChildView(this.childView);
     });
 
     it('should call the "remove" method', function() {
       expect(this.childView.remove).to.have.been.called;
+    });
+
+    it('should return the childView', function() {
+      expect(this.collectionView.removeChildView).to.have.returned(this.childView);
     });
   });
 


### PR DESCRIPTION
### Proposed changes
 - The CollectionView's `removeChildView` doesn't return the view like it's sibling function, `addChildView`
 - Reseting `removeChildView` to return the childView keeps the functions consistent with each other
 - `collection-view.spec.js` is also reverted to test for the childView being returned
