### PR TITLE
Optimize triggerMethod, mergeOptions and hot handles

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -31,6 +31,29 @@ const ClassOptions = [
   'viewComparator'
 ];
 
+function childViewEventHandle(eventName, ...args) {
+  const prefix = _.result(this, 'childViewEventPrefix');
+
+  const childEventName = prefix + ':' + eventName;
+
+  const childViewEvents = this.normalizeMethods(this._childViewEvents);
+
+  // call collectionView childViewEvent if defined
+  if (typeof childViewEvents !== 'undefined' && _.isFunction(childViewEvents[eventName])) {
+    childViewEvents[eventName].apply(this, args);
+  }
+
+  // use the parent view's proxyEvent handlers
+  const childViewTriggers = this._childViewTriggers;
+
+  // Call the event with the proxy name on the parent layout
+  if (childViewTriggers && _.isString(childViewTriggers[eventName])) {
+    this.triggerMethod(childViewTriggers[eventName], ...args);
+  }
+
+  this.triggerMethod(childEventName, ...args);
+};
+
 // A view that iterates over a Backbone.Collection
 // and renders an individual child view for each model.
 const CollectionView = Backbone.View.extend({
@@ -697,31 +720,9 @@ const CollectionView = Backbone.View.extend({
 
   // Set up the child view event forwarding. Uses a "childview:" prefix in front of all forwarded events.
   _proxyChildEvents(view) {
-    const prefix = _.result(this, 'childViewEventPrefix');
-
     // Forward all child view events through the parent,
     // prepending "childview:" to the event name
-    this.listenTo(view, 'all', (eventName, ...args) => {
-
-      const childEventName = prefix + ':' + eventName;
-
-      const childViewEvents = this.normalizeMethods(this._childViewEvents);
-
-      // call collectionView childViewEvent if defined
-      if (typeof childViewEvents !== 'undefined' && _.isFunction(childViewEvents[eventName])) {
-        childViewEvents[eventName].apply(this, args);
-      }
-
-      // use the parent view's proxyEvent handlers
-      const childViewTriggers = this._childViewTriggers;
-
-      // Call the event with the proxy name on the parent layout
-      if (childViewTriggers && _.isString(childViewTriggers[eventName])) {
-        this.triggerMethod(childViewTriggers[eventName], ...args);
-      }
-
-      this.triggerMethod(childEventName, ...args);
-    });
+    this.listenTo(view, 'all', childViewEventHandle);
   }
 });
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -5,6 +5,7 @@ import _                  from 'underscore';
 import Backbone           from 'backbone';
 import destroyBackboneView from './utils/destroy-backbone-view';
 import isNodeAttached     from './common/is-node-attached';
+import childViewEventHandler from './common/child-view-event-handler';
 import monitorViewEvents  from './common/monitor-view-events';
 import { triggerMethodOn } from './common/trigger-method';
 import ChildViewContainer from './child-view-container';
@@ -30,29 +31,6 @@ const ClassOptions = [
   'ui',
   'viewComparator'
 ];
-
-function childViewEventHandle(eventName, ...args) {
-  const prefix = _.result(this, 'childViewEventPrefix');
-
-  const childEventName = prefix + ':' + eventName;
-
-  const childViewEvents = this.normalizeMethods(this._childViewEvents);
-
-  // call collectionView childViewEvent if defined
-  if (typeof childViewEvents !== 'undefined' && _.isFunction(childViewEvents[eventName])) {
-    childViewEvents[eventName].apply(this, args);
-  }
-
-  // use the parent view's proxyEvent handlers
-  const childViewTriggers = this._childViewTriggers;
-
-  // Call the event with the proxy name on the parent layout
-  if (childViewTriggers && _.isString(childViewTriggers[eventName])) {
-    this.triggerMethod(childViewTriggers[eventName], ...args);
-  }
-
-  this.triggerMethod(childEventName, ...args);
-};
 
 // A view that iterates over a Backbone.Collection
 // and renders an individual child view for each model.
@@ -720,9 +698,7 @@ const CollectionView = Backbone.View.extend({
 
   // Set up the child view event forwarding. Uses a "childview:" prefix in front of all forwarded events.
   _proxyChildEvents(view) {
-    // Forward all child view events through the parent,
-    // prepending "childview:" to the event name
-    this.listenTo(view, 'all', childViewEventHandle);
+    this.listenTo(view, 'all', childViewEventHandler);
   }
 });
 

--- a/src/common/child-view-event-handler.js
+++ b/src/common/child-view-event-handler.js
@@ -1,0 +1,27 @@
+import _ from 'underscore';
+
+// Called with the context of the parent view
+const childViewEventHandler = function(eventName, ...args) {
+  const prefix = _.result(this, 'childViewEventPrefix');
+
+  const childEventName = prefix + ':' + eventName;
+
+  const childViewEvents = this.normalizeMethods(this._childViewEvents);
+
+  // call collectionView childViewEvent if defined
+  if (typeof childViewEvents !== 'undefined' && _.isFunction(childViewEvents[eventName])) {
+    childViewEvents[eventName].apply(this, args);
+  }
+
+  // use the parent view's proxyEvent handlers
+  const childViewTriggers = this._childViewTriggers;
+
+  // Call the event with the proxy name on the parent layout
+  if (childViewTriggers && _.isString(childViewTriggers[eventName])) {
+    this.triggerMethod(childViewTriggers[eventName], ...args);
+  }
+
+  this.triggerMethod(childEventName, ...args);
+};
+
+export default childViewEventHandler;

--- a/src/common/merge-options.js
+++ b/src/common/merge-options.js
@@ -3,7 +3,13 @@ import _ from 'underscore';
 // Merge `keys` from `options` onto `this`
 const mergeOptions = function(options, keys) {
   if (!options) { return; }
-  _.extend(this, _.pick(options, keys));
+
+  _.each(keys, (key) => {
+    const option = options[key];
+    if (option !== undefined) {
+      this[key] = option;
+    }
+  });
 };
 
 export default mergeOptions;

--- a/src/common/monitor-view-events.js
+++ b/src/common/monitor-view-events.js
@@ -33,39 +33,39 @@ function shouldDetach(view) {
   return true;
 }
 
+function triggerDOMRefresh(view) {
+  if (view._isAttached && view._isRendered) {
+    triggerMethodOn(view, 'dom:refresh', view);
+  }
+}
+
+function handleBeforeAttach() {
+  triggerMethodChildren(this, 'before:attach', shouldTriggerAttach);
+}
+
+function handleAttach() {
+  triggerMethodChildren(this, 'attach', shouldAttach);
+  triggerDOMRefresh(this);
+}
+
+function handleBeforeDetach() {
+  triggerMethodChildren(this, 'before:detach', shouldTriggerDetach);
+}
+
+function handleDetach() {
+  triggerMethodChildren(this, 'detach', shouldDetach);
+}
+
+function handleRender() {
+  triggerDOMRefresh(this);
+}
+
 // Monitor a view's state, propagating attach/detach events to children and firing dom:refresh
 // whenever a rendered view is attached or an attached view is rendered.
 function monitorViewEvents(view) {
   if (view._areViewEventsMonitored) { return; }
 
   view._areViewEventsMonitored = true;
-
-  function handleBeforeAttach() {
-    triggerMethodChildren(view, 'before:attach', shouldTriggerAttach);
-  }
-
-  function handleAttach() {
-    triggerMethodChildren(view, 'attach', shouldAttach);
-    triggerDOMRefresh();
-  }
-
-  function handleBeforeDetach() {
-    triggerMethodChildren(view, 'before:detach', shouldTriggerDetach);
-  }
-
-  function handleDetach() {
-    triggerMethodChildren(view, 'detach', shouldDetach);
-  }
-
-  function handleRender() {
-    triggerDOMRefresh();
-  }
-
-  function triggerDOMRefresh() {
-    if (view._isAttached && view._isRendered) {
-      triggerMethodOn(view, 'dom:refresh', view);
-    }
-  }
 
   view.on({
     'before:attach': handleBeforeAttach,

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -93,7 +93,7 @@ export default {
     _invoke(this._behaviors, 'unbindUIElements');
   },
 
-  _triggerEventOnBehaviors(...args) {
+  _triggerEventOnBehaviors(args) {
     const behaviors = this._behaviors;
     // Use good ol' for as this is a very hot function
     for (let i = 0, length = behaviors && behaviors.length; i < length; i++) {

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -93,11 +93,11 @@ export default {
     _invoke(this._behaviors, 'unbindUIElements');
   },
 
-  _triggerEventOnBehaviors(args) {
+  _triggerEventOnBehaviors() {
     const behaviors = this._behaviors;
     // Use good ol' for as this is a very hot function
     for (let i = 0, length = behaviors && behaviors.length; i < length; i++) {
-      triggerMethod.apply(behaviors[i], args);
+      triggerMethod.apply(behaviors[i], arguments);
     }
   }
 };

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -188,7 +188,7 @@ const ViewMixin = {
   triggerMethod() {
     const ret = triggerMethod.apply(this, arguments);
 
-    this._triggerEventOnBehaviors(arguments);
+    this._triggerEventOnBehaviors.apply(this, arguments);
     this._triggerEventOnParentLayout.apply(this, arguments);
 
     return ret;

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -185,11 +185,11 @@ const ViewMixin = {
 
   // import the `triggerMethod` to trigger events with corresponding
   // methods if the method exists
-  triggerMethod(...args) {
-    const ret = triggerMethod.apply(this, args);
+  triggerMethod() {
+    const ret = triggerMethod.apply(this, arguments);
 
-    this._triggerEventOnBehaviors(...args);
-    this._triggerEventOnParentLayout(...args);
+    this._triggerEventOnBehaviors(arguments);
+    this._triggerEventOnParentLayout.apply(this, arguments);
 
     return ret;
   },
@@ -215,16 +215,24 @@ const ViewMixin = {
     // use the parent view's childViewEvents handler
     const childViewEvents = layoutView.normalizeMethods(layoutView._childViewEvents);
 
-    if (!!childViewEvents && _.isFunction(childViewEvents[eventName])) {
-      childViewEvents[eventName].apply(layoutView, args);
+    if (!!childViewEvents) {
+      const childViewEvent = childViewEvents[eventName];
+
+      if (_.isFunction(childViewEvent)) {
+        childViewEvent.apply(layoutView, args);
+      }
     }
 
     // use the parent view's proxyEvent handlers
     const childViewTriggers = layoutView._childViewTriggers;
 
     // Call the event with the proxy name on the parent layout
-    if (childViewTriggers && _.isString(childViewTriggers[eventName])) {
-      layoutView.triggerMethod(childViewTriggers[eventName], ...args);
+    if (childViewTriggers) {
+      const childViewTrigger = childViewTriggers[eventName];
+
+      if (_.isString(childViewTrigger)) {
+        layoutView.triggerMethod(childViewTrigger, ...args);
+      }
     }
   },
 

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -3,6 +3,7 @@
 
 import Backbone from 'backbone';
 import _ from 'underscore';
+import childViewEventHandler from '../common/child-view-event-handler';
 import { triggerMethod } from '../common/trigger-method';
 import BehaviorsMixin from './behaviors';
 import CommonMixin from './common';
@@ -200,40 +201,13 @@ const ViewMixin = {
     this._childViewTriggers = _.result(this, 'childViewTriggers');
   },
 
-  _triggerEventOnParentLayout(eventName, ...args) {
+  _triggerEventOnParentLayout() {
     const layoutView = this._parentView();
     if (!layoutView) {
       return;
     }
 
-    // invoke triggerMethod on parent view
-    const eventPrefix = _.result(layoutView, 'childViewEventPrefix');
-    const prefixedEventName = eventPrefix + ':' + eventName;
-
-    layoutView.triggerMethod(prefixedEventName, ...args);
-
-    // use the parent view's childViewEvents handler
-    const childViewEvents = layoutView.normalizeMethods(layoutView._childViewEvents);
-
-    if (!!childViewEvents) {
-      const childViewEvent = childViewEvents[eventName];
-
-      if (_.isFunction(childViewEvent)) {
-        childViewEvent.apply(layoutView, args);
-      }
-    }
-
-    // use the parent view's proxyEvent handlers
-    const childViewTriggers = layoutView._childViewTriggers;
-
-    // Call the event with the proxy name on the parent layout
-    if (childViewTriggers) {
-      const childViewTrigger = childViewTriggers[eventName];
-
-      if (_.isString(childViewTrigger)) {
-        layoutView.triggerMethod(childViewTrigger, ...args);
-      }
-    }
+    childViewEventHandler.apply(layoutView, arguments);
   },
 
   // Walk the _parent tree until we find a view (if one exists).


### PR DESCRIPTION
# Proposed changes
 - Optimize common `triggerMethod` and `View` mixin `triggerMethod`
 - Optimize `mergeOptions` to only use 1 loop (each only now) instead of 2 (pick and extend)
 - Create handles once for monitor view events and inline triggerMethodOn statement
 - Create handles once for CollectionView `_proxyChildEvents`

## mergeOptions src/common/merge-options.js
* iterate through `keys` and merge instead
  of getting the `keys` from options, then merging

## monitor-view-events  src/common/monitor-view-events.js
* Define once:
   triggerDOMRefresh
   handleBeforeAttach
   handleAttach
   handleBeforeDetach
   handleDetach
   handleRender

## CollectionView src/collection-view.js
* private childViewEventHandle for optimization
* using childViewEventHandler

## src/common/trigger-method.js
* will remember the last `event` name transform

## src/mixins/behaviors.js
_triggerEventOnBehaviors
* using `arguments`

## src/mixins/view.js
triggerMethod
* only passes along `arguments` other functions

@paulfalgout initiated the investigation, I just went the OCD route and kept going till I got to this point.

Adding gif for visual effect. The gif is an example of how the render, destroy, and triggerMethod optimization numbers will look when they get merged into master.

![triggermethod](https://cloud.githubusercontent.com/assets/833429/18031607/0c998614-6c9d-11e6-9a35-7db72efd9e3f.gif)
