### PR TITLE
Remove v3 warning from docs

### DIFF
--- a/docs/backbone.radio.md
+++ b/docs/backbone.radio.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Backbone Radio
 
 The Backbone Radio provides easy support for a number of messaging patterns for

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Common Marionette Concepts
 
 This document covers the basic usage patterns and concepts across Marionette.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Installing Marionette
 
 As with all JavaScript libraries, there are a number of ways to get started with

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.Application
 
 The `Application` is used to model your Marionette application under a single

--- a/docs/marionette.approuter.md
+++ b/docs/marionette.approuter.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.AppRouter
 
 The Marionette `AppRouter` extends the [`Backbone.Router`][backbone-router] to

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.Behavior
 
 A `Behavior` provides a clean separation of concerns to your view logic,

--- a/docs/marionette.behaviors.md
+++ b/docs/marionette.behaviors.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.Behaviors
 
 **_DEPRECATED: The `behaviorsLookup` is deprecated pending removal. See the

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.CollectionView
 
 The `CollectionView` will loop through all of the models in the

--- a/docs/marionette.collectionviewadvanced.md
+++ b/docs/marionette.collectionviewadvanced.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Advanced CollectionView Usage
 
 `CollectionView` provides a lot of possibilities to sort, filter and manages children.

--- a/docs/marionette.compositeview.md
+++ b/docs/marionette.compositeview.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.CompositeView
 
 **_DEPRECATED: `CompositeView` is deprecated. See

--- a/docs/marionette.events.md
+++ b/docs/marionette.events.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette Events
 
 The Marionette Event system provides a system for objects to communicate with

--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette functions
 
 Marionette provides a set of utility / helper functions that are used to

--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.Object
 
 A base class which other classes can extend from.

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Regions
 
 Regions provide consistent methods to manage, show and destroy

--- a/docs/marionette.renderer.md
+++ b/docs/marionette.renderer.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.Renderer
 
 The `Renderer` object was extracted from the `View` rendering process, in order

--- a/docs/marionette.templatecache.md
+++ b/docs/marionette.templatecache.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.TemplateCache
 
 The `TemplateCache` provides a cache for retrieving templates from script blocks

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Marionette.View
 
 A `View` is a view that represents an item to be displayed with a template.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,6 +2,3 @@
 
 All of the documentation for Marionette can be found on the website at
 ##### [marionettejs.com/docs/current](http://marionettejs.com/docs/current)
-
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,6 +1,3 @@
-**_These docs are for Marionette 3 which is still in pre-release. Some parts may
-not be accurate or up-to-date_**
-
 # Template Rendering
 
 The Marionette View's primary purpose is to render your model and collection


### PR DESCRIPTION
### Proposed changes
- Removed warning message from the top of docs pages

Link to the issue: #3109 

