### PR TITLE
make function declaration consistent

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,7 +54,7 @@
     "no-undef": 2,
     "no-unused-vars": [ 1, { "args": "none" } ],
     "no-with": 2,
-    "one-var": [ 2, "never" ],
+    "no-var": 2,
     "operator-linebreak": [ 2, "after" ],
     "quotes": [ 2, "single" ],
     "semi": [ 0, "never" ],
@@ -71,6 +71,7 @@
     "strict": 0,
     "valid-jsdoc": 2,
     "valid-typeof": 2,
-    "wrap-iife": [ 2, "inside" ]
+    "wrap-iife": [ 2, "inside" ],
+    "object-shorthand": [ 2, "methods" ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -53,8 +53,9 @@
     "no-trailing-spaces": 2,
     "no-undef": 2,
     "no-unused-vars": [ 1, { "args": "none" } ],
-    "no-with": 2,
     "no-var": 2,
+    "no-with": 2,
+    "object-shorthand": [ 2, "methods" ],
     "operator-linebreak": [ 2, "after" ],
     "quotes": [ 2, "single" ],
     "semi": [ 0, "never" ],
@@ -72,6 +73,6 @@
     "valid-jsdoc": 2,
     "valid-typeof": 2,
     "wrap-iife": [ 2, "inside" ],
-    "object-shorthand": [ 2, "methods" ]
+
   }
 }

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -30,7 +30,7 @@ const ClassOptions = [
 
 const AppRouter = Backbone.Router.extend({
 
-  constructor: function(options) {
+  constructor(options) {
     this._setOptions(options);
 
     this.mergeOptions(options, ClassOptions);
@@ -45,7 +45,7 @@ const AppRouter = Backbone.Router.extend({
 
   // Similar to route method on a Backbone Router but
   // method is called on the controller
-  appRoute: function(route, methodName) {
+  appRoute(route, methodName) {
     const controller = this._getController();
     this._addAppRoute(controller, route, methodName);
     return this;
@@ -53,7 +53,7 @@ const AppRouter = Backbone.Router.extend({
 
   // process the route event and trigger the onRoute
   // method call, if it exists
-  _processOnRoute: function(routeName, routeArgs) {
+  _processOnRoute(routeName, routeArgs) {
     // make sure an onRoute before trying to call it
     if (_.isFunction(this.onRoute)) {
       // find the path that matches the current route
@@ -65,7 +65,7 @@ const AppRouter = Backbone.Router.extend({
   // Internal method to process the `appRoutes` for the
   // router, and turn them in to routes that trigger the
   // specified method on the specified `controller`.
-  processAppRoutes: function(controller, appRoutes) {
+  processAppRoutes(controller, appRoutes) {
     if (!appRoutes) { return this; }
 
     const routeNames = _.keys(appRoutes).reverse(); // Backbone requires reverted order of routes
@@ -77,11 +77,11 @@ const AppRouter = Backbone.Router.extend({
     return this;
   },
 
-  _getController: function() {
+  _getController() {
     return this.controller;
   },
 
-  _addAppRoute: function(controller, route, methodName) {
+  _addAppRoute(controller, route, methodName) {
     const method = controller[methodName];
 
     if (!method) {

--- a/src/application.js
+++ b/src/application.js
@@ -13,7 +13,7 @@ const ClassOptions = [
 const Application = MarionetteObject.extend({
   cidPrefix: 'mna',
 
-  constructor: function(options) {
+  constructor(options) {
     this._setOptions(options);
 
     this.mergeOptions(options, ClassOptions);
@@ -25,7 +25,7 @@ const Application = MarionetteObject.extend({
 
   regionClass: Region,
 
-  _initRegion: function(options) {
+  _initRegion(options) {
     const region = this.region;
     const RegionClass = this.regionClass;
 
@@ -41,21 +41,21 @@ const Application = MarionetteObject.extend({
     this._region = region;
   },
 
-  getRegion: function() {
+  getRegion() {
     return this._region;
   },
 
-  showView: function(view, ...args) {
+  showView(view, ...args) {
     const region = this.getRegion();
     return region.show(view, ...args);
   },
 
-  getView: function() {
+  getView() {
     return this.getRegion().currentView;
   },
 
   // kick off all of the application's processes.
-  start: function(options) {
+  start(options) {
     this.triggerMethod('before:start', this, options);
     this.triggerMethod('start', this, options);
     return this;

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -24,7 +24,7 @@ const ClassOptions = [
 const Behavior = MarionetteObject.extend({
   cidPrefix: 'mnb',
 
-  constructor: function(options, view) {
+  constructor(options, view) {
     // Setup reference to the view.
     // this comes in handle when a behavior
     // wants to directly talk up the chain
@@ -50,56 +50,56 @@ const Behavior = MarionetteObject.extend({
   // proxy behavior $ method to the view
   // this is useful for doing jquery DOM lookups
   // scoped to behaviors view.
-  $: function() {
+  $() {
     return this.view.$.apply(this.view, arguments);
   },
 
   // Stops the behavior from listening to events.
   // Overrides Object#destroy to prevent additional events from being triggered.
-  destroy: function() {
+  destroy() {
     this.stopListening();
 
     return this;
   },
 
-  proxyViewProperties: function() {
+  proxyViewProperties() {
     this.$el = this.view.$el;
     this.el = this.view.el;
 
     return this;
   },
 
-  bindUIElements: function() {
+  bindUIElements() {
     this._bindUIElements();
 
     return this;
   },
 
-  unbindUIElements: function() {
+  unbindUIElements() {
     this._unbindUIElements();
 
     return this;
   },
 
-  getUI: function(name) {
+  getUI(name) {
     this.view._ensureViewIsIntact();
     return this._getUI(name);
   },
 
   // Handle `modelEvents`, and `collectionEvents` configuration
-  delegateEntityEvents: function() {
+  delegateEntityEvents() {
     this._delegateEntityEvents(this.view.model, this.view.collection);
 
     return this;
   },
 
-  undelegateEntityEvents: function() {
+  undelegateEntityEvents() {
     this._undelegateEntityEvents(this.view.model, this.view.collection);
 
     return this;
   },
 
-  getEvents: function() {
+  getEvents() {
     // Normalize behavior events hash to allow
     // a user to use the @ui. syntax.
     const behaviorEvents = this.normalizeUIKeys(_.result(this, 'events'));
@@ -117,7 +117,7 @@ const Behavior = MarionetteObject.extend({
   },
 
   // Internal method to build all trigger handlers for a given behavior
-  getTriggers: function() {
+  getTriggers() {
     if (!this.triggers) { return; }
 
     // Normalize behavior triggers hash to allow

--- a/src/error.js
+++ b/src/error.js
@@ -10,7 +10,7 @@ const errorProps = ['description', 'fileName', 'lineNumber', 'name', 'message', 
 const MarionetteError = extend.call(Error, {
   urlRoot: 'http://marionettejs.com/docs/v' + version + '/',
 
-  constructor: function MarionetteError(message, options) {
+  constructor(message, options) {
     if (_.isObject(message)) {
       options = message;
       message = options.message;
@@ -28,13 +28,13 @@ const MarionetteError = extend.call(Error, {
     }
   },
 
-  captureStackTrace: function() {
+  captureStackTrace() {
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, MarionetteError);
     }
   },
 
-  toString: function() {
+  toString() {
     return this.name + ': ' + this.message + (this.url ? ' See: ' + this.url : '');
   }
 });

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -44,7 +44,7 @@ function parseBehaviors(view, behaviors) {
 }
 
 export default {
-  _initBehaviors: function() {
+  _initBehaviors() {
     const behaviors = _.result(this, 'behaviors');
 
     // Behaviors defined on a view can be a flat object literal
@@ -52,32 +52,32 @@ export default {
     this._behaviors = _.isObject(behaviors) ? parseBehaviors(this, behaviors) : {};
   },
 
-  _getBehaviorTriggers: function() {
+  _getBehaviorTriggers() {
     const triggers = _invoke(this._behaviors, 'getTriggers');
     return _.extend({}, ...triggers);
   },
 
-  _getBehaviorEvents: function() {
+  _getBehaviorEvents() {
     const events = _invoke(this._behaviors, 'getEvents');
     return _.extend({}, ...events);
   },
 
   // proxy behavior $el to the view's $el.
-  _proxyBehaviorViewProperties: function() {
+  _proxyBehaviorViewProperties() {
     _invoke(this._behaviors, 'proxyViewProperties');
   },
 
   // delegate modelEvents and collectionEvents
-  _delegateBehaviorEntityEvents: function() {
+  _delegateBehaviorEntityEvents() {
     _invoke(this._behaviors, 'delegateEntityEvents');
   },
 
   // undelegate modelEvents and collectionEvents
-  _undelegateBehaviorEntityEvents: function() {
+  _undelegateBehaviorEntityEvents() {
     _invoke(this._behaviors, 'undelegateEntityEvents');
   },
 
-  _destroyBehaviors: function(args) {
+  _destroyBehaviors(args) {
     // Call destroy on each behavior after
     // destroying the view.
     // This unbinds event listeners
@@ -85,15 +85,15 @@ export default {
     _invoke(this._behaviors, 'destroy', ...args);
   },
 
-  _bindBehaviorUIElements: function() {
+  _bindBehaviorUIElements() {
     _invoke(this._behaviors, 'bindUIElements');
   },
 
-  _unbindBehaviorUIElements: function() {
+  _unbindBehaviorUIElements() {
     _invoke(this._behaviors, 'unbindUIElements');
   },
 
-  _triggerEventOnBehaviors: function(...args) {
+  _triggerEventOnBehaviors(...args) {
     const behaviors = this._behaviors;
     // Use good ol' for as this is a very hot function
     for (let i = 0, length = behaviors && behaviors.length; i < length; i++) {

--- a/src/mixins/delegate-entity-events.js
+++ b/src/mixins/delegate-entity-events.js
@@ -11,7 +11,7 @@ import {
 
 export default {
   // Handle `modelEvents`, and `collectionEvents` configuration
-  _delegateEntityEvents: function(model, collection) {
+  _delegateEntityEvents(model, collection) {
     this._undelegateEntityEvents(model, collection);
 
     const modelEvents = _.result(this, 'modelEvents');
@@ -21,7 +21,7 @@ export default {
     bindEntityEvents.call(this, collection, collectionEvents);
   },
 
-  _undelegateEntityEvents: function(model, collection) {
+  _undelegateEntityEvents(model, collection) {
     const modelEvents = _.result(this, 'modelEvents');
     unbindEntityEvents.call(this, model, modelEvents);
 

--- a/src/mixins/radio.js
+++ b/src/mixins/radio.js
@@ -18,7 +18,7 @@ import {
 
 export default {
 
-  _initRadio: function() {
+  _initRadio() {
     const channelName = _.result(this, 'channelName');
 
     if (!channelName) {
@@ -36,11 +36,11 @@ export default {
     this.on('destroy', this._destroyRadio);
   },
 
-  _destroyRadio: function() {
+  _destroyRadio() {
     this._channel.stopReplying(null, null, this);
   },
 
-  getChannel: function() {
+  getChannel() {
     return this._channel;
   },
 

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -12,7 +12,7 @@ export default {
 
   // Internal method to initialize the regions that have been defined in a
   // `regions` attribute on this View.
-  _initRegions: function() {
+  _initRegions() {
 
     // init regions hash
     this.regions =  this.regions || {};
@@ -23,19 +23,19 @@ export default {
 
   // Internal method to re-initialize all of the regions by updating
   // the `el` that they point to
-  _reInitRegions: function() {
+  _reInitRegions() {
     _invoke(this._regions, 'reset');
   },
 
   // Add a single region, by name, to the View
-  addRegion: function(name, definition) {
+  addRegion(name, definition) {
     const regions = {};
     regions[name] = definition;
     return this.addRegions(regions)[name];
   },
 
   // Add multiple regions as a {name: definition, name2: def2} object literal
-  addRegions: function(regions) {
+  addRegions(regions) {
     // If there's nothing to add, stop here.
     if (_.isEmpty(regions)) {
       return;
@@ -52,7 +52,7 @@ export default {
   },
 
   // internal method to build and add regions
-  _addRegions: function(regionDefinitions) {
+  _addRegions(regionDefinitions) {
     return _.reduce(regionDefinitions, (regions, definition, name) => {
       regions[name] = this._buildRegion(definition);
       this._addRegion(regions[name], name);
@@ -61,7 +61,7 @@ export default {
   },
 
   // return the region instance from the definition
-  _buildRegion: function(definition) {
+  _buildRegion(definition) {
     if (definition instanceof Region) {
       return definition;
     }
@@ -69,7 +69,7 @@ export default {
     return this._buildRegionFromDefinition(definition);
   },
 
-  _buildRegionFromDefinition: function(definition) {
+  _buildRegionFromDefinition(definition) {
     if (_.isString(definition)) {
       return this._buildRegionFromObject({el: definition});
     }
@@ -88,7 +88,7 @@ export default {
     });
   },
 
-  _buildRegionFromObject: function(definition) {
+  _buildRegionFromObject(definition) {
     const RegionClass = definition.regionClass || this.regionClass;
 
     const options = _.omit(definition, 'regionClass');
@@ -102,13 +102,13 @@ export default {
   },
 
   // Build the region directly from a given `RegionClass`
-  _buildRegionFromRegionClass: function(RegionClass) {
+  _buildRegionFromRegionClass(RegionClass) {
     return new RegionClass({
       parentEl: _.partial(_.result, this, 'el')
     });
   },
 
-  _addRegion: function(region, name) {
+  _addRegion(region, name) {
     this.triggerMethod('before:add:region', this, name, region);
 
     region._parent = this;
@@ -119,7 +119,7 @@ export default {
   },
 
   // Remove a single region from the View, by name
-  removeRegion: function(name) {
+  removeRegion(name) {
     const region = this._regions[name];
 
     this._removeRegion(region, name);
@@ -128,7 +128,7 @@ export default {
   },
 
   // Remove all regions from the View
-  removeRegions: function() {
+  removeRegions() {
     const regions = this.getRegions();
 
     _.each(this._regions, _.bind(this._removeRegion, this));
@@ -136,7 +136,7 @@ export default {
     return regions;
   },
 
-  _removeRegion: function(region, name) {
+  _removeRegion(region, name) {
     this.triggerMethod('before:remove:region', this, name, region);
 
     region.empty();
@@ -150,7 +150,7 @@ export default {
 
   // Empty all regions in the region manager, but
   // leave them attached
-  emptyRegions: function() {
+  emptyRegions() {
     const regions = this.getRegions();
     _invoke(regions, 'empty');
     return regions;
@@ -159,28 +159,28 @@ export default {
   // Checks to see if view contains region
   // Accepts the region name
   // hasRegion('main')
-  hasRegion: function(name) {
+  hasRegion(name) {
     return !!this.getRegion(name);
   },
 
   // Provides access to regions
   // Accepts the region name
   // getRegion('main')
-  getRegion: function(name) {
+  getRegion(name) {
     return this._regions[name];
   },
 
   // Get all regions
-  getRegions: function() {
+  getRegions() {
     return _.clone(this._regions);
   },
 
-  showChildView: function(name, view, ...args) {
+  showChildView(name, view, ...args) {
     const region = this.getRegion(name);
     return region.show(view, ...args);
   },
 
-  getChildView: function(name) {
+  getChildView(name) {
     return this.getRegion(name).currentView;
   }
 

--- a/src/mixins/triggers.js
+++ b/src/mixins/triggers.js
@@ -29,7 +29,7 @@ export default {
 
   // Configure `triggers` to forward DOM events to view
   // events. `triggers: {"click .foo": "do:foo"}`
-  _getViewTriggers: function(view, triggers) {
+  _getViewTriggers(view, triggers) {
     // Configure the triggers, prevent default
     // action and stop propagation of DOM events
     return _.reduce(triggers, (events, value, key) => {

--- a/src/mixins/ui.js
+++ b/src/mixins/ui.js
@@ -44,19 +44,19 @@ export default {
 
   // normalize the keys of passed hash with the views `ui` selectors.
   // `{"@ui.foo": "bar"}`
-  normalizeUIKeys: function(hash) {
+  normalizeUIKeys(hash) {
     const uiBindings = this._getUIBindings();
     return normalizeUIKeys(hash, uiBindings);
   },
 
   // normalize the values of passed hash with the views `ui` selectors.
   // `{foo: "@ui.bar"}`
-  normalizeUIValues: function(hash, properties) {
+  normalizeUIValues(hash, properties) {
     const uiBindings = this._getUIBindings();
     return normalizeUIValues(hash, uiBindings, properties);
   },
 
-  _getUIBindings: function() {
+  _getUIBindings() {
     const uiBindings = _.result(this, '_uiBindings');
     const ui = _.result(this, 'ui');
     return uiBindings || ui;
@@ -64,7 +64,7 @@ export default {
 
   // This method binds the elements specified in the "ui" hash inside the view's code with
   // the associated jQuery selectors.
-  _bindUIElements: function() {
+  _bindUIElements() {
     if (!this.ui) { return; }
 
     // store the ui hash in _uiBindings so they can be reset later
@@ -87,7 +87,7 @@ export default {
     this.ui = this._ui;
   },
 
-  _unbindUIElements: function() {
+  _unbindUIElements() {
     if (!this.ui || !this._uiBindings) { return; }
 
     // delete all of the existing ui bindings
@@ -101,7 +101,7 @@ export default {
     delete this._ui;
   },
 
-  _getUI: function(name) {
+  _getUI(name) {
     return this._ui[name];
   }
 };

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -87,7 +87,7 @@ const ViewMixin = {
     return this;
   },
 
-  _getEvents: function(eventsArg) {
+  _getEvents(eventsArg) {
     const events = eventsArg || this.events;
 
     if (_.isFunction(events)) {
@@ -212,7 +212,7 @@ const ViewMixin = {
   },
 
   // Cache `childViewEvents` and `childViewTriggers`
-  _buildEventProxies: function() {
+  _buildEventProxies() {
     this._childViewEvents = _.result(this, 'childViewEvents');
     this._childViewTriggers = _.result(this, 'childViewTriggers');
   },

--- a/src/object.js
+++ b/src/object.js
@@ -36,14 +36,14 @@ _.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, RadioMixin, {
   // for parity with Marionette.AbstractView lifecyle
   _isDestroyed: false,
 
-  isDestroyed: function() {
+  isDestroyed() {
     return this._isDestroyed;
   },
 
   //this is a noop method intended to be overridden by classes that extend from this base
-  initialize: function() {},
+  initialize() {},
 
-  destroy: function(...args) {
+  destroy(...args) {
     if (this._isDestroyed) { return this; }
 
     this.triggerMethod('before:destroy', this, ...args);

--- a/src/region.js
+++ b/src/region.js
@@ -281,7 +281,7 @@ const Region = MarionetteObject.extend({
     return this;
   },
 
-  destroy: function(options) {
+  destroy(options) {
     this.reset(options);
     return MarionetteObject.prototype.destroy.apply(this, arguments);
   }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -13,7 +13,7 @@ const Renderer = {
   // passed to the `TemplateCache` object to retrieve the
   // template function. Override this method to provide your own
   // custom rendering and template handling for all of Marionette.
-  render: function(template, data) {
+  render(template, data) {
     if (!template) {
       throw new MarionetteError({
         name: 'TemplateNotFoundError',

--- a/src/template-cache.js
+++ b/src/template-cache.js
@@ -20,7 +20,7 @@ _.extend(TemplateCache, {
   // Get the specified template by id. Either
   // retrieves the cached version, or loads it
   // from the DOM.
-  get: function(templateId, options) {
+  get(templateId, options) {
     let cachedTemplate = this.templateCaches[templateId];
 
     if (!cachedTemplate) {
@@ -38,7 +38,7 @@ _.extend(TemplateCache, {
   // If arguments are specified, clears each of the
   // specified templates from the cache:
   // `clear("#t1", "#t2", "...")`
-  clear: function(...args) {
+  clear(...args) {
     let i;
     const length = args.length;
 
@@ -58,7 +58,7 @@ _.extend(TemplateCache, {
 _.extend(TemplateCache.prototype, {
 
   // Internal method to load the template
-  load: function(options) {
+  load(options) {
     // Guard clause to prevent loading this template more than once
     if (this.compiledTemplate) {
       return this.compiledTemplate;
@@ -76,7 +76,7 @@ _.extend(TemplateCache.prototype, {
   // For asynchronous loading with AMD/RequireJS, consider
   // using a template-loader plugin as described here:
   // https://github.com/marionettejs/backbone.marionette/wiki/Using-marionette-with-requirejs
-  loadTemplate: function(templateId, options) {
+  loadTemplate(templateId, options) {
     const $template = Backbone.$(templateId);
 
     if (!$template.length) {
@@ -92,7 +92,7 @@ _.extend(TemplateCache.prototype, {
   // this method if you do not need to pre-compile a template
   // (JST / RequireJS for example) or if you want to change
   // the template engine used (Handebars, etc).
-  compileTemplate: function(rawTemplate, options) {
+  compileTemplate(rawTemplate, options) {
     return _.template(rawTemplate, options);
   }
 });

--- a/src/view.js
+++ b/src/view.js
@@ -140,7 +140,7 @@ const View = Backbone.View.extend({
   // object literal, or a function that returns an object
   // literal. All methods and attributes from this object
   // are copies to the object passed in.
-  mixinTemplateContext: function(target = {}) {
+  mixinTemplateContext(target = {}) {
     const templateContext = _.result(this, 'templateContext');
     return _.extend(target, templateContext);
   },
@@ -168,7 +168,7 @@ const View = Backbone.View.extend({
     this.removeRegions();
   },
 
-  _getImmediateChildren: function() {
+  _getImmediateChildren() {
     return _.chain(this.getRegions())
       .map('currentView')
       .compact()

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -4,9 +4,9 @@
     "mocha": true
   },
   "rules": {
-    "new-cap": 0,
+    "object-shorthand": 0,
     "one-var": [ 2, "never" ],
-    "no-var": 0,
-    "object-shorthand": 0
+    "new-cap": 0,
+    "no-var": 0
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -4,6 +4,9 @@
     "mocha": true
   },
   "rules": {
-    "new-cap": 0
+    "new-cap": 0,
+    "one-var": [ 2, "never" ],
+    "no-var": 0,
+    "object-shorthand": 0
   }
 }


### PR DESCRIPTION
### Proposed changes
 - in some places we have `foo: function() {...}` in some `bar() {...}`, so I proposing to make it consistent in format `bar() {...}`

Link to the issue:
I think It's a bit related to https://github.com/marionettejs/backbone.marionette/issues/2858
So for Classes we can have `bar() {...}` declaration and for utils 
```
function foo() {
  ...
}

function bar() {
  ...
}
export {foo, bar}
```
as it is now.

