### PR TITLE
CollectionView and CompositeView removing views performance update.

### DIFF
--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -41,7 +41,7 @@ const CompositeView = CollectionView.extend({
 
     if (this.collection) {
       this.listenTo(this.collection, 'add', this._onCollectionAdd);
-      this.listenTo(this.collection, 'remove', this._onCollectionRemove);
+      this.listenTo(this.collection, 'update', this._onCollectionUpdate);
       this.listenTo(this.collection, 'reset', this.renderChildren);
 
       if (this.sort) {

--- a/test/unit/collection-view.filter.spec.js
+++ b/test/unit/collection-view.filter.spec.js
@@ -71,7 +71,7 @@ describe('collection view - filter', function() {
       this.collection.add(this.passModel);
       this.collection.add(this.failModel);
       this.collectionView = new this.CollectionView();
-      this.sinon.spy(this.collectionView, 'removeChildView');
+      this.sinon.spy(this.collectionView, '_removeChildViews');
       this.collectionView.render();
     });
 
@@ -118,14 +118,15 @@ describe('collection view - filter', function() {
 
     describe('when all models passing the filter are removed from the collection', function() {
       beforeEach(function() {
-        this.passView = this.collectionView.children.first();
+        this.removedViews = this.collectionView.children.first();
+        this.removedModels = [this.passModel];
         this.collection.remove(this.passModel);
       });
 
       it('should remove the child view', function() {
-        expect(this.collectionView.removeChildView).to.have.been.calledOnce
+        expect(this.collectionView._removeChildViews).to.have.been.calledOnce
           .and.calledOn(this.collectionView)
-          .and.calledWith(this.passView);
+          .and.calledWith(this.removedModels);
       });
 
       it('should show the EmptyView', function() {

--- a/test/unit/collection-view.filter.spec.js
+++ b/test/unit/collection-view.filter.spec.js
@@ -71,7 +71,7 @@ describe('collection view - filter', function() {
       this.collection.add(this.passModel);
       this.collection.add(this.failModel);
       this.collectionView = new this.CollectionView();
-      this.sinon.spy(this.collectionView, '_removeChildViews');
+      this.sinon.spy(this.collectionView, '_removeChildModels');
       this.collectionView.render();
     });
 
@@ -124,7 +124,7 @@ describe('collection view - filter', function() {
       });
 
       it('should remove the child view', function() {
-        expect(this.collectionView._removeChildViews).to.have.been.calledOnce
+        expect(this.collectionView._removeChildModels).to.have.been.calledOnce
           .and.calledOn(this.collectionView)
           .and.calledWith(this.removedModels);
       });

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -659,12 +659,12 @@ describe('collection view', function() {
 
       this.beforeRenderSpy = this.sinon.spy(this.collectionView, 'onBeforeRenderEmpty');
       this.renderSpy = this.sinon.spy(this.collectionView, 'onRenderEmpty');
-      this._removeChildViewsSpy = this.sinon.spy(this.collectionView, '_removeChildViews');
+      this._removeChildModelsSpy = this.sinon.spy(this.collectionView, '_removeChildModels');
 
       this.sinon.spy(this.childView, 'destroy');
       this.sinon.spy(this.EmptyView.prototype, 'render');
 
-      this.collectionView._removeChildViews([this.model]);
+      this.collectionView._removeChildModels([this.model]);
     });
 
     it('should destroy the models view', function() {
@@ -683,8 +683,8 @@ describe('collection view', function() {
       expect(this.renderSpy).to.have.been.called;
     });
 
-    it('should call "_removeChildViews"', function() {
-      expect(this._removeChildViewsSpy).to.have.been.called
+    it('should call "_removeChildModels"', function() {
+      expect(this._removeChildModelsSpy).to.have.been.called
                                         .and.to.have.been.calledWith([this.model]);
     });
   });
@@ -949,10 +949,6 @@ describe('collection view', function() {
     it('should call the "remove" method on each child', function() {
       expect(this.childView0.remove).to.have.been.called;
       expect(this.childView1.remove).to.have.been.called;
-    });
-
-    it('should return the child views', function() {
-      expect(this.collectionView._destroyChildren).to.have.returned(this.childrenViews);
     });
 
     it('should call checkEmpty', function() {

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -659,11 +659,12 @@ describe('collection view', function() {
 
       this.beforeRenderSpy = this.sinon.spy(this.collectionView, 'onBeforeRenderEmpty');
       this.renderSpy = this.sinon.spy(this.collectionView, 'onRenderEmpty');
+      this._removeChildViewsSpy = this.sinon.spy(this.collectionView, '_removeChildViews');
 
       this.sinon.spy(this.childView, 'destroy');
       this.sinon.spy(this.EmptyView.prototype, 'render');
 
-      this.collectionView._onCollectionRemove(this.model);
+      this.collectionView._removeChildViews([this.model]);
     });
 
     it('should destroy the models view', function() {
@@ -680,6 +681,11 @@ describe('collection view', function() {
 
     it('should call "onRenderEmpty"', function() {
       expect(this.renderSpy).to.have.been.called;
+    });
+
+    it('should call "_removeChildViews"', function() {
+      expect(this._removeChildViewsSpy).to.have.been.called
+                                        .and.to.have.been.calledWith([this.model]);
     });
   });
 
@@ -772,7 +778,6 @@ describe('collection view', function() {
       this.collectionView.listenTo(this.collectionView, 'item:foo', this.collectionView.someViewCallback);
 
       this.sinon.spy(this.childView, 'destroy');
-      this.sinon.spy(this.collectionView, '_onCollectionRemove');
       this.sinon.spy(this.collectionView, 'stopListening');
       this.sinon.spy(this.collectionView, '_removeElement');
       this.sinon.spy(this.collectionView, 'someCallback');
@@ -955,16 +960,22 @@ describe('collection view', function() {
     });
 
     describe('with the checkEmpty flag set as false', function() {
-      it('should not call checkEmpty', function() {
+      it('should not call _checkEmpty', function() {
         this.collectionView._destroyChildren({checkEmpty: false});
         expect(this.collectionView._checkEmpty).to.have.been.calledOnce;
       });
     });
 
     describe('with the checkEmpty flag set as true', function() {
-      it('should call checkEmpty', function() {
+      it('should call _checkEmpty', function() {
+        this.collectionView.collection.add({id: 3});
         this.collectionView._destroyChildren({checkEmpty: true});
         expect(this.collectionView._checkEmpty).to.have.been.calledTwice;
+      });
+
+      it('should not call _checkEmpty when collection is empty', function() {
+        this.collectionView._destroyChildren({checkEmpty: true});
+        expect(this.collectionView._checkEmpty).to.have.been.calledOnce;
       });
     });
   });
@@ -1116,27 +1127,73 @@ describe('collection view', function() {
       });
 
       this.collectionView.render();
-
-      this.childView = this.collectionView.children[this.model.cid];
-      this.collection.remove(this.model);
     });
 
-    it('should not retain any bindings to this view', function() {
-      var suite = this;
-      var bindings = this.collectionView.bindings || {};
-      expect(_.some(bindings, function(binding) {
-        return binding.obj === suite.childView;
-      })).to.be.false;
+    describe('by model', function() {
+      beforeEach(function() {
+        this.collection.remove(this.model);
+        this.childView = this.collectionView.children[this.model.cid];
+      });
+
+      it('should not retain any bindings to this view', function() {
+        var suite = this;
+        var bindings = this.collectionView.bindings || {};
+        expect(_.some(bindings, function(binding) {
+          return binding.obj === suite.childView;
+        })).to.be.false;
+      });
+
+      it('should not retain any references to this view', function() {
+        expect(_.size(this.collectionView.children)).to.equal(0);
+      });
+
+      it('childView should be undefined', function() {
+        expect(this.childView).to.be.undefined;
+      });
     });
 
-    it('should not retain any references to this view', function() {
-      expect(_.size(this.collectionView.children)).to.equal(0);
+    describe('by view', function() {
+      beforeEach(function() {
+        this.childView = this.collectionView.children.findByModel(this.model);
+        this.removedChildView = this.collectionView.removeChildView(this.childView);
+        this.afterRemoveChildView = this.collectionView.children.findByModel(this.model);
+      });
+
+      it('should not retain any bindings to this view', function() {
+        var suite = this;
+        var bindings = this.collectionView.bindings || {};
+        expect(_.some(bindings, function(binding) {
+          return binding.obj === suite.childView;
+        })).to.be.false;
+      });
+
+      it('should not retain any references to this view', function() {
+        expect(this.collectionView.children.length).to.equal(0);
+      });
+
+      it('childView should be undefined', function() {
+        expect(this.afterRemoveChildView).to.be.undefined;
+      });
+
+      it('should be removed and returned', function() {
+        expect(this.childView).to.equal(this.removedChildView);
+      });
     });
 
-    it('childView should be undefined', function() {
-      expect(this.childView).to.be.undefined;
-    });
+    describe('and trying to remove a view that isn\'t a view', function() {
+      beforeEach(function() {
+        this.sinon.spy(this.collectionView, '_removeChildView');
+        this.removedChildView = this.collectionView.removeChildView(null);
+      });
 
+      it('should return null', function() {
+        expect(this.removedChildView).is.null;
+      });
+
+      it('should not call internal function', function() {
+        expect(this.collectionView._removeChildView).is.not.called;
+      });
+    });
   });
 
   describe('when the collection of a collection view is reset', function() {

--- a/test/unit/sorted-views.spec.js
+++ b/test/unit/sorted-views.spec.js
@@ -133,6 +133,11 @@ describe('collection/composite view sorting', function() {
         expect(this.compositeView.$el).to.have.$text('13');
       });
 
+      it('should have children view with correct _index', function() {
+        expect(this.collectionView.children.findByModel(this.collection.at(0))).to.have.property('_index', 0);
+        expect(this.collectionView.children.findByModel(this.collection.at(1))).to.have.property('_index', 1);
+      });
+
       describe('and then adding another', function() {
         beforeEach(function() {
           this.model = new Backbone.Model({foo: '4'});
@@ -271,6 +276,11 @@ describe('collection/composite view sorting', function() {
       it('should have the order in the dom', function() {
         expect(this.collectionView.$el).to.have.$text('31');
         expect(this.compositeView.$el).to.have.$text('31');
+      });
+
+      it('should have children view with correct _index', function() {
+        expect(this.collectionView.children.findByModel(this.collection.at(0))).to.have.property('_index', 1);
+        expect(this.collectionView.children.findByModel(this.collection.at(1))).to.have.property('_index', 0);
       });
 
       describe('and then adding another', function() {


### PR DESCRIPTION
# CollectionView and CompositeView removing views performance update.
## _initialEvents
* Listen to `this.collection~event:update` instead.

## _onCollectionUpdate
* pass `options.changed.removed` to `this._removeChildViews`
* updated test to reflect additions

##  _removeChildViews
* use array of models to determine what views to remove if not already destroyed.
* Support `checkEmpty` for preventing empty collection checking

## _destroyChildren
* checks to see if there are any children to destroy before calling `_removeChildViews`

## removeChildView
* using _destroyChildView
* added test for trying to remove falsy and valid values

## _getRemovedViews

## _removeChildView

## ~~_onCollectionRemove~~
* test and references removed

## _findGreatestIndexedView
* finds the view with the greatest `_index` and returns it.

## _updateIndices
* accepts array of views for _findGreatestIndexedView

## [test] when removing the sorted view, the `view._index` should update.

![im](https://cloud.githubusercontent.com/assets/833429/16716502/0890f328-46b3-11e6-8be9-6694eeab5888.gif)