### PR TITLE
use any patch version as the peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "backbone.radio": "2.0.0-pre.1"
   },
   "peerDependencies": {
-    "backbone": "1.2.1 - 1.3.2",
-    "underscore": "1.8 - 1.8.3"
+    "backbone": "~1.3.3",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "babel-core": "^6.7.0",


### PR DESCRIPTION
### Proposed changes
 - use any patch version as the peer dependency

Link to the issue:
#3037 
