### PR TITLE
Unexpose ChildViewContainer

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -30,7 +30,6 @@ import {
 import MarionetteObject   from './object';
 import TemplateCache      from './template-cache';
 import View               from './view';
-import ChildViewContainer from './child-view-container';
 import CollectionView     from './collection-view';
 import CompositeView      from './composite-view';
 import Behavior           from './behavior';
@@ -86,7 +85,6 @@ Marionette.AppRouter = AppRouter;
 Marionette.Renderer = Renderer;
 Marionette.TemplateCache = TemplateCache;
 Marionette.View = View;
-Marionette.ChildViewContainer = ChildViewContainer;
 Marionette.CollectionView = CollectionView;
 Marionette.CompositeView = CompositeView;
 Marionette.Behavior = Behavior;

--- a/test/.globals.json
+++ b/test/.globals.json
@@ -7,6 +7,7 @@
     "jQuery": true,
     "_": true,
     "Backbone": true,
-    "Marionette": true
+    "Marionette": true,
+    "ChildViewContainer": true
   }
 }

--- a/test/setup/setup.js
+++ b/test/setup/setup.js
@@ -5,13 +5,17 @@ module.exports = function() {
   Backbone.$ = jQuery;
   Backbone.Radio = require('backbone.radio');
   var Marionette = require('../../src/backbone.marionette');
+  var ChildViewContainer = require('../../src/child-view-container');
 
   Marionette = 'default' in Marionette ? Marionette.default : Marionette;
+
+  ChildViewContainer = 'default' in ChildViewContainer ? ChildViewContainer.default : ChildViewContainer;
 
   global.$ = global.jQuery = jQuery;
   global._ = _;
   global.Backbone = Backbone;
   global.Marionette = Backbone.Marionette = Marionette;
+  global.ChildViewContainer = ChildViewContainer;
   global.expect = global.chai.expect;
 
   var $fixtures;

--- a/test/unit/child-view-container.spec.js
+++ b/test/unit/child-view-container.spec.js
@@ -10,7 +10,7 @@ describe('childview container', function() {
         new Backbone.View()
       ];
 
-      container = new Marionette.ChildViewContainer(views);
+      container = new ChildViewContainer(views);
     });
 
     it('should add all of the views', function() {
@@ -28,7 +28,7 @@ describe('childview container', function() {
     beforeEach(function() {
       view = new Backbone.View();
 
-      container = new Marionette.ChildViewContainer();
+      container = new ChildViewContainer();
 
       container.add(view);
 
@@ -61,7 +61,7 @@ describe('childview container', function() {
         model: model
       });
 
-      container = new Marionette.ChildViewContainer();
+      container = new ChildViewContainer();
 
       container.add(view);
 
@@ -81,7 +81,7 @@ describe('childview container', function() {
     beforeEach(function() {
       view = new Backbone.View();
 
-      container = new Marionette.ChildViewContainer();
+      container = new ChildViewContainer();
 
       container.add(view, 'custom indexer');
 
@@ -107,7 +107,7 @@ describe('childview container', function() {
         model: model
       });
 
-      container = new Marionette.ChildViewContainer();
+      container = new ChildViewContainer();
       container.add(view, cust);
 
       container.remove(view);
@@ -145,7 +145,7 @@ describe('childview container', function() {
         model: model
       });
 
-      container = new Marionette.ChildViewContainer();
+      container = new ChildViewContainer();
     });
 
     it('should return itself when adding, for chaining methods', function() {
@@ -166,7 +166,7 @@ describe('childview container', function() {
       views = [];
       view = new Backbone.View();
 
-      container = new Marionette.ChildViewContainer();
+      container = new ChildViewContainer();
       container.add(view);
 
       container.each(function(v) {


### PR DESCRIPTION
I had originally exposed it because.. why not?  Babysitter’s was available on Backbone.. but if the goal is to change this such that it gets more heavily integrated into collectionview than we don’t want people using it directly.. removing ensures we can integrate it without introducing breaking changes.