### PR TITLE
Advanced event doc

### DIFF
--- a/docs/marionette.events.md
+++ b/docs/marionette.events.md
@@ -408,3 +408,9 @@ var GrantParentView = Marionette.View.extend({
   }
 });
 ```
+
+## Lifecycle Events
+
+Marionette Views fire events during their creation and destruction lifecycle.
+For more information see [`View` Lifecycle](./marionette.view.md#lifecycle-events)
+and [`CollectionView` Lifecycle](./marionette.collectionview.md#collectionview-events-and-callbacks) events.

--- a/docs/marionette.events.md
+++ b/docs/marionette.events.md
@@ -20,7 +20,8 @@ responding to events.
   * [View `triggerMethod`](#view-triggermethod)
   * [Listening to Events](#listening-to-events)
     * [Magic Method Binding](#magic-method-binding)
-* [Managing View Children](#managing-view-children)
+  * [View events and triggers](#view-events-and-triggers)
+* [Child View Events](#child-view-events)
   * [Event Bubbling](#event-bubbling)
   * [Explicit Event Listeners](#explicit-event-listeners)
 * [Lifecycle Events](#lifecycle-events)
@@ -147,4 +148,42 @@ As before, all arguments passed into `triggerMethod` will make their way into
 the event handler. Using this method ensures there will be no unexpected
 memory leaks.
 
-## Managing View Children
+### View events and triggers
+
+Using this,
+
+## Child View Events
+
+The [`View`](marionette.view.md) and [`CollectionView`](marionette.collectionview.md)
+are able to monitor and act on events on any children they own. Any events fired
+on a view are automatically propagated to their direct parents as well. Let's
+see a quick example:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var Item = Mn.View.extend({
+  tagName: 'li',
+
+  triggers: {
+    'click a': 'select:item'
+  }
+});
+
+var Collection = Mn.CollectionView.extend({
+  tagName: 'ul',
+
+  childEvents: {
+    'select:item': 'itemSelected'
+  },
+
+  itemSelected: function(view) {
+    console.log('item selected: ' + view.model.id);
+  }
+});
+```
+
+### Event Bubbling
+
+Events called on a view bubble up to their direct parent views, calling any
+methods

--- a/docs/marionette.events.md
+++ b/docs/marionette.events.md
@@ -22,4 +22,129 @@ responding to events.
     * [Magic Method Binding](#magic-method-binding)
 * [Managing View Children](#managing-view-children)
   * [Event Bubbling](#event-bubbling)
+  * [Explicit Event Listeners](#explicit-event-listeners)
 * [Lifecycle Events](#lifecycle-events)
+
+## Triggering and Listening to Events
+
+The traditional [event handling system in Backbone](http://backbonejs.org/#Events)
+is also supported in Marionette. Marionette, however, provides an alternative
+event system using the `triggerMethod` method on `Marionette.Object` - the key
+difference between the two is that `triggerMethod` triggers magically named
+event handlers on views. This section covers how `triggerMethod` works and how
+listeners are set up to handle it.
+
+### View `triggerMethod`
+
+The `triggerMethod` method fires the named event on the view - any listeners
+will then be triggered on the event. If there are no listeners, this call will
+still succeed. All arguments after the first argument will be passed to all
+event handlers.
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
+  callMethod: function(myString) {
+    console.log(myString + ' was passed');
+  }
+});
+
+var myView = new MyView();
+/* See Backbone.listenTo */
+myView.on('something:happened', myView.callMethod, myView);
+
+/* Calls callMethod('foo'); */
+myView.triggerMethod('something:happened', 'foo');
+```
+
+**The `triggerMethod` call actually comes from
+[`Marionette.Object`](./marionette.object.md) - anything extending it will also
+have access to this method**
+
+### Listening to Events
+
+Marionette's event triggers work just like regular Backbone events - you can
+use `view.on` and `view.listenTo` to act on events:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
+  initialize: function() {
+    this.on('event:happened', this.logCall);
+  },
+
+  logCall: function(myVal) {
+    console.log(myVal);
+  }
+});
+```
+
+You can also use `listenTo` as in Backbone:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var OtherView = Mn.View.extend({
+  initialize: function(someView) {
+    this.listenTo(someView, 'event:happened', this.logCall);
+  },
+
+  logCall: function(myVal) {
+    console.log(myVal);
+  }
+});
+
+var MyView = Mn.View.extend();
+
+var myView = new MyView();
+
+var otherView = new OtherView(myView);
+```
+
+As in [Backbone](http://backbonejs.org/#Events), `listenTo` will pass the object
+it is called on in as the context variable. These behave exactly as in Backbone,
+so using `object.on` will require you to unhook any event handlers yourself to
+prevent memory leaks. Marionette, however, does provide extra helpers as part of
+the view lifecycle that bind and unbind event handlers for you. this is the
+core of Magic Method Binding.
+
+#### Magic Method Binding
+
+The major difference between `Backbone.trigger` and `View.triggerMethod` is
+that `triggerMethod` can fire specially named events on the attached view. For
+instance, a view that has been rendered will fire `view.triggerMethod('render')`
+and call `onRender` - providing a handy way to add behavior to your views.
+
+Determining what method an event will call is easy, we will outline this with an
+example using `before:dom:refresh` though this also works with any custom events
+you want to fire:
+
+1. Split the words around the `:` characters - so `before`, `dom`, `refresh`
+2. Capitalize the first letter of each word - `Before`, `Dom`, `Refresh`
+3. Add a leading `on` - `on`, `Before`, `Dom`, `Refresh`
+4. Mash it into a single call - `onBeforeDomRefresh`
+
+Using this process, `before:dom:refresh` will call the `onBeforeDomRefresh`
+method. Let's see it in action with a custom event:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
+  onMyEvent: function(myVal) {
+    console.log(myVal);
+  }
+});
+
+var myView = new MyView();
+
+myView.triggerMethod('my:event', 'someValue'); // Logs 'someValue'
+```
+
+As before, all arguments passed into `triggerMethod` will make their way into
+the event handler. Using this method ensures there will be no unexpected
+memory leaks.
+
+## Managing View Children

--- a/docs/marionette.events.md
+++ b/docs/marionette.events.md
@@ -1,0 +1,25 @@
+**_These docs are for Marionette 3 which is still in pre-release. Some parts may
+not be accurate or up-to-date_**
+
+# Marionette Events
+
+The Marionette Event system provides a system for objects to communicate with
+each other in a uniform way. In Marionette, this typically involves objects
+(models, collections, and views) triggering events that other objects
+(typically views) listen to and act on.
+
+This section will mostly deal with View events and the semantics and methods of
+responding to events.
+
+**This section will not cover events from models and collections. See the
+[documentation for View](./marionette.view.md#model-and-collection-events).**
+
+## Documentation Index
+
+* [Triggering and Listening to Events](#triggering-and-listening-to-events)
+  * [View `triggerMethod`](#view-triggermethod)
+  * [Listening to Events](#listening-to-events)
+    * [Magic Method Binding](#magic-method-binding)
+* [Managing View Children](#managing-view-children)
+  * [Event Bubbling](#event-bubbling)
+* [Lifecycle Events](#lifecycle-events)

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -687,7 +687,7 @@ should be called:
 3. Add a leading `on` - `on`, `Before`, `Dom`, `Refresh`
 4. Mash it into a single call - `onBeforeDomRefresh`
 
-For more detail, see the [events documentation](#marionette.events.md#magic-method-binding).
+For more detail, see the [events documentation](./marionette.events.md#magic-method-binding).
 
 ### Lifecycle Events
 
@@ -915,6 +915,8 @@ var MyView = Mn.View.extend({
 The DOM event gets passed in as the first argument, allowing you to see any
 information passed as part of the event.
 
+**When passing a method reference, the method must exist on the View.**
+
 ##### Defining Listeners
 
 Listeners are defined as:
@@ -965,6 +967,67 @@ As when passing a string reference to a view method, the `events` attribute
 passes in the `event` as the argument to the function called.
 
 #### View `triggers`
+
+The view `triggers` attribute binds DOM events to Marionette View events that
+can be responded to at the view or parent level. For more information on events,
+see the [events documentation](./marionette.events.md). This section will just
+cover how to bind these events to views.
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
+  triggers: {
+    'click a': 'link:clicked'
+  },
+
+  onLinkClicked: function() {
+    console.log('Show the modal');
+  }
+});
+```
+
+When the `a` tag is clicked here, the `link:click` event is fired. This event
+can be listened to using the
+[Magic Method Binding](./marionette.events.md#magic-method-binding) technique
+discussed in the [events documentation](./marionette.events.md).
+
+##### Defining Listeners
+
+Listeners are defined as:
+
+```javascript
+eventname jqueryselector
+```
+
+* The `eventname` part refers to a jQuery DOM event e.g. `click` or `change`.
+* The `jqueryselector` part is a jQuery selector string e.g. `.myclass`
+
+You can also pass just the eventname part causing the event handler to fire on
+the entire view. This is especially useful for buttons and click handlers:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var ButtonView = Mn.View.extend({
+  tagName: 'button',
+
+  events: {
+    click: 'entire:view:clicked'
+  },
+
+  onEntireViewClicked: function() {
+    alert('Button was clicked');
+  }
+});
+```
+
+##### Event Bubbling
+
+The major benefit of the `triggers` attribute over `events` is that triggered
+events can bubble up to any parent views. For a full explanation of bubbling
+events and listening to child events, see the
+[event bubbling documentation](./marionette.events#child-view-events).
 
 ## Model and Collection events
 

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -19,10 +19,14 @@ A `View` is a view that represents an item to be displayed with a template.This
 * [Events](#events)
   * [onEvent Listeners](#onevent-listeners)
   * [Lifecycle Events](#lifecycle-events)
-    * ["before:render" / onBeforeRender event](#beforerender--onbeforerender-event)
-    * ["render" / onRender event](#render--onrender-event)
-    * ["before:destroy" / onBeforeDestroy event](#beforedestroy--onbeforedestroy-event)
-    * ["destroy" / onDestroy event](#destroy--ondestroy-event)
+    * [View Creation Lifecycle](#view-creation-lifecycle)
+    * [View Destruction Lifecycle](#view-destruction-lifecycle)
+    * [View Creation Events](#view-creation-events)
+    * [View Destruction Events](#view-destruction-events)
+    * [Other View Events](#other-view-events)
+  * [Binding To User Input](#binding-custom-events)
+    * [View `events`](#view-events)
+    * [View `triggers`](#view-triggers)
 * [Model and Collection Events](#model-and-collection-events)
   * [Model Events](#model-events)
   * [Collection Events](#collection-events)
@@ -599,7 +603,8 @@ it, according to the jQuery documentation.
 #### Referencing UI in events
 
 The UI attribute is especially useful when setting handlers in the
-[`events`](#events-and-callback-methods) object, simply use the `@ui.*` prefix:
+[`events`](#view-events) and [`triggers`](#view-triggers) objects - simply use
+the `@ui.` prefix:
 
 ```javascript
 var Mn = require('backbone.marionette');
@@ -624,6 +629,10 @@ var MyView = Mn.View.extend({
   }
 });
 ```
+
+In this example, when the user clicks on `#save-button`, `handleSave` will be
+called. If the user clicks on `.close-button`, then the event `close:view` will
+be fired on `MyView`.
 
 By prefixing with `@ui`, we can change the underlying template without having to
 hunt through our view for every place where that selector is referenced - just
@@ -673,17 +682,12 @@ This will display in the console:
 The onEvent listeners follow clearly defined rules for determining whether they
 should be called:
 
-  1. Split the event name around `:`
-  2. Capitalize the first letter of each "word"
-  3. Prepend `on` to the event name
-  4. If the associated method exists, call it
-  5. Any extra arguments passed to `triggerMethod` get passed in
+1. Split the words around the `:` characters - so `before`, `dom`, `refresh`
+2. Capitalize the first letter of each word - `Before`, `Dom`, `Refresh`
+3. Add a leading `on` - `on`, `Before`, `Dom`, `Refresh`
+4. Mash it into a single call - `onBeforeDomRefresh`
 
-A few simple examples:
-
-  1. `triggerMethod('render')` calls `onRender()`
-  2. `triggerMethod('before:render')` calls `onBeforeRender()`
-  3. `triggerMethod('before:sync', model)` calls `onBeforeSync(model)`
+For more detail, see the [events documentation](#marionette.events.md#magic-method-binding).
 
 ### Lifecycle Events
 
@@ -881,6 +885,86 @@ view.addRegion("foo", "#bar");
 
 view.removeRegion("foo");
 ```
+
+### Binding To User Input
+
+Views can bind custom events whenever users perform some interaction with the
+DOM. Using the view `events` and `triggers` handlers lets us either bind  user
+input directly to an action or fire a generic trigger that may or may not be
+handled.
+
+#### View `events`
+
+The view `events` attribute binds DOM events to functions or methods on the
+view. The simplest form is to reference a method on the view:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
+  events: {
+    'click a': 'showModal'
+  },
+
+  showModal: function(event) {
+    console.log('Show the modal');
+  }
+});
+```
+
+The DOM event gets passed in as the first argument, allowing you to see any
+information passed as part of the event.
+
+##### Defining Listeners
+
+Listeners are defined as:
+
+```javascript
+eventname jqueryselector
+```
+
+* The `eventname` part refers to a jQuery DOM event e.g. `click` or `change`.
+* The `jqueryselector` part is a jQuery selector string e.g. `.myclass`
+
+You can also pass just the eventname part causing the event handler to fire on
+the entire view. This is especially useful for buttons and click handlers:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var ButtonView = Mn.View.extend({
+  tagName: 'button',
+
+  events: {
+    click: 'showAlert'
+  },
+
+  showAlert: function() {
+    alert('Button was clicked');
+  }
+});
+```
+
+##### Passing a Function
+
+The `events` attribute can also directly bind functions:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
+  events: {
+    'click a': function(event) {
+      console.log('Show the modal');
+    }
+  }
+});
+```
+
+As when passing a string reference to a view method, the `events` attribute
+passes in the `event` as the argument to the function called.
+
+#### View `triggers`
 
 ## Model and Collection events
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -55,6 +55,10 @@ Bubbled child events no longer pass the `childView` implicitly and only pass the
 arguments passed as part of `triggerMethod`. This means that the arguments
 passed to `onEvent` and `onChildviewEvent` are now identical.
 
+In Marionette 2, `childEvents` where bound on every event. In Marionette 3,
+`childViewEvents` are bound once and cached. This means that you cannot add new
+events after the view has been created.
+
 ### View `triggers`
 
 The view `triggers` attribute no longer passes an `options` attribute to event


### PR DESCRIPTION
### Proposed changes
 - Adds event docs in their own where they can be linked from `View` and `CollectionView`
 - Adds the missing `events` and `triggers` attributes to `View`
 - Added notice to the Upgrade Guide

Link to the issue: #2920 #2971 
