### PR TITLE
CollectionView and CompositeView rendering views performance increase

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -122,8 +122,7 @@ const CollectionView = Backbone.View.extend({
 
     if (this._shouldAddChild(child, index)) {
       this._destroyEmptyView();
-      const ChildView = this._getChildView(child);
-      this._addChild(child, ChildView, index);
+      this._addChild(child, index)
     }
   },
 
@@ -402,28 +401,10 @@ const CollectionView = Backbone.View.extend({
     }
   },
 
-  _renderChildView(view) {
-    if (!view.supportsRenderLifecycle) {
-      triggerMethodOn(view, 'before:render', view);
-    }
-
-    // Render view
-    view.render();
-
-    if (!view.supportsRenderLifecycle) {
-      view._isRendered = true;
-      triggerMethodOn(view, 'render', view);
-    }
-
-    return view;
-  },
-
   // Internal method to loop through collection and show each child view.
   _showCollection(models) {
-    _.each(models, (child, index) => {
-      const ChildView = this._getChildView(child);
-      this._addChild(child, ChildView, index);
-    });
+    _.each(models, _.bind(this._addChild, this));
+    this.children._updateLength();
   },
 
   // Allow the collection to be sorted by a custom view comparator
@@ -497,10 +478,8 @@ const CollectionView = Backbone.View.extend({
       const view = this.buildChildView(model, EmptyView, emptyViewOptions);
 
       this.triggerMethod('before:render:empty', this, view);
-      this._addChildView(view, 0);
+      this.addChildView(view, 0);
       this.triggerMethod('render:empty', this, view);
-
-      view._parent = this;
     }
   },
 
@@ -563,11 +542,8 @@ const CollectionView = Backbone.View.extend({
   },
 
   // Internal method for building and adding a child view
-  _addChild(child, ChildView, index) {
-    const childViewOptions = this._getChildViewOptions(child, index);
-
-    const view = this.buildChildView(child, ChildView, childViewOptions);
-
+  _addChild(child, index) {
+    const view = this._createView(child, index);
     this.addChildView(view, index);
 
     return view;
@@ -586,13 +562,21 @@ const CollectionView = Backbone.View.extend({
   // children in sync with the collection.
   addChildView(view, index) {
     this.triggerMethod('before:add:child', this, view);
+    this._setupChildView(view, index);
 
-    // increment indices of views after this one
-    this._updateIndices(view, true, index);
+    // Store the child view itself so we can properly remove and/or destroy it later
+    if (this._isBuffering) {
+      // Add to children, but don't update children's length.
+      this.children._add(view);
+    } else {
+      // increment indices of views after this one
+      this._updateIndices(view, true);
+      this.children.add(view);
+    }
 
-    view._parent = this;
+    this._renderView(view);
 
-    this._addChildView(view, index);
+    this._attachView(view, index);
 
     this.triggerMethod('add:child', this, view);
 
@@ -601,17 +585,12 @@ const CollectionView = Backbone.View.extend({
 
   // Internal method. This decrements or increments the indices of views after the added/removed
   // view to keep in sync with the collection.
-  _updateIndices(views, increment, index) {
+  _updateIndices(views, increment) {
     if (!this.sort) {
       return;
     }
 
     const view = _.isArray(views) ? this._findGreatestIndexedView(views) : views;
-
-    if (increment) {
-      // assign the index to the view
-      view._index = index;
-    }
 
     // update the indexes of views after this one
     this.children.each((laterView) => {
@@ -619,21 +598,6 @@ const CollectionView = Backbone.View.extend({
         laterView._index += increment ? 1 : -1;
       }
     });
-  },
-
-  // Internal Method. Add the view to children and render it at the given index.
-  _addChildView(view, index) {
-    monitorViewEvents(view);
-
-    // set up the child view event forwarding
-    this._proxyChildEvents(view);
-
-    // Store the child view itself so we can properly remove and/or destroy it later
-    this.children.add(view);
-
-    this._renderView(view);
-
-    this._attachView(view, index);
   },
 
   _renderView(view) {

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -382,6 +382,42 @@ const CollectionView = Backbone.View.extend({
     }
   },
 
+  _createView(model, index) {
+    const ChildView = this._getChildView(model);
+    const childViewOptions = this._getChildViewOptions(model, index);
+    const view = this.buildChildView(model, ChildView, childViewOptions);
+    return view;
+  },
+
+  _setupChildView(view, index) {
+    view._parent = this;
+
+    monitorViewEvents(view);
+
+    // set up the child view event forwarding
+    this._proxyChildEvents(view);
+
+    if (this.sort) {
+      view._index = index;
+    }
+  },
+
+  _renderChildView(view) {
+    if (!view.supportsRenderLifecycle) {
+      triggerMethodOn(view, 'before:render', view);
+    }
+
+    // Render view
+    view.render();
+
+    if (!view.supportsRenderLifecycle) {
+      view._isRendered = true;
+      triggerMethodOn(view, 'render', view);
+    }
+
+    return view;
+  },
+
   // Internal method to loop through collection and show each child view.
   _showCollection(models) {
     _.each(models, (child, index) => {

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -149,7 +149,7 @@ describe('collection view', function() {
       this.sinon.spy(this.collectionView.$el, 'append');
       this.sinon.spy(this.collectionView, '_startBuffering');
       this.sinon.spy(this.collectionView, '_endBuffering');
-      this.sinon.spy(this.collectionView, '_addChild');
+      this.sinon.spy(this.collectionView, 'addChildView');
 
       this.collectionView.render();
     });
@@ -254,10 +254,12 @@ describe('collection view', function() {
       expect(this.collectionView.onChildViewRender.callCount).to.equal(2);
     });
 
-    it('should call `addChild` for each item in the collection', function() {
-      expect(this.collectionView._addChild).to.have.been.calledTwice.
-        and.calledWith(this.collection.models[0]).
-        and.calledWith(this.collection.models[1]);
+    it('should call `addChildView` for each item in the collection', function() {
+      var v1 = this.collectionView.children.findByIndex(0);
+      var v2 = this.collectionView.children.findByIndex(1);
+      expect(this.collectionView.addChildView).to.have.been.calledTwice.
+        and.calledWith(v1).
+        and.calledWith(v2);
     });
 
     it('should be marked rendered', function() {
@@ -370,7 +372,7 @@ describe('collection view', function() {
         collection: this.collection
       });
       this.collectionView.render();
-      this.childView = this.collectionView._addChild(this.model, ChildView, 0);
+      this.childView = this.collectionView._addChild(this.model, 0);
     });
 
     it('should call "render" on the childView', function() {
@@ -648,7 +650,7 @@ describe('collection view', function() {
         onRenderEmpty: function() {},
 
         render: function() {
-          this._addChild(suite.model, this.childView, 0);
+          this._addChild(suite.model, 0);
         }
       });
 
@@ -1277,7 +1279,7 @@ describe('collection view', function() {
     describe('when a child view is added to a collection view, after the collection view has been shown', function() {
       beforeEach(function() {
         this.sinon.spy(this.collectionView, 'attachBuffer');
-        this.sinon.spy(this.collectionView, '_addChild');
+        this.sinon.spy(this.collectionView, 'addChildView');
         this.model3 = new Backbone.Model({foo: 3});
         this.collection.add(this.model3);
         this.childView3 = this.collectionView.children.findByIndex(2);
@@ -1287,8 +1289,8 @@ describe('collection view', function() {
         expect(this.collectionView.attachBuffer).not.to.have.been.called;
       });
 
-      it('should call addChild with the new model', function() {
-        expect(this.collectionView._addChild).to.have.been.calledWith(this.model3);
+      it('should call addChildView with the new view', function() {
+        expect(this.collectionView.addChildView).to.have.been.calledWith(this.childView3);
       });
 
       it('should trigger events on the added child view in proper order', function() {
@@ -1304,7 +1306,7 @@ describe('collection view', function() {
         this.childViewAtIndex0 = this.collectionView.children.findByIndex(0);
 
         this.beforeModel = new Backbone.Model({foo: 0});
-        this.collectionView._addChild(this.beforeModel, this.ChildView, 0);
+        this.collectionView._addChild(this.beforeModel, 0);
       });
 
       it('should increment the later childView indexes', function() {
@@ -1558,7 +1560,7 @@ describe('collection view', function() {
     beforeEach(function() {
       this.model = new Backbone.Model({foo: 'bar'});
       this.collectionView = new this.CollectionView();
-      this.childView = this.collectionView._addChild(this.model, this.ChildView, 0);
+      this.childView = this.collectionView._addChild(this.model, 0);
     });
 
     it('should return the child view for the model', function() {


### PR DESCRIPTION
# CollectionView and CompositeView rendering views performance increase 

## addChildView
* using `_setupChildView`
* triggers `event~before:add:child`
* triggers `event~add:child`
* when buffering, will add view to list of children
  but will not update children length for performance increase
* using `_renderView`

## ~~_addChildView~~

## _updateIndices
* removed need to pass index

## _addChild
* removed passing ChildView param
* using `_createView`

## _onCollectionAdd
* using `_addChild`

## _showCollection
* using `_addChild`
* calls `children._updateLength`

## _showEmptyView
* removed unnecessary `view._parent` setting

## addChildView
* moved bulk of functions into `_addChildView`

## _createView
* creates view from model

## _renderChildView
* render views and triggers render events

## _setupChildView
* sets child view properties:
  parent, _index (conditionally), monitorViewEvents, and  _proxyChildEvents.

![faster](https://cloud.githubusercontent.com/assets/833429/17460539/230693c0-5c20-11e6-9c7c-4a807ebc70b4.gif)