### PR TITLE
Allow CollectionView to be populated with pre-rendered DOM

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -4,6 +4,7 @@
 import _                  from 'underscore';
 import Backbone           from 'backbone';
 import destroyBackboneView from './utils/destroy-backbone-view';
+import isNodeAttached     from './common/is-node-attached';
 import monitorViewEvents  from './common/monitor-view-events';
 import { triggerMethodOn } from './common/trigger-method';
 import ChildViewContainer from './child-view-container';
@@ -130,6 +131,21 @@ const CollectionView = Backbone.View.extend({
     const view = this.children.findByModel(model);
     this.removeChildView(view);
     this._checkEmpty();
+  },
+
+  // Overriding Backbone.View's `setElement` to handle
+  // if an el was previously defined. If so, the view might be
+  // attached on setElement.
+  setElement() {
+    const hasEl = !!this.el;
+
+    Backbone.View.prototype.setElement.apply(this, arguments);
+
+    if (hasEl) {
+      this._isAttached = isNodeAttached(this.el);
+    }
+
+    return this;
   },
 
   // Render children views. Override this method to provide your own implementation of a

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -489,10 +489,6 @@ const CollectionView = Backbone.View.extend({
 
   // Internal Method. Add the view to children and render it at the given index.
   _addChildView(view, index) {
-    // Only trigger attach if already attached and not buffering,
-    // otherwise _endBuffering() or Region#show() handles this.
-    const shouldTriggerAttach = !this._isBuffering && this._isAttached;
-
     monitorViewEvents(view);
 
     // set up the child view event forwarding
@@ -501,23 +497,37 @@ const CollectionView = Backbone.View.extend({
     // Store the child view itself so we can properly remove and/or destroy it later
     this.children.add(view);
 
+    this._renderView(view);
+
+    this._attachView(view, index);
+  },
+
+  _renderView(view) {
+    if (view._isRendered) {
+      return;
+    }
+
     if (!view.supportsRenderLifecycle) {
       triggerMethodOn(view, 'before:render', view);
     }
 
-    // Render view
     view.render();
 
     if (!view.supportsRenderLifecycle) {
       view._isRendered = true;
       triggerMethodOn(view, 'render', view);
     }
+  },
+
+  _attachView(view, index) {
+    // Only trigger attach if already attached and not buffering,
+    // otherwise _endBuffering() or Region#show() handles this.
+    const shouldTriggerAttach = !view._isAttached && !this._isBuffering && this._isAttached;
 
     if (shouldTriggerAttach) {
       triggerMethodOn(view, 'before:attach', view);
     }
 
-    // Attach view
     this.attachHtml(this, view, index);
 
     if (shouldTriggerAttach) {

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -3,7 +3,6 @@
 
 import Backbone from 'backbone';
 import _ from 'underscore';
-import isNodeAttached from '../common/is-node-attached';
 import { triggerMethod } from '../common/trigger-method';
 import BehaviorsMixin from './behaviors';
 import CommonMixin from './common';
@@ -44,22 +43,6 @@ const ViewMixin = {
 
   isAttached() {
     return !!this._isAttached;
-  },
-
-  // Overriding Backbone.View's `setElement` to handle
-  // if an el was previously defined. If so, the view might be
-  // rendered or attached on setElement.
-  setElement() {
-    const hasEl = !!this.el;
-
-    Backbone.View.prototype.setElement.apply(this, arguments);
-
-    if (hasEl) {
-      this._isRendered = !!this.$el.length;
-      this._isAttached = isNodeAttached(this.el);
-    }
-
-    return this;
   },
 
   // Overriding Backbone.View's `delegateEvents` to handle

--- a/src/view.js
+++ b/src/view.js
@@ -3,6 +3,7 @@
 
 import _                  from 'underscore';
 import Backbone           from 'backbone';
+import isNodeAttached     from './common/is-node-attached';
 import monitorViewEvents  from './common/monitor-view-events';
 import ViewMixin          from './mixins/view';
 import RegionsMixin       from './mixins/regions';
@@ -80,6 +81,22 @@ const View = Backbone.View.extend({
   serializeCollection() {
     if (!this.collection) { return {}; }
     return this.collection.map(function(model) { return _.clone(model.attributes); });
+  },
+
+  // Overriding Backbone.View's `setElement` to handle
+  // if an el was previously defined. If so, the view might be
+  // rendered or attached on setElement.
+  setElement() {
+    const hasEl = !!this.el;
+
+    Backbone.View.prototype.setElement.apply(this, arguments);
+
+    if (hasEl) {
+      this._isRendered = !!this.$el.length;
+      this._isAttached = isNodeAttached(this.el);
+    }
+
+    return this;
   },
 
   // Render the view, defaulting to underscore.js templates.

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -30,16 +30,21 @@ describe('collection view', function() {
 
   describe('when a collection view is DOM', function() {
     beforeEach(function() {
-      this.$fixtureEl = $('<div id="fixture-collectionview"></div>');
+      this.$fixtureEl = $('<div id="fixture-collectionview"><span id="el1">1</span></div>');
     });
 
     describe('and it\'s not attached to the document', function() {
       beforeEach(function() {
-        this.collectionView = new this.CollectionView({el: '#fixture-collectionview'});
+        this.collectionView = new this.CollectionView({el: this.$fixtureEl[0]});
+        this.view1 = this.collectionView.addChildView(new Backbone.View({el: this.$fixtureEl.children()[0]}), 0);
       });
 
       it('should have _isAttached set to false', function() {
         expect(this.collectionView).to.have.property('_isAttached', false);
+      });
+
+      it('should have a child view without _isAttached', function() {
+        expect(this.view1).to.not.have.property('_isAttached');
       });
     });
 
@@ -47,10 +52,15 @@ describe('collection view', function() {
       beforeEach(function() {
         this.setFixtures(this.$fixtureEl);
         this.collectionView = new this.CollectionView({el: '#fixture-collectionview'});
+        this.view1 = this.collectionView.addChildView(new Backbone.View({el: '#el1'}), 0);
       });
 
       it('should have _isAttached set to true', function() {
         expect(this.collectionView).to.have.property('_isAttached', true);
+      });
+
+      it('should have a child view with _isAttached set to true', function() {
+        expect(this.view1).to.have.property('_isAttached', true);
       });
     });
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -28,6 +28,34 @@ describe('collection view', function() {
   // Collection View Specs
   // ---------------------
 
+  describe('when a collection view is DOM', function() {
+    beforeEach(function() {
+      this.$fixtureEl = $('<div id="fixture-collectionview"></div>');
+    });
+
+    describe('and it\'s not attached to the document', function() {
+      beforeEach(function() {
+        this.collectionView = new this.CollectionView({el: '#fixture-collectionview'});
+      });
+
+      it('should have _isAttached set to false', function() {
+        expect(this.collectionView).to.have.property('_isAttached', false);
+      });
+    });
+
+    describe('and it\'s attached to the document', function() {
+      beforeEach(function() {
+        this.setFixtures(this.$fixtureEl);
+        this.collectionView = new this.CollectionView({el: '#fixture-collectionview'});
+      });
+
+      it('should have _isAttached set to true', function() {
+        expect(this.collectionView).to.have.property('_isAttached', true);
+      });
+    });
+
+  });
+
   describe('before rendering a collection view', function() {
     beforeEach(function() {
       var CollectionView = this.CollectionView.extend({
@@ -337,6 +365,12 @@ describe('collection view', function() {
 
     it('should call "render" on the childView', function() {
       expect(this.childView.render).to.have.been.calledOnce;
+    });
+
+    it('should not render childView twice', function() {
+      this.collectionView._renderView(this.childView);
+
+      expect(this.childView.render).to.not.have.been.calledTwice;
     });
   });
 


### PR DESCRIPTION
https://jsfiddle.net/t29dkss1/1/

I don't really know if this would be considered breaking..  I don't really think so..

~~This will need tests..~~ thanks @rafde 

Also one point to note.. overriding `buildChildView` was easy.. however that same function is used to build the emptyView which is kind of unfortunate.. it means that when an emptyView is built we're making an empty model to pass to this function..  and when you override it, we'll have to first detect if the view being passed is the childView or the emptyView before doing something out of the ordinary with the el.

