### PR TITLE
Make specs compatible with jquery v3

### DIFF
--- a/test/unit/composite-view.spec.js
+++ b/test/unit/composite-view.spec.js
@@ -946,10 +946,6 @@ describe('composite view', function() {
       expect(this.bindUIElementsSpy).to.have.been.calledOnce;
     });
 
-    it('should bind the ui hash to jQuery selectors', function() {
-      expect(this.compositeView.ui.testElement.selector).to.equal('.test-element');
-    });
-
     it('should trigger a before:render event', function() {
       expect(this.triggerSpy).to.have.been.calledWith('before:render', this.compositeView);
     });

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -804,7 +804,7 @@ describe('region', function() {
     });
 
     it('should manage the specified el', function() {
-      expect(this.region.$el.selector).to.equal(this.el);
+      expect(this.region.el).to.equal(this.el);
     });
   });
 

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -555,15 +555,12 @@ describe('layoutView', function() {
 
     it('should apply the relevant @ui. syntax selector to a simple string value', function() {
       expect(this.layoutView.getRegion('war')).to.exist;
-      expect(this.layoutView.getRegion('war').$el.selector).to.equal('.craft');
     });
     it('should apply the relevant @ui. syntax selector to selector in a region definition object', function() {
       expect(this.layoutView.getRegion('mario')).to.exist;
-      expect(this.layoutView.getRegion('mario').$el.selector).to.equal('.bros');
     });
     it('should apply the relevant @ui. syntax selector to el in a region definition object', function() {
       expect(this.layoutView.getRegion('princess')).to.exist;
-      expect(this.layoutView.getRegion('princess').$el.selector).to.equal('.toadstool');
     });
   });
 

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -85,10 +85,6 @@ describe('item view', function() {
       expect(this.bindUIElementsSpy).to.have.been.calledOnce;
     });
 
-    it('should bind the ui hash to jQuery selectors', function() {
-      expect(this.view.ui.testElement.selector).to.equal('.test-element');
-    });
-
     it('should trigger a before:render event', function() {
       expect(this.triggerSpy).to.have.been.calledWith('before:render', this.view);
     });


### PR DESCRIPTION
### Proposed changes
Update specs to not do test on removed jQuery property `.selector`

Link to the issue:
fixes #3095

Marionette V3