### PR TITLE
Replace onBeforeShow recommendation with onRender

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -3,7 +3,13 @@ not be accurate or up-to-date_**
 
 # Marionette.View
 
-A `View` is a view that represents an item to be displayed with a template.This is typically a `Backbone.Model`, `Backbone.Collection`, or nothing at all.Views are also used to build up your application hierarchy - you can easily nestmultiple views through the `regions` attribute.**_Note: From Marionette v3.x, `Marionette.View` replaces
+A `View` is a view that represents an item to be displayed with a template.
+This is typically a `Backbone.Model`, `Backbone.Collection`, or nothing at all.
+
+Views are also used to build up your application hierarchy - you can easily nest
+multiple views through the `regions` attribute.
+
+**_Note: From Marionette v3.x, `Marionette.View` replaces
 `Marionette.LayoutView` and `Marionette.ItemView`._**
 
 ## Documentation Index
@@ -468,11 +474,11 @@ However, a region will only be able to populate itself if the `View` has access 
 When your views get some more regions, you may want to think of the most efficient way to render your views. Since manipulating the DOM is performany heavy, it's best practice to render most of your views at once.
 
 Marionette provides a simple mechanism to infinitely nest views in a single paint: just render all
-of the children in the onBeforeShow callback.
+of the children in the onRender callback.
 
 ```javascript
 var ParentView = Marionette.View.extend({
-  onBeforeShow: function() {
+  onRender: function() {
     this.showChildView('header', new HeaderView());
     this.showChildView('footer', new FooterView());
   }
@@ -483,7 +489,7 @@ myRegion.show(new ParentView(), options);
 In this example, the doubly-nested view structure will be rendered in a single paint.
 
 This system is recursive, so it works for any deeply nested structure. The child views
-you show can render their own child views within their onBeforeShow callbacks!
+you show can render their own child views within their onRender callbacks!
 
 ### Listening to events on children
 


### PR DESCRIPTION
There's something wrong with the diff here - based on the documentation at https://github.com/marionettejs/backbone.marionette/blob/v3.0.0-pre.4/docs/marionette.view.md the diff should be quite different.

### Proposed changes
 - Replace onBeforeShow recommendation with onRender

Link to the issue:

In https://github.com/marionettejs/backbone.marionette/issues/2539 the usefulness of onBeforeShow was questioned, and in https://github.com/marionettejs/backbone.marionette/pull/2850 it appears to have been mostly removed. But the docs still recommend using it.

Hooking the nested view structure recommendation to onRender accomplishes the same effect.