### PR TITLE
Fix behavior to be compatible with lodash v4

### DIFF
--- a/src/behavior.js
+++ b/src/behavior.js
@@ -105,7 +105,7 @@ const Behavior = MarionetteObject.extend({
     const behaviorEvents = this.normalizeUIKeys(_.result(this, 'events'));
 
     // binds the handler to the behavior and builds a unique eventName
-    return _.reduce(behaviorEvents, function(events, behaviorHandler, key) {
+    return _.reduce(behaviorEvents, (events, behaviorHandler, key) => {
       if (!_.isFunction(behaviorHandler)) {
         behaviorHandler = this[behaviorHandler];
       }
@@ -113,7 +113,7 @@ const Behavior = MarionetteObject.extend({
       key = getUniqueEventName(key);
       events[key] = _.bind(behaviorHandler, this);
       return events;
-    } , {}, this);
+    }, {});
   },
 
   // Internal method to build all trigger handlers for a given behavior


### PR DESCRIPTION
### Hello :)

This is my first PR for Marionette so I hope I am doing this right.

I ran into a bug when using behaviors that declare events with the latest release of Marionette.

I am using the following library versions:

 - Marionette `3.0.0`
 - Backbone `1.3.3`
 - Lodash `4.15.0`

### Proposed changes
 - Pass an arrow function as iteratee to `_.reduce` in `getEvents` method instead of passing `this` as the last argument to be compatible with lodash v4

The tests are passing using `npm test` but I was never able to build the library due to a gulp error (same kind of error when trying to run the browser test). As I don't know much about gulp I did not dig into it very much.

I manually tested that this would "fix" the problem by directly patching the built source of Marionette with a `function () {}.bind(this)` passed to the `_.reduce` call.

I guess my tests are not exact but I saw the same kind of fixes in the [lodash 4 support](https://github.com/marionettejs/backbone.marionette/pull/2889/files) PR.

Reading the [contribution guide](https://github.com/RasCarlito/backbone.marionette/blob/master/CONTRIBUTING.md) I saw that a bug fix should be made on the `patch` branch, but I could only find the v3 code in the `next` and `master` branches. So my best guess was to make the modifications on the `next` branch.

Hope this helps.

Cheers