### PR TITLE
Style Fixes

### DIFF
--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -17,9 +17,9 @@ communicate and share information.
 Let's look at a simplified example in Marionette:
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
-var NotificationHandler = Marionette.Object.extend({
+var NotificationHandler = Mn.Object.extend({
   channelName: 'notify',
 
   radioRequests: {
@@ -71,7 +71,7 @@ In addition to this documentation, the Radio documentation can be found on
 
 In addition to the standard documentation, the Radio has been integrated in
 Marionette 3 to provide clearer interfaces to the existing API. This is detailed
-in the documentation below. Anything that extends from `Marionette.Object` has
+in the documentation below. Anything that extends from `Mn.Object` has
 access to this API.
 
 ## Documentation Index
@@ -121,9 +121,9 @@ use the `channelName` attribute. We then retrieve the channel instance with
 `getChannel()`:
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
-var ChannelHandler = Marionette.Object.extend({
+var ChannelHandler = Mn.Object.extend({
   channelName: 'basic',
 
   initialize: function() {
@@ -172,11 +172,11 @@ myChannel.off('left:building');
 Just like Backbone Events, the Radio respects the `listenTo` handler as well:
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 var Radio = require('backbone.radio');
 
 
-var Star = Marionette.Object.extend({
+var Star = Mn.Object.extend({
   initialize: function() {
     var starChannel = Radio.channel('star');
 
@@ -200,10 +200,10 @@ listeners on your object instances. This works with a bound `channelName` to let
 us provide listeners using the `radioEvents` attributes.
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
 
-var Star = Marionette.Object.extend({
+var Star = Mn.Object.extend({
   channelName: 'star',
 
   radioEvents: {
@@ -244,12 +244,12 @@ As with request, any arguments passed in `channel.request` will be passed into
 the callback.
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 var Radio = require('backbone.radio');
 
 var channel = Radio.channel('notify');
 
-var Notification = Marionette.Object.extend({
+var Notification = Mn.Object.extend({
   initialize: function() {
     channel.reply('show:success', this.showSuccessMessage);
     channel.reply('show:error', this.showErrorMessage);
@@ -268,12 +268,12 @@ var Notification = Marionette.Object.extend({
 So, for example, when a model sync fails:
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 var Radio = require('backbone.radio');
 
 var channel = Radio.channel('notify');
 
-var ModelView = Marionette.View.extend({
+var ModelView = Mn.View.extend({
   modelEvents: {
     error: 'showErrorMessage'
   },
@@ -295,12 +295,12 @@ let's assume we attach the currently logged-in user to the `Application` object
 and we want to know if they're still logged-in.
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 var Radio = require('backbone.radio');
 
 var channel = Radio.channel('user');
 
-var App = Marionette.Application.extend({
+var App = Mn.Application.extend({
   initialize: function() {
     channel.reply('user:logged:in', this.isLoggedIn);
   },
@@ -328,9 +328,9 @@ Marionette 3 integrates Request/Reply directly onto its `Object` class through
 `radioRequests`. This will simplify the `Notification` quite a bit:
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
-var Notification = Marionette.Object.extend({
+var Notification = Mn.Object.extend({
   channelName: 'notify',
 
   radioRequests: {
@@ -355,9 +355,9 @@ definition.
 As with a normal request/reply, we can return values from these bound handlers:
 
 ```javascript
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
-var App = Marionette.Application.extend({
+var App = Mn.Application.extend({
   channelName: 'user',
 
   radioRequests: {

--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -163,7 +163,7 @@ myChannel.on('left:building', function(person) {
   console.log(person.get('name') + ' has left the building!');
 });
 
-var elvis = new Backbone.Model({name: 'Elvis'});
+var elvis = new Bb.Model({name: 'Elvis'});
 myChannel.trigger('left:building', elvis);
 
 myChannel.off('left:building');

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -46,11 +46,12 @@ hold a reference to the root entry of your View tree. Marionette 3 has added
 this with the `region` attribute and `showView`. This example demonstrates how
 we can use this:
 
-```js
+```javascript
+var Mn = require('backbone.marionette');
 var RootView = require('./views/root');
 
 
-var App = Marionette.Application.extend({
+var App = Mn.Application.extend({
   region: '#root-element',
 
   onStart: function() {
@@ -72,8 +73,10 @@ Like other objects in Backbone and Marionette, Applications have an `initialize`
 method. It is called immediately after the Application has been instantiated,
 and is invoked with the same arguments that the constructor received.
 
-```js
-var App = Marionette.Application.extend({
+```javascript
+var Mn = require('backbone.marionette');
+
+var App = Mn.Application.extend({
   initialize: function(options) {
     console.log('My value:', options.model.get('key'));
   }
@@ -103,11 +106,12 @@ your views and starting `Backbone.history`.
 
 ```js
 var Backbone = require('backbone');
+var Mn = require('backbone.marionette');
 
 var MyModel = require('./mymodel');
 var MyView = require('./myview');
 
-var App = Marionette.Application.extend({
+var App = Mn.Application.extend({
   initialize: function(options) {
     console.log('My value:', options.model.get('key'));
   },

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -20,7 +20,7 @@ var app = new Mn.Application();
 
 // Start history when our application is ready
 app.on('start', function() {
-  Backbone.history.start();
+  Bb.history.start();
 });
 
 // Load some initial data, and then start our application
@@ -74,6 +74,7 @@ method. It is called immediately after the Application has been instantiated,
 and is invoked with the same arguments that the constructor received.
 
 ```javascript
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var App = Mn.Application.extend({
@@ -84,7 +85,7 @@ var App = Mn.Application.extend({
 
 // The application won't attach a model by default - this merely passes it into
 // the options object to be, potentially, passed into views.
-var app = new App({model: new Backbone.Model({key: 'value'})});
+var app = new App({model: new Bb.Model({key: 'value'})});
 ```
 
 ## Application Triggers
@@ -105,7 +106,7 @@ your views and starting `Backbone.history`.
 ### Application Lifecycle
 
 ```js
-var Backbone = require('backbone');
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var MyModel = require('./mymodel');
@@ -122,7 +123,7 @@ var App = Mn.Application.extend({
 
   onStart: function(options) {
     this.showView(new MyView({model: this.model}));
-    Backbone.history.start();
+    Bb.history.start();
   }
 });
 ```

--- a/docs/marionette.approuter.md
+++ b/docs/marionette.approuter.md
@@ -18,8 +18,10 @@ Have your routers configured to call the method on your object, directly.
 
 Configure an AppRouter with `appRoutes`. The route definition is passed on to Backbone's standard routing handlers. This means that you define routes like you normally would.  However, instead of providing a callback method that exists on the router, you provide a callback method that exists on the controller, which you specify for the router instance (see below.)
 
-```js
-var MyRouter = Marionette.AppRouter.extend({
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyRouter = Mn.AppRouter.extend({
   // "someMethod" must exist at controller.someMethod
   appRoutes: {
     "some/route": "someMethod"
@@ -42,8 +44,10 @@ You can also add standard routes to an AppRouter with methods on the router.
 
 Routes can be defined through the constructor function options, as well.
 
-```js
-var MyRouter = new Marionette.AppRouter({
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyRouter = new Mn.AppRouter({
   controller: myController,
   appRoutes: {
     "foo": "doFoo",
@@ -64,8 +68,10 @@ method call. It works the same as the built-in `router.route()` call from
 Backbone's Router, but has all the same semantics and behavior of the `appRoutes`
 configuration.
 
-```js
-var MyRouter = Marionette.AppRouter.extend({});
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyRouter = Mn.AppRouter.extend({});
 
 var router = new MyRouter();
 router.appRoute("/foo", "fooThat");
@@ -73,8 +79,10 @@ router.appRoute("/foo", "fooThat");
 Also you can specify a controller with the multiple routes at runtime with method
 `processAppRoutes`. However, In this case the current controller of `AppRouter` will not change.
 
-```js
-var MyRouter = Marionette.AppRouter.extend({});
+```javascript
+var Mn = require('backbone.marionette');
+
+var MyRouter = Mn.AppRouter.extend({});
 
 var router = new MyRouter();
 router.processAppRoutes(myController, {
@@ -88,12 +96,14 @@ router.processAppRoutes(myController, {
 App routers can only use one `controller` object. You can either specify this
 directly in the router definition:
 
-```js
+```javascript
+var Mn = require('backbone.marionette');
+
 var someController = {
   someMethod: function(){ /*...*/ }
 };
 
-Marionette.AppRouter.extend({
+Mn.AppRouter.extend({
   controller: someController
 });
 ```

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -80,10 +80,12 @@ Specify a `childView` in your collection view definition. This must be
 a Backbone view object definition, not an instance. It can be any
 `Backbone.View` or be derived from `Marionette.View`.
 
-```js
-var MyChildView = Marionette.View.extend({});
+```javascript
+var Mn = require('backbone.marionette');
 
-Marionette.CollectionView.extend({
+var MyChildView = Mn.View.extend({});
+
+Mn.CollectionView.extend({
   childView: MyChildView
 });
 ```
@@ -95,7 +97,9 @@ Alternatively, you can specify a `childView` in the options for
 the constructor:
 
 ```js
-var MyCollectionView = Marionette.CollectionView.extend({...});
+var Mn = require('backbone.marionette');
+
+var MyCollectionView = Mn.CollectionView.extend({...});
 
 new MyCollectionView({
   childView: MyChildView
@@ -111,20 +115,23 @@ when a `Model` needs to be initially rendered. This method also gives you
 the ability to customize per `Model` `ChildViews`.
 
 ```js
+var Backbone = require('backbone');
+var Mn = require('backbone.marionette');
+
 var FooBar = Backbone.Model.extend({
   defaults: {
     isFoo: false
   }
 });
 
-var FooView = Marionette.View.extend({
+var FooView = Mn.View.extend({
   template: '#foo-template'
 });
-var BarView = Marionette.View.extend({
+var BarView = Mn.View.extend({
   template: '#bar-template'
 });
 
-var MyCollectionView = Marionette.CollectionView.extend({
+var MyCollectionView = Mn.CollectionView.extend({
   childView: function(item) {
     // Choose which view class to render,
     // depending on the properties of the item model
@@ -161,13 +168,15 @@ literal. This will be passed to the constructor of your childView as part
 of the `options`.
 
 ```js
-var ChildView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var ChildView = Mn.View.extend({
   initialize: function(options) {
     console.log(options.foo); // => "bar"
   }
 });
 
-var CollectionView = Marionette.CollectionView.extend({
+var CollectionView = Mn.CollectionView.extend({
   childView: ChildView,
 
   childViewOptions: {
@@ -183,7 +192,9 @@ the function should you need access to it when calculating
 of the object will be copied to the `childView` instance's options.
 
 ```js
-var CollectionView = Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+var CollectionView = Mn.CollectionView.extend({
   childViewOptions: function(model, index) {
     // do some calculations based on the model
     return {
@@ -202,7 +213,9 @@ on the collection view. For more information on the `childViewEventPrefix` see
 ["childview:*" event bubbling from child views](#childview-event-bubbling-from-child-views)
 
 ```js
-var CV = Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+var CV = Mn.CollectionView.extend({
   childViewEventPrefix: 'some:prefix'
 });
 
@@ -227,8 +240,10 @@ manually setting bindings. The values of the hash can either be a function or a 
 method name on the collection view.
 
 ```js
+var Mn = require('backbone.marionette');
+
 // childViewEvents can be specified as a hash...
-var MyCollectionView = Marionette.CollectionView.extend({
+var MyCollectionView = Mn.CollectionView.extend({
 
   childViewEvents: {
     // This callback will be called whenever a child is rendered or emits a `render` event
@@ -239,7 +254,7 @@ var MyCollectionView = Marionette.CollectionView.extend({
 });
 
 // ...or as a function that returns a hash.
-var MyCollectionView = Marionette.CollectionView.extend({
+var MyCollectionView = Mn.CollectionView.extend({
 
   childViewEvents: function() {
     return {
@@ -256,8 +271,10 @@ var MyCollectionView = Marionette.CollectionView.extend({
 `childViewEvents` also catches custom events fired by a child view.
 
 ```js
+var Mn = require('backbone.marionette');
+
 // The child view fires a custom event, `show:message`
-var ChildView = Marionette.View.extend({
+var ChildView = Mn.View.extend({
 
   // Events hash defines local event handlers that in turn may call `triggerMethod`.
   events: {
@@ -278,7 +295,7 @@ var ChildView = Marionette.View.extend({
 });
 
 // The parent uses childViewEvents to catch the child view's custom event
-var ParentView = Marionette.CollectionView.extend({
+var ParentView = Mn.CollectionView.extend({
 
   childView: ChildView,
 
@@ -306,8 +323,10 @@ setting bindings. The values of the hash should be a string of the event to trig
 in the same way that [View `triggers`](#abstractviewtriggers) are sugar for [View `events`](#abstractviewevents).
 
 ```js
+var Mn = require('backbone.marionette');
+
 // The child view fires a custom event, `show:message`
-var ChildView = Marionette.View.extend({
+var ChildView = Mn.View.extend({
 
   // Events hash defines local event handlers that in turn may call `triggerMethod`.
   events: {
@@ -328,7 +347,7 @@ var ChildView = Marionette.View.extend({
 });
 
 // The parent uses childViewEvents to catch the child view's custom event
-var ParentView = Marionette.CollectionView.extend({
+var ParentView = Mn.CollectionView.extend({
 
   childView: ChildView,
 
@@ -355,7 +374,9 @@ the views within the collection view, iterate them, find them by
 a given indexer such as the view's model or collection, and more.
 
 ```js
-var cv = new Marionette.CollectionView({
+var Mn = require('backbone.marionette');
+
+var cv = new Mn.CollectionView({
   collection: someCollection
 });
 
@@ -396,7 +417,9 @@ Override this method when you need a more complicated build, but use [`childView
 if you need to determine _which_ View class to instantiate.
 
 ```js
-var MyCollectionView = Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+var MyCollectionView = Mn.CollectionView.extend({
   childView: function(child) {
     if (child.get('type') === 'list') {
       return MyListView;
@@ -431,7 +454,9 @@ The `addChildView` method can be used to add a view that is independent of your 
 This method takes two parameters, the child view instance and the index for where it should be placed within the [CollectionView's children](#collectionviews-children).
 
 ```js
-Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+Mn.CollectionView.extend({
   onRender: function() {
     var buttonView = new ButtonView();
     this.addChildView(buttonView, this.collection.length);
@@ -446,7 +471,9 @@ The `removeChildView` method is useful if you need to remove a view from the `Co
 This method the child view instance to remove as its parameter.
 
 ```js
-Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+Mn.CollectionView.extend({
   onChildViewClose: function(childView, model) {
     // NOTE: we must wait for the server to confirm
     // the destroy PRIOR to removing it from the collection
@@ -466,11 +493,13 @@ collection view. The `emptyView` just like the [`childView`](#collectionviews-ch
 function that returns the `emptyView`.
 
 ```js
-var MyEmptyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyEmptyView = Mn.View.extend({
   template: _.template('Nothing to display.')
 });
 
-Marionette.CollectionView.extend({
+var MyCollectionView = Mn.CollectionView.extend({
   // ...
 
   emptyView: MyEmptyView
@@ -484,13 +513,15 @@ Similar to [`childView`](#collectionviews-childview) and [`childViewOptions`](#c
 If `emptyViewOptions` aren't provided the `CollectionView` will default to passing the `childViewOptions` to the `emptyView`.
 
 ```js
-var EmptyView = Marionette.View({
+var Mn = require('backbone.marionette');
+
+var EmptyView = Mn.View({
   initialize: function(options){
     console.log(options.foo); // => "bar"
   }
 });
 
-var CollectionView = Marionette.CollectionView({
+var CollectionView = Mn.CollectionView({
   emptyView: EmptyView,
 
   emptyViewOptions: {
@@ -505,7 +536,9 @@ If you want to control when the empty view is rendered, you can override
 `isEmpty`:
 
 ```js
-Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+var MyCollectionView = Mn.CollectionView.extend({
   isEmpty: function(options) {
     // some logic to calculate if the view should be rendered as empty
     return this.collection.length < 2;
@@ -521,7 +554,9 @@ children in the collection and renders them individually as a
 `childView`. By default when a `collectionView` is fully rendered it buffers the DOM changes for a single [`attachBuffer`](#collectionviews-attachbuffer)] DOM change.
 
 ```js
-var MyCollectionView = Marionette.CollectionView.extend({...});
+var Mn = require('backbone.marionette');
+
+var MyCollectionView = Mn.CollectionView.extend({...});
 
 // all of the children views will now be rendered.
 new MyCollectionView().render();
@@ -547,13 +582,16 @@ When the collection for the view is sorted, the view will automatically re-sort 
 If the [`reorderOnSort`](#collectionviews-reorderonsort) option is set it will attempt to reorder the DOM and do this without a full re-render, otherwise it will re-render if the order has changed. Please Note that if you apply a filter to the collection view and the filtered views change during a sort then it will always re-render.
 
 ```js
+var Backbone = require('backbone');
+var Mn = require('backbone.marionette');
+
 var collection = new Backbone.Collection();
 
-var MyChildView = Marionette.View.extend({
+var MyChildView = Mn.View.extend({
   template: false
 });
 
-var MyCollectionView = Marionette.CollectionView.extend({
+var MyCollectionView = Mn.CollectionView.extend({
   childView: MyChildView,
   collection: collection,
 });
@@ -586,7 +624,9 @@ view definition. This method takes three parameters and has no return
 value.
 
 ```js
-Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+Mn.CollectionView.extend({
 
   // The default implementation:
   attachHtml: function(collectionView, childView, index){
@@ -625,7 +665,9 @@ increase the buffer provides.
 When overriding [`attachHtml`](#collectionviews-attachhtml) it may be necessary to also override how the buffer is attached. This method receives two parameters. The `collectionView` and the buffer HTML of all of the child views.
 
 ```js
-Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+var MyCollectionView = Mn.CollectionView.extend({
   // The default implementation:
   // Called after all children have been appended into the buffer
   attachBuffer: function(collectionView, buffer) {
@@ -641,14 +683,16 @@ destroys its children and cleans up listeners.
 
 
 ```js
-var MyChildView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyChildView = Mn.View.extend({
   template: _.template('ChildView'),
   onDestroy: function() {
     console.log('I will get destroyed');
   }
 })
 
-var myCollectionView = new Marionette.CollectionView({
+var myCollectionView = new Mn.CollectionView({
   childView: MyChildView,
   collection: new Backbone.Collection([{ id: 1 }])
 });
@@ -666,7 +710,10 @@ The filter function takes a model from the collection and returns a truthy value
 and a falsey value if it should not.
 
 ```js
-var cv = new Marionette.CollectionView({
+var Backbone = require('backbone');
+var Mn = require('backbone.marionette');
+
+var cv = new Mn.CollectionView({
   childView: SomeChildView,
   emptyView: SomeEmptyView,
   collection: new Backbone.Collection([
@@ -703,7 +750,9 @@ rendering the whole DOM structure again.
 Passing `{ preventRender: true }` in the options argument will prevent the view being rendered.
 
 ```js
-var cv = new Marionette.CollectionView({
+var Mn = require('backbone.marionette');
+
+var cv = new Mn.CollectionView({
   collection: someCollection
 });
 
@@ -726,7 +775,9 @@ This function is actually an alias of `setFilter(null, options)`. It is useful f
 `removeFilter` also accepts `preventRender` as a option.
 
 ```js
-var cv = new Marionette.CollectionView({
+var Mn = require('backbone.marionette');
+
+var cv = new Mn.CollectionView({
   collection: someCollection
 });
 
@@ -754,12 +805,12 @@ var myCollection = new Backbone.Collection([
 
 myCollection.comparator = 'id';
 
-var mySortedColView = new Marionette.CollectionView({
+var mySortedColView = new Mn.CollectionView({
   //...
   collection: myCollection
 });
 
-var myUnsortedColView = new Marionette.CollectionView({
+var myUnsortedColView = new Mn.CollectionView({
   //...
   collection: myCollection,
   sort: false
@@ -778,7 +829,9 @@ myCollection.sort();
 `CollectionView` allows for a custom `viewComparator` option if you want your `CollectionView`'s children to be rendered with a different sort order than the underlying Backbone collection uses.
 
 ```js
-var cv = new Marionette.CollectionView({
+var Mn = require('backbone.marionette');
+
+var cv = new Mn.CollectionView({
   collection: someCollection,
   viewComparator: 'otherFieldToSortOn'
 });
@@ -791,7 +844,9 @@ The `viewComparator` can take any of the acceptable `Backbone.Collection` [compa
 Override this method to determine which `viewComparator` to use.
 
 ```js
-var MyCollectionView = Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+var MyCollectionView = Mn.CollectionView.extend({
   sortAsc: function(model) {
     return -model.get('order');
   },
@@ -835,7 +890,9 @@ The `CollectionView` will re-render its children or [`reorder`](#collectionviews
 Override this function if you need further customization.
 
 ```js
-var MyCollectionView = Marionette.CollectionView.extend({
+var Mn = require('backbone.marionette');
+
+var MyCollectionView = Mn.CollectionView.extend({
   resortView: function() {
     // provide custom logic for rendering after sorting the collection
   }
@@ -859,7 +916,9 @@ You can implement this in your view to provide custom code for dealing
 with the view's `el` after it has been rendered:
 
 ```js
-var MyView = Marionette.CollectionView.extend({...});
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.CollectionView.extend({...});
 
 var myView = new MyView();
 
@@ -880,7 +939,9 @@ myView.render();
 The `render:children` event is triggered after a `collectionView`'s children have been rendered and buffered. It differs from the `collectionViews`'s `render` event in that it happens __only__ if the `collection` is not not empty. It may also happen when the children sort when [`reorderOnSort`](#collectionviews-reorderonsort) is false.
 
 ```js
-var MyView = Marionette.CollectionView.extend({...});
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.CollectionView.extend({...});
 
 var myView = new MyView({
   collection: new Backbone.Collection([{ id: 1 }]);
@@ -903,7 +964,9 @@ myView.render();
 Triggered just after destroying the view.  `onBeforeDestroy` is the optimal function for any additional necessary cleanup within the `collectionView`.
 
 ```js
-var MyView = Marionette.CollectionView.extend({...});
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.CollectionView.extend({...});
 
 var myView = new MyView();
 
@@ -924,7 +987,9 @@ myView.destroy();
 Triggered when the `collectionView` is destroyed or before the `collectionView`'s children are re-rendered.
 
 ```js
-var MyView = Marionette.CollectionView.extend({...});
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.CollectionView.extend({...});
 
 var myView = new MyView();
 
@@ -986,11 +1051,13 @@ cv.on({
 The `"render:empty"` event is triggered when rendering the empty view and adding it to the view's DOM element.
 
 ```js
-var myEmptyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var myEmptyView = Mn.View.extend({
   template: false
 });
 
-var MyCollectionView = Marionette.CollectionView.extend({
+var MyCollectionView = Mn.CollectionView.extend({
   emptyView: myEmptyView
 });
 
@@ -1013,17 +1080,20 @@ myCollectionView.render()
 Triggered just after destroying the empty view from the DOM.
 
 ```js
+var Backbone = require('backbone');
+var Mn = require('backbone.marionette');
+
 var collection = new Backbone.Collection();
 
-var myChildView = Marionette.View.extend({
+var myChildView = Mn.View.extend({
   template: false
 });
 
-var myEmptyView = Marionette.View.extend({
+var myEmptyView = Mn.View.extend({
   template: false
 });
 
-var MyCollectionView = Marionette.CollectionView.extend({
+var MyCollectionView = Mn.CollectionView.extend({
   childView: myChildView,
   collection: collection,
   emptyView: myEmptyView
@@ -1049,7 +1119,9 @@ collection.add([{foo: 'bar'}])
 When [`reorderOnSort`](#collectionviews-resortview) is set to `true`, these events are fired for the reordering of the collection.
 
 ```js
-var MyView = Marionette.CollectionView.extend({...});
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.CollectionView.extend({...});
 
 var myCol = new Backbone.Collection({ comparator: ... })
 var myView = new MyView({ reorderOnSort: true });
@@ -1080,13 +1152,15 @@ That is, if a child view triggers "do:something", the
 parent collection view will then trigger "childview:do:something".
 
 ```js
+var Mn = require('backbone.marionette');
+
 // set up basic collection
 var myModel = new MyModel();
 var myCollection = new MyCollection();
 
 myCollection.add(myModel);
 
-var MyView = Marionette.View.extend({
+var MyView = Mn.View.extend({
   triggers: {
     'click button': 'do:something'
   }
@@ -1138,12 +1212,14 @@ Lists are possibly the simplest use of `CollectionView` - simply set a
 `childView` option:
 
 ```javascript
-var ListItemView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var ListItemView = Mn.View.extend({
   tagName: 'li',
   template: '#list-item-text'
 });
 
-var ListView = Marionette.View.extend({
+var ListView = Mn.View.extend({
   tagName: 'ul',
   className: 'list-unstyled',
 
@@ -1192,12 +1268,14 @@ To build a table in Marionette 2 requires the `CompositeView` which we'll build
 as such:
 
 ```javascript
-var RowView = Marionette.LayoutView.extend({
+var Mn = require('backbone.marionette');
+
+var RowView = Mn.LayoutView.extend({
   tagName: 'tr',
   template: '#table-row'
 });
 
-var TableView = Marionette.CompositeView.extend({
+var TableView = Mn.CompositeView.extend({
   tagName: 'table',
   className: 'table table-hover',
   template: '#table',
@@ -1272,17 +1350,19 @@ Marionette 3 doesn't use `CompositeView` any more. We now build tables using
 [Marionette 2](#tables-using-marionette-2):
 
 ```javascript
-var RowView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var RowView = Mn.View.extend({
   tagName: 'tr',
   template: '#row-template'
 });
 
-var TableBody = Marionette.CollectionView.extend({
+var TableBody = Mn.CollectionView.extend({
   tagName: 'tbody',
   childView: RowView
 });
 
-var TableView = Marionette.View.extend({
+var TableView = Mn.View.extend({
   tagName: 'table',
   className: 'table table-hover',
   template: '#table',
@@ -1326,12 +1406,14 @@ picker.
 #### Trees in Marionette 2
 
 ```javascript
-var TreeView = Marionette.CompositeView.extend({
+var Mn = require('backbone.marionette');
+
+var TreeView = Mn.CompositeView.extend({
   tagName: 'ul',
   template: '#tree-template'
 });
 
-var TreeRoot = Marionette.CollectionView.extend({
+var TreeRoot = Mn.CollectionView.extend({
   tagName: 'ul',
   childView: TreeView
 });
@@ -1367,7 +1449,9 @@ As in tables, trees in Marionette 3 require us to combine `View` and
 implicit version provided by Marionette 2.
 
 ```javascript
-var TreeNode = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var TreeNode = Mn.View.extend({
   tagName: 'li',
   template: '#tree-template',
 
@@ -1385,7 +1469,7 @@ var TreeNode = Marionette.View.extend({
   }
 });
 
-var TreeView = Marionette.CollectionView.extend({
+var TreeView = Mn.CollectionView.extend({
   tagName: 'ul',
   childView: TreeNode
 });

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -115,10 +115,10 @@ when a `Model` needs to be initially rendered. This method also gives you
 the ability to customize per `Model` `ChildViews`.
 
 ```js
-var Backbone = require('backbone');
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
-var FooBar = Backbone.Model.extend({
+var FooBar = Bb.Model.extend({
   defaults: {
     isFoo: false
   }
@@ -417,6 +417,7 @@ Override this method when you need a more complicated build, but use [`childView
 if you need to determine _which_ View class to instantiate.
 
 ```js
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var MyCollectionView = Mn.CollectionView.extend({
@@ -431,7 +432,7 @@ var MyCollectionView = Mn.CollectionView.extend({
     var options = {};
 
     if (child.get('type') === 'list') {
-      var childList = new Backbone.Collection(child.get('list'));
+      var childList = new Bb.Collection(child.get('list'));
       options = _.extend({collection: childList}, childViewOptions);
     } else {
       options = _.extend({model: child}, childViewOptions);
@@ -449,9 +450,13 @@ var MyCollectionView = Mn.CollectionView.extend({
 
 ### CollectionView's `addChildView`
 
-The `addChildView` method can be used to add a view that is independent of your Backbone.Collection. Note that this added view will be subject to filtering and ordering and may be difficult to manage in complex situations. Use with care.
+The `addChildView` method can be used to add a view that is independent of your
+`Backbone.Collection`. Note that this added view will be subject to filtering
+and ordering and may be difficult to manage in complex situations. Use with
+care.
 
-This method takes two parameters, the child view instance and the index for where it should be placed within the [CollectionView's children](#collectionviews-children).
+This method takes two parameters, the child view instance and the index for
+where it should be placed within the [CollectionView's children](#collectionviews-children).
 
 ```js
 var Mn = require('backbone.marionette');
@@ -582,10 +587,10 @@ When the collection for the view is sorted, the view will automatically re-sort 
 If the [`reorderOnSort`](#collectionviews-reorderonsort) option is set it will attempt to reorder the DOM and do this without a full re-render, otherwise it will re-render if the order has changed. Please Note that if you apply a filter to the collection view and the filtered views change during a sort then it will always re-render.
 
 ```js
-var Backbone = require('backbone');
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
-var collection = new Backbone.Collection();
+var collection = new Bb.Collection();
 
 var MyChildView = Mn.View.extend({
   template: false
@@ -683,6 +688,7 @@ destroys its children and cleans up listeners.
 
 
 ```js
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var MyChildView = Mn.View.extend({
@@ -694,7 +700,7 @@ var MyChildView = Mn.View.extend({
 
 var myCollectionView = new Mn.CollectionView({
   childView: MyChildView,
-  collection: new Backbone.Collection([{ id: 1 }])
+  collection: new Bb.Collection([{ id: 1 }])
 });
 
 myCollectionView.render();
@@ -710,13 +716,13 @@ The filter function takes a model from the collection and returns a truthy value
 and a falsey value if it should not.
 
 ```js
-var Backbone = require('backbone');
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var cv = new Mn.CollectionView({
   childView: SomeChildView,
   emptyView: SomeEmptyView,
-  collection: new Backbone.Collection([
+  collection: new Bb.Collection([
     { value: 1 },
     { value: 2 },
     { value: 3 },
@@ -792,11 +798,15 @@ cv.removeFilter({ preventRender: true });
 ```
 
 ## CollectionView's `sort`
+
 By default the `CollectionView` will maintain a sorted collection's order
 in the DOM. This behavior can be disabled by specifying `{sort: false}` on initialize. The `sort` flag cannot be changed after instantiation.
 
 ```js
-var myCollection = new Backbone.Collection([
+var Bb = require('backbone');
+var Mn = require('backbone.marionette');
+
+var myCollection = new Bb.Collection([
   { id: 1 },
   { id: 4 },
   { id: 3 },
@@ -837,7 +847,11 @@ var cv = new Mn.CollectionView({
 });
 ```
 
-The `viewComparator` can take any of the acceptable `Backbone.Collection` [comparator formats](http://backbonejs.org/#Collection-comparator) -- a sortBy (pass a function that takes a single argument), as a sort (pass a comparator function that expects two arguments), or as a string indicating the attribute to sort by.
+The `viewComparator` can take any of the acceptable `Backbone.Collection`
+[comparator formats](http://backbonejs.org/#Collection-comparator) -- a sortBy
+(pass a function that takes a single argument), as a sort (pass a comparator
+function that expects two arguments), or as a string indicating the attribute to
+sort by.
 
 ### CollectionView's `getViewComparator`
 
@@ -939,12 +953,13 @@ myView.render();
 The `render:children` event is triggered after a `collectionView`'s children have been rendered and buffered. It differs from the `collectionViews`'s `render` event in that it happens __only__ if the `collection` is not not empty. It may also happen when the children sort when [`reorderOnSort`](#collectionviews-reorderonsort) is false.
 
 ```js
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var MyView = Mn.CollectionView.extend({...});
 
 var myView = new MyView({
-  collection: new Backbone.Collection([{ id: 1 }]);
+  collection: new Bb.Collection([{ id: 1 }]);
 });
 
 myView.on({
@@ -1080,10 +1095,10 @@ myCollectionView.render()
 Triggered just after destroying the empty view from the DOM.
 
 ```js
-var Backbone = require('backbone');
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
-var collection = new Backbone.Collection();
+var collection = new Bb.Collection();
 
 var myChildView = Mn.View.extend({
   template: false
@@ -1119,11 +1134,12 @@ collection.add([{foo: 'bar'}])
 When [`reorderOnSort`](#collectionviews-resortview) is set to `true`, these events are fired for the reordering of the collection.
 
 ```js
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var MyView = Mn.CollectionView.extend({...});
 
-var myCol = new Backbone.Collection({ comparator: ... })
+var myCol = new Bb.Collection({ comparator: ... })
 var myView = new MyView({ reorderOnSort: true });
 
 myView.render();
@@ -1212,6 +1228,7 @@ Lists are possibly the simplest use of `CollectionView` - simply set a
 `childView` option:
 
 ```javascript
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var ListItemView = Mn.View.extend({
@@ -1226,7 +1243,7 @@ var ListView = Mn.View.extend({
   childView: ListItemView
 });
 
-var list = new Backbone.Collection([
+var list = new Bb.Collection([
   {id: 1, text: 'My text'},
   {id: 2, text: 'Another Item'}
 ]);
@@ -1268,6 +1285,7 @@ To build a table in Marionette 2 requires the `CompositeView` which we'll build
 as such:
 
 ```javascript
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var RowView = Mn.LayoutView.extend({
@@ -1283,7 +1301,7 @@ var TableView = Mn.CompositeView.extend({
   childViewContainer: 'tbody'
 });
 
-var list = new Backbone.Collection([
+var list = new Bb.Collection([
   {id: 1, text: 'My text'},
   {id: 2, text: 'Another Item'}
 ]);
@@ -1350,6 +1368,7 @@ Marionette 3 doesn't use `CompositeView` any more. We now build tables using
 [Marionette 2](#tables-using-marionette-2):
 
 ```javascript
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var RowView = Mn.View.extend({
@@ -1381,7 +1400,7 @@ var TableView = Mn.View.extend({
   }
 });
 
-var list = new Backbone.Collection([
+var list = new Bb.Collection([
   {id: 1, text: 'My text'},
   {id: 2, text: 'Another Item'}
 ]);
@@ -1406,6 +1425,7 @@ picker.
 #### Trees in Marionette 2
 
 ```javascript
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var TreeView = Mn.CompositeView.extend({
@@ -1419,7 +1439,7 @@ var TreeRoot = Mn.CollectionView.extend({
 });
 
 
-var tree = new Backbone.Collection([
+var tree = new Bb.Collection([
   {
     id: 5,
     nodes: [
@@ -1449,6 +1469,7 @@ As in tables, trees in Marionette 3 require us to combine `View` and
 implicit version provided by Marionette 2.
 
 ```javascript
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
 var TreeNode = Mn.View.extend({
@@ -1464,7 +1485,7 @@ var TreeNode = Mn.View.extend({
 
   onRender: function() {
     this.showChildView('tree', new TreeView({
-      collection: new Backbone.Collection(this.model.get('nodes'))
+      collection: new Bb.Collection(this.model.get('nodes'))
     }));
   }
 });
@@ -1474,7 +1495,7 @@ var TreeView = Mn.CollectionView.extend({
   childView: TreeNode
 });
 
-var tree = new Backbone.Collection([
+var tree = new Bb.Collection([
   {
     id: 5,
     nodes: [

--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -18,13 +18,15 @@ like `initialize` and `Backbone.Events`.
 * [Basic Use](#basic-use)
 
 
-### Initialize
+## Initialize
 Initialize is called immediately after the Object has been instantiated,
 and is invoked with the same arguments that the constructor received.
 
 
 ```js
-var Friend = Marionette.Object.extend({
+var Mn = require('backbone.marionette');
+
+var Friend = Mn.Object.extend({
   initialize: function(options){
     console.log(options.name);
   }
@@ -34,13 +36,15 @@ new Friend({name: 'John'});
 ```
 
 
-### Events
+## Events
 `Marionette.Object` extends `Backbone.Events` and includes `triggerMethod`.
 This makes it easy for Objects to emit events that other objects can listen for
 with `on` or `listenTo`.
 
 ```js
-var Friend = Marionette.Object.extend({
+var Mn = require('backbone.marionette');
+
+var Friend = Mn.Object.extend({
   graduate: function() {
     this.triggerMethod('announce', 'I graduated!!!');
   }
@@ -55,7 +59,7 @@ john.on('announce', function(message) {
 john.graduate();
 ```
 
-### Radio Events
+## Radio Events
 `Marionette.Object` integrates with `Backbone.Radio` to provide powerful messaging capabilities.  Objects can respond to both of Radio's message types; `Events` and `Requests`.  The syntax is similar to the `events` syntax from Backbone Views, and looks like this:
 
 ```js
@@ -79,21 +83,21 @@ radioRequests: {
 
 means that the object will listen for the `doFoo` request on the `app` channel, and run the 'executeFoo' method.  When using Radio Requests with Objects, the same rules and restrictions that normal Radio use implies also apply here: a single handler can be associated with a request, either through manual use of the reply functions, or through the Object API.
 
-### mergeOptions
+## mergeOptions
 Merge keys from the `options` object directly onto the instance. This is the preferred way to access options
 passed into the Object.
 
 More information at [mergeOptions](./marionette.functions.md#marionettemergeoptions)
 
-### getOption
+## getOption
 Retrieve an object's attribute either directly from the object, or from the object's this.options, with this.options taking precedence.
 
 More information [getOption](./marionette.functions.md#marionettegetoption).
 
-### bindEntityEvents
+## bindEntityEvents
 Helps bind a backbone "entity" to methods on a target object. More information [bindEntityEvents](./marionette.functions.md#marionettebindentityevents).
 
-### Destroying A Object
+## Destroying A Object
 
 Objects have a `destroy` method that unbind the events that are directly attached to the
 instance.
@@ -103,8 +107,10 @@ Invoking the `destroy` method will trigger a "before:destroy" event and correspo
 was invoked with. Invoking `destroy` will return the object, this can be useful for chaining.
 
 ```js
+var Mn = require('backbone.marionette');
+
 // define a object with an onDestroy method
-var MyObject = Marionette.Object.extend({
+var MyObject = Mn.Object.extend({
 
   onBeforeDestroy: function(arg1, arg2){
     // put custom code here, to destroy this object
@@ -126,14 +132,16 @@ obj.destroy(arg1, arg2);
 ```
 
 
-### Basic Use
+## Basic Use
 
 Selections is a simple Object that manages a selection of things.
 Because Selections extends from Object, it gets `initialize` and `Events`
 for free.
 
 ```js
-var Selections = Marionette.Object.extend({
+var Mn = require('backbone.marionette');
+
+var Selections = Mn.Object.extend({
 
   initialize: function(options){
     this.selections = {};

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -431,4 +431,4 @@ myView.someRegion.show(someView, options);
 You can optionally add an `initialize` function to your Region
 definition as shown in this example. It receives the `options`
 that were passed to the constructor of the Region, similar to
-a Backbone.View.
+a `Backbone.View`.

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -38,10 +38,10 @@ can be accessed through `getRegion()` or have a view displayed directly with
 `showView()`. Below is a short example:
 
 ```js
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 var SomeView = require('./view');
 
-var App = Marionette.Application.extend({
+var App = Mn.Application.extend({
   region: '#main-content',
 
   onStart: function() {
@@ -66,9 +66,9 @@ although they will work for `Application` as well - just replace `regions` with
 You can use a jQuery string selector to define regions.
 
 ```js
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
-var MyView = Marionette.View.extend({
+var MyView = Mn.View.extend({
   regions: {
     mainRegion: '#main'
   }
@@ -229,8 +229,9 @@ myRegion.show(myView, {triggerBeforeAttach: false, triggerAttach: false});
 In order to add conditional logic when rendering a view you can override the `renderView` method. This could be useful if you don't want the region to re-render views that aren't destroyed. By default this method will call `view.render`.
 
 ```js
+var Mn = require('backbone.marionette');
 
-var CachingRegion = Marionette.Region.extend({
+var CachingRegion = Mn.Region.extend({
   shouldDestroyView: function(view, options) { return false; },
   renderView: function(view, options) {
     if (!view.isRendered) { view.render(); }
@@ -243,7 +244,9 @@ var CachingRegion = Marionette.Region.extend({
 In order to add conditional logic around whether the current view should be destroyed when showing a new one you can override the `shouldDestroyView` method. This is particularly useful as an alternative to the `preventDestroy` option when you wish to prevent destroy on all views that are shown in the region.
 
 ```js
-var CachingRegion = Marionette.Region.extend({
+var Mn = require('backbone.marionette');
+
+var CachingRegion = Mn.Region.extend({
   shouldDestroyView: function(view, options) { return false; }
 });
 ```
@@ -287,7 +290,9 @@ to the DOM. This method receives one parameter - the view to show.
 The default implementation of `attachHtml` is:
 
 ```js
-Marionette.Region.prototype.attachHtml = function(view){
+var Mn = require('backbone.marionette');
+
+Mn.Region.prototype.attachHtml = function(view){
   this.$el.empty().append(view.el);
 }
 ```
@@ -296,7 +301,9 @@ This replaces the contents of the region with the view's
 `el` / content. You can override `attachHtml` for transition effects and more.
 
 ```js
-Marionette.Region.prototype.attachHtml = function(view){
+var Mn = require('backbone.marionette');
+
+Mn.Region.prototype.attachHtml = function(view){
   this.$el.hide();
   this.$el.html(view.el);
   this.$el.slideDown("fast");
@@ -310,9 +317,9 @@ This example will make a view slide down from the top of the screen instead of j
 appearing in place:
 
 ```js
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
-var ModalRegion = Marionette.Region.extend({
+var ModalRegion = Mn.Region.extend({
   attachHtml: function(view){
     // Some effect to show the view:
     this.$el.empty().append(view.el);
@@ -320,7 +327,7 @@ var ModalRegion = Marionette.Region.extend({
   }
 });
 
-var MyView = Marionette.View.extend({
+var MyView = Mn.View.extend({
   regions: {
     mainRegion: '#main-region',
     modalRegion: {
@@ -360,13 +367,13 @@ new region class by specifying the region class as the
 value. In this case, `addRegions` expects the constructor itself, not an instance.
 
 ```js
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
-var FooterRegion = Marionette.Region.extend({
+var FooterRegion = Mn.Region.extend({
   el: "#footer"
 });
 
-var MyView = Marionette.View.extend({
+var MyView = Mn.View.extend({
   regions: {
     footerRegion: FooterRegion
   }
@@ -377,13 +384,13 @@ You can also specify a selector for the region by using
 an object literal for the configuration.
 
 ```js
-var Marionette = require('backbone.marionette');
+var Mn = require('backbone.marionette');
 
-var FooterRegion = Marionette.Region.extend({
+var FooterRegion = Mn.Region.extend({
   el: "#footer"
 });
 
-var MyView = Marionette.View.extend({
+var MyView = Mn.View.extend({
   regions: {
     footerRegion: {
       regionClass: FooterRegion
@@ -406,7 +413,9 @@ need to extend from `Region` as shown above and then use
 that constructor function on your own:
 
 ```js
-var SomeRegion = Marionette.Region.extend({
+var Mn = require('backbone.marionette');
+
+var SomeRegion = Mn.Region.extend({
   el: "#some-div",
 
   initialize: function(options){

--- a/docs/marionette.templatecache.md
+++ b/docs/marionette.templatecache.md
@@ -3,17 +3,17 @@ not be accurate or up-to-date_**
 
 # Marionette.TemplateCache
 
-The `TemplateCache` provides a cache for retrieving templates
-from script blocks in your HTML. This will improve
-the speed of subsequent calls to get a template.
+The `TemplateCache` provides a cache for retrieving templates from script blocks
+in your HTML. This improved the speed of subsequent calls to get a template.
 
 ## Documentation Index
 
 * [Basic Usage](#basic-usage)
-* [Clear Items From cache](#clear-items-from-cache)
+  * [Clear All Templates from cache](#clear-all-templates-from-cache)
+  * [Clear Specific Templates from Cache](#clear-specific-templates-from-cache)
 * [Customizing Template Access](#customizing-template-access)
-* [Override Template Retrieval](#override-template-retrieval)
-* [Override Template Compilation](#override-template-compilation)
+  * [Override Template Retrieval](#override-template-retrieval)
+  * [Override Template Compilation](#override-template-compilation)
 
 ## Basic Usage
 
@@ -22,65 +22,78 @@ Internally, instances of the TemplateCache class will be created and stored
 but you do not have to manually create these instances yourself. `get` will
 return a compiled template function.
 
-```js
-var template = Marionette.TemplateCache.get("#my-template", {some: options});
+```javascript
+var Mn = require('backbone.marionette');
+
+var template = Mn.TemplateCache.get("#my-template", {option: 'value'});
 // use the template
 template({param1:'value1', paramN:'valueN'});
 ```
 
-Making multiple calls to get the same template will retrieve the
-template from the cache on subsequence calls.
+Making multiple calls to get the same template will retrieve the template from
+the cache on subsequence calls.
 
-### Clear Items From cache
+### Clear All Templates from Cache
 
-You can clear one or more, or all items from the cache using the
-`clear` method. Clearing a template from the cache will force it
-to re-load from the DOM (via the `loadTemplate`
-function which can be overridden, see below) the next time it is retrieved.
+You can clear one or more, or all items from the cache using the `clear` method.
+Clearing a template from the cache will force it to re-load from the DOM (via
+the `loadTemplate` function which can be overridden, see below) the next time it
+is retrieved.
 
-If you do not specify any parameters, all items will be cleared
-from the cache:
+If you do not specify any parameters, all items will be cleared from the cache:
 
-```js
-Marionette.TemplateCache.get("#my-template");
-Marionette.TemplateCache.get("#this-template");
-Marionette.TemplateCache.get("#that-template");
+```javascript
+var Mn = require('backbone.marionette');
+
+Mn.TemplateCache.get("#my-template");
+Mn.TemplateCache.get("#this-template");
+Mn.TemplateCache.get("#that-template");
 
 // clear all templates from the cache
-Marionette.TemplateCache.clear()
+Mn.TemplateCache.clear()
 ```
 
-If you specify one or more parameters, these parameters are assumed
-to be the `templateId` used for loading / caching:
+### Clear Specific Templates from Cache
 
-```js
-Marionette.TemplateCache.get("#my-template");
-Marionette.TemplateCache.get("#this-template");
-Marionette.TemplateCache.get("#that-template");
+To clear only specific templates from the cache, specify the jQuery selector
+that was passed in `get` to your `clear` call:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+// Pre-load our cache
+Mn.TemplateCache.get("#my-template");
+Mn.TemplateCache.get("#this-template");
+Mn.TemplateCache.get("#that-template");
 
 // clear 2 of 3 templates from the cache
-Marionette.TemplateCache.clear("#my-template", "#this-template")
+Mn.TemplateCache.clear("#my-template", "#this-template")
 ```
 
 ## Customizing Template Access
 
-If you want to use an alternate template engine while
-still taking advantage of the template caching functionality, or want to customize
-how templates are stored and retrieved, you will need to customize the
-`TemplateCache object`. The default operation of `TemplateCache`, is to
-retrieve templates from the DOM based on the containing element's id
-attribute, and compile the html in that element with the underscore.js
-`template` function.
+If you want to use an alternate template engine while still taking advantage of
+the template caching functionality, or want to customize how templates are
+stored and retrieved, you will need to customize the `TemplateCache object`. The
+default operation of `TemplateCache`, is to retrieve templates from the DOM
+based on the containing element's id attribute, and compile the html in that
+element with the [underscore.js `template`](http://underscorejs.org#template)
+function.
 
 ### Override Template Retrieval
 
-The default template retrieval is to select the template contents
-from the DOM using jQuery. If you wish to change the way this
-works, you can override the `loadTemplate` method on the
-`TemplateCache` object.
+The default template retrieval is to select the template contents from the DOM
+using jQuery. If you wish to change the way this works, you can override the
+`loadTemplate` method on the `TemplateCache` object.
 
-```js
-Marionette.TemplateCache.prototype.loadTemplate = function(templateId, options){
+```javascript
+var Mn = require('backbone.marionette');
+
+var myTemplateFunc = function(selector) {
+  // custom template logic
+};
+
+Mn.TemplateCache.prototype.loadTemplate = function(templateId, options){
   // load your template here, returning the data needed for the compileTemplate
   // function. For example, you have a function that creates templates based on the
   // value of templateId
@@ -88,20 +101,23 @@ Marionette.TemplateCache.prototype.loadTemplate = function(templateId, options){
 
   // send the template back
   return myTemplate;
-}
+};
 ```
 
 ### Override Template Compilation
 
-The default template compilation passes the results from
-`loadTemplate` to the `compileTemplate` function, which returns
-an underscore.js compiled template function. When overriding `compileTemplate`
-remember that it must return a function which takes an object of parameters and values
-and returns a formatted HTML string.
+The default template compilation passes the results from `loadTemplate` to the
+`compileTemplate` function, which returns an underscore.js compiled template
+function. When overriding `compileTemplate` remember that it must return a
+function which takes an object of parameters and values and returns a formatted
+HTML string.
 
-```js
-Marionette.TemplateCache.prototype.compileTemplate = function(rawTemplate, options) {
+```javascript
+var Handlebars = require('handlebars');
+var Mn = require('backbone.marionette');
+
+Mn.TemplateCache.prototype.compileTemplate = function(rawTemplate, options) {
   // use Handlebars.js to compile the template
   return Handlebars.compile(rawTemplate);
-}
+};
 ```

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -107,10 +107,10 @@ particularly interesting result. As with Backbone, we can attach a model to our
 views and render the data they represent:
 
 ```javascript
-var Backbone = require('backbone');
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
-var MyModel = Backbone.Model.extend({
+var MyModel = Bb.Model.extend({
   defaults: {
     name: 'world'
   }
@@ -133,10 +133,10 @@ a template. Simply pass in the collection as `collection` and Marionette will
 provide an `items` attribute to render:
 
 ```javascript
-var Backbone = require('backbone');
+var Bb = require('backbone');
 var Mn = require('backbone.marionette');
 
-var MyCollection = Backbone.Collection.extend({
+var MyCollection = Bb.Collection.extend({
 });
 
 var MyView = Mn.View.extend({

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -448,7 +448,9 @@ If no view is available, `getChildView` returns `null`.
 A `View` can take a `regions` hash that allows you to specify regions per `View` instance.
 
 ```javascript
-new Marionette.View({
+var Mn = require('backbone.marionette');
+
+new Mn.View({
  regions: {
    "cat": ".doge",
    "wow": {
@@ -471,7 +473,9 @@ Marionette provides a simple mechanism to infinitely nest views in a single pain
 of the children in the onBeforeShow callback.
 
 ```javascript
-var ParentView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var ParentView = Mn.View.extend({
   onBeforeShow: function() {
     this.showChildView('header', new HeaderView());
     this.showChildView('footer', new FooterView());
@@ -726,7 +730,9 @@ These events are fired during the view's creation and rendering in a region.
 Triggered before a View is rendered.
 
 ```js
-Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+Mn.View.extend({
   onBeforeRender: function() {
     // set up final bits just before rendering the view's `el`
   }
@@ -740,7 +746,9 @@ You can implement this in your view to provide custom code for dealing
 with the view's `el` after it has been rendered.
 
 ```js
-Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+Mn.View.extend({
   onRender: function() {
     console.log('el exists but is not visible in the DOM');
   }
@@ -778,7 +786,9 @@ These events are fired during the view's destruction and removal from a region.
 Triggered just prior to destroying the view, when the view's `destroy()` method has been called.
 
 ```js
-Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+Mn.View.extend({
   onBeforeDestroy: function() {
     // manipulate the `el` here. it's already
     // been rendered, and is full of the view's
@@ -803,7 +813,9 @@ Triggered just after the view has been destroyed. At this point, the view has
 been completely removed from the DOM.
 
 ```js
-Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+Mn.View.extend({
   onDestroy: function() {
     // custom destroying and cleanup goes here
   }
@@ -870,7 +882,9 @@ time, or remove the region from an object that has a
 reference to it:
 
 ```javascript
-var view = new Marionette.View();
+var Mn = require('backbone.marionette');
+
+var view = new Mn.View();
 
 view.on("remove:region", function(name, region) {
   // add the region instance to an object
@@ -892,7 +906,9 @@ collections - this includes both [standard][backbone-events] and custom events.
 For example, to listen to a model's events:
 
 ```javascript
-var MyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
   modelEvents: {
     'change:attribute': 'actOnChange'
   },
@@ -911,7 +927,9 @@ to `model.trigger('event', arguments)`.
 You can also bind a function callback directly in the `modelEvents` attribute:
 
 ```javascript
-var MyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
   modelEvents: {
     'change:attribute': function() {
       console.log('attribute was changed');
@@ -927,7 +945,9 @@ returns the object to to attach to `modelEvents`. This is particularly handy for
 binding to events based on options passed into the view:
 
 ```javascript
-var MyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
   modelEvents: function() {
     var events = {};
     var fieldToListenTo = this.getOption('customField');
@@ -944,7 +964,9 @@ var MyView = Marionette.View.extend({
 ### Collection Events
 
 ```javascript
-var MyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
   collectionEvents: {
     sync: 'actOnSync'
   },
@@ -960,7 +982,9 @@ var MyView = Marionette.View.extend({
 You can also bind a function callback directly in the `modelEvents` attribute:
 
 ```javascript
-var MyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
   collectionEvents: {
     'update': function() {
       console.log('the collection was updated');
@@ -976,7 +1000,9 @@ returns the object to to attach to `modelEvents`. This is particularly handy for
 binding to events based on options passed into the view:
 
 ```javascript
-var MyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
   collectionEvents: function() {
     var events = {};
     var eventToListenTo = this.getOption('customListener');
@@ -996,7 +1022,9 @@ If your view has a `model` and `collection` attached, it will listen for events
 on both:
 
 ```javascript
-var MyView = Marionette.View.extend({
+var Mn = require('backbone.marionette');
+
+var MyView = Mn.View.extend({
   modelEvents: {
     'change:someattribute': 'changeMyAttribute'
   },


### PR DESCRIPTION
### Proposed changes
 - Adding imports where necessary at the top of all script blocks
 - Move to use `Mn` instead of `Marionette` in script blocks
 - Fixed indents

Link to the issue: #3066 
