### PR TITLE
reset "destroyed" lifecycle flag via initialization

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -26,6 +26,10 @@ Marionette.View = Backbone.View.extend({
     Marionette.MonitorDOMRefresh(this);
   },
 
+  initialize: function() {
+    this.isDestroyed = false;
+  },
+
   // Get the template for this view
   // instance. You can set a `template` attribute in the view
   // definition or pass a `template: "whatever"` parameter in

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -5,6 +5,7 @@ describe('base view', function() {
     beforeEach(function() {
       this.initializeStub = this.sinon.stub();
       this.viewConstructorSpy = this.sinon.spy(Backbone, 'View');
+      this.viewInitializeSpy = this.sinon.spy(Marionette.View.prototype, 'initialize');
 
       this.View = Marionette.View.extend({
         initialize: this.initializeStub
@@ -17,12 +18,39 @@ describe('base view', function() {
       expect(this.viewConstructorSpy).to.have.been.calledOnce;
     });
 
+    it('should call the Marionette.View initialize', function() {
+      expect(this.viewInitializeSpy).to.have.been.calledOnce;
+    });
+
     it('should call initialize', function() {
       expect(this.initializeStub).to.have.been.calledOnce;
     });
 
     it('should set _behaviors', function() {
       expect(this.view._behaviors).to.be.eql({});
+    });
+
+    it('should reset isDestroyed', function() {
+      expect(this.view).to.be.have.property('isDestroyed', false);
+    });
+
+    describe('and re-initializing after destroying', function() {
+      beforeEach(function() {
+        this.view.destroy();
+        this.view.initialize();
+      });
+
+      it('should call the Marionette.View initialize', function() {
+        expect(this.viewInitializeSpy).to.have.been.calledTwice;
+      });
+
+      it('should call initialize', function() {
+        expect(this.initializeStub).to.have.been.calledTwice;
+      });
+
+      it('should reset isDestroyed', function() {
+        expect(this.view).to.be.have.property('isDestroyed', false);
+      });
     });
   });
 


### PR DESCRIPTION
> allowing views to be re-initialized (and thus re-used)

This is useful for certain use-cases, and doesn't break any behavior.

I searched for occurrences of `isDestroyed` in the source tree and found no logic in the implementations that cared about the state, so this shouldn't break any assumptions or change any behavior whatsoever.