### PR TITLE
Separate Mn DOM interaction into a mixin for DOM plugin ease.

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -357,7 +357,7 @@ const CollectionView = Backbone.View.extend({
   // Internal method. Separated so that CompositeView can append to the childViewContainer
   // if necessary
   _appendReorderedChildren(children) {
-    this.$el.append(children);
+    this.appendChildren(this.el, children);
   },
 
   // Internal method. Separated so that CompositeView can have more control over events
@@ -674,14 +674,14 @@ const CollectionView = Backbone.View.extend({
 
   // You might need to override this if you've overridden attachHtml
   attachBuffer(collectionView, buffer) {
-    collectionView.$el.append(buffer);
+    this.appendChildren(collectionView.el, buffer);
   },
 
   // Create a fragment buffer from the currently buffered children
   _createBuffer() {
-    const elBuffer = document.createDocumentFragment();
+    const elBuffer = this.createBuffer();
     _.each(this._bufferedChildren, (b) => {
-      elBuffer.appendChild(b.el);
+      this.appendChildren(elBuffer, b.el);
     });
     return elBuffer;
   },
@@ -716,7 +716,7 @@ const CollectionView = Backbone.View.extend({
     }
 
     if (currentView) {
-      currentView.$el.before(childView.el);
+      this.beforeEl(currentView.el, childView.el);
       return true;
     }
 
@@ -725,7 +725,7 @@ const CollectionView = Backbone.View.extend({
 
   // Internal method. Append a view to the end of the $el
   _insertAfter(childView) {
-    this.$el.append(childView.el);
+    this.appendChildren(this.el, childView.el);
   },
 
   // Internal method to set up the `children` object for storing all of the child views

--- a/src/common/is-node-attached.js
+++ b/src/common/is-node-attached.js
@@ -1,11 +1,9 @@
 // Marionette.isNodeAttached
 // -------------------------
 
-import Backbone from 'backbone';
-
 // Determine if `el` is a child of the document
 const isNodeAttached = function(el) {
-  return Backbone.$.contains(document.documentElement, el);
+  return document.documentElement.contains(el && el.parentNode);
 };
 
 export default isNodeAttached;

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -110,7 +110,7 @@ const CompositeView = CollectionView.extend({
   // You might need to override this if you've overridden attachHtml
   attachBuffer(compositeView, buffer) {
     const $container = this.getChildViewContainer(compositeView);
-    $container.append(buffer);
+    this.appendChildren($container, buffer);
   },
 
   // Internal method. Append a view to the end of the $el.
@@ -118,7 +118,7 @@ const CompositeView = CollectionView.extend({
   // childViewContainer
   _insertAfter(childView) {
     const $container = this.getChildViewContainer(this, childView);
-    $container.append(childView.el);
+    this.appendChildren($container, childView.el);
   },
 
   // Internal method. Append reordered childView'.
@@ -126,7 +126,7 @@ const CompositeView = CollectionView.extend({
   // are appended to childViewContainer
   _appendReorderedChildren(children) {
     const $container = this.getChildViewContainer(this);
-    $container.append(children);
+    this.appendChildren($container, children);
   },
 
   // Internal method to ensure an `$childViewContainer` exists, for the
@@ -145,7 +145,7 @@ const CompositeView = CollectionView.extend({
       if (selector.charAt(0) === '@' && containerView.ui) {
         container = containerView.ui[selector.substr(4)];
       } else {
-        container = containerView.$(selector);
+        container = this.findEls(selector, containerView.$el);
       }
 
       if (container.length <= 0) {

--- a/src/mixins/dom.js
+++ b/src/mixins/dom.js
@@ -1,0 +1,44 @@
+// DomMixin
+//  ---------
+
+import Backbone from 'backbone';
+
+export default {
+  createBuffer() {
+    return document.createDocumentFragment();
+  },
+
+  appendChildren(el, children) {
+    Backbone.$(el).append(children);
+  },
+
+  beforeEl(el, sibling) {
+    Backbone.$(el).before(sibling);
+  },
+
+  replaceEl(newEl, oldEl) {
+    const parent = oldEl.parentNode;
+
+    if (!parent) {
+      return;
+    }
+
+    parent.replaceChild(newEl, oldEl);
+  },
+
+  detachContents(el) {
+    Backbone.$(el).contents().detach();
+  },
+
+  setInnerContent(el, html) {
+    Backbone.$(el).html(html);
+  },
+
+  removeEl(el) {
+    Backbone.$(el).remove();
+  },
+
+  findEls(selector, context) {
+    return Backbone.$(selector, context);
+  }
+};

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -11,6 +11,7 @@ import TriggersMixin from './triggers';
 import UIMixin from './ui';
 import View from '../view';
 import MarionetteError from '../error';
+import DomMixin from './dom';
 
 // MixinOptions
 // - behaviors
@@ -137,8 +138,7 @@ const ViewMixin = {
     this.unbindUIElements();
 
     // remove the view from the DOM
-    // https://github.com/jashkenas/backbone/blob/1.2.3/backbone.js#L1235
-    this._removeElement();
+    this.removeEl(this.el);
 
     if (shouldTriggerDetach) {
       this._isAttached = false;
@@ -248,6 +248,6 @@ const ViewMixin = {
   }
 };
 
-_.extend(ViewMixin, BehaviorsMixin, CommonMixin, DelegateEntityEventsMixin, TriggersMixin, UIMixin);
+_.extend(ViewMixin, DomMixin, BehaviorsMixin, CommonMixin, DelegateEntityEventsMixin, TriggersMixin, UIMixin);
 
 export default ViewMixin;

--- a/src/region.js
+++ b/src/region.js
@@ -10,6 +10,7 @@ import isNodeAttached from './common/is-node-attached';
 import { triggerMethodOn } from './common/trigger-method';
 import MarionetteObject from './object';
 import MarionetteError from './error';
+import DomMixin from './mixins/dom';
 
 const ClassOptions = [
   'allowMissingEl',
@@ -154,16 +155,15 @@ const Region = MarionetteObject.extend({
   // Override this method to change how the region finds the DOM element that it manages. Return
   // a jQuery selector object scoped to a provided parent el or the document if none exists.
   getEl(el) {
-    return Backbone.$(el, _.result(this, 'parentEl'));
+    return this.findEls(el, _.result(this, 'parentEl'));
   },
 
   _replaceEl(view) {
     // always restore the el to ensure the regions el is present before replacing
     this._restoreEl();
 
-    const parent = this.el.parentNode;
+    this.replaceEl(view.el, this.el);
 
-    parent.replaceChild(view.el, this.el);
     this._isReplaced = true;
   },
 
@@ -180,13 +180,8 @@ const Region = MarionetteObject.extend({
       return;
     }
 
-    const parent = view.el.parentNode;
+    this.replaceEl(this.el, view.el);
 
-    if (!parent) {
-      return;
-    }
-
-    parent.replaceChild(this.el, view.el);
     this._isReplaced = false;
   },
 
@@ -198,7 +193,7 @@ const Region = MarionetteObject.extend({
   // Override this method to change how the new view is appended to the `$el` that the
   // region is managing
   attachHtml(view) {
-    this.el.appendChild(view.el);
+    this.appendChildren(this.el, view.el);
   },
 
   // Destroy the current view, if there is one. If there is no current view, it does
@@ -281,7 +276,7 @@ const Region = MarionetteObject.extend({
 
   // Override this method to change how the region detaches current content
   detachHtml() {
-    this.$el.contents().detach();
+    this.detachContents(this.el);
   },
 
   // Checks whether a view is currently present within the region. Returns `true` if there is
@@ -309,5 +304,7 @@ const Region = MarionetteObject.extend({
     return MarionetteObject.prototype.destroy.apply(this, arguments);
   }
 });
+
+_.extend(Region.prototype, DomMixin);
 
 export default Region;

--- a/src/template-cache.js
+++ b/src/template-cache.js
@@ -2,7 +2,7 @@
 // --------------
 
 import _ from 'underscore';
-import Backbone from 'backbone';
+import DomMixin from './mixins/dom';
 import MarionetteError from './error';
 
 // Manage templates stored in `<script>` blocks,
@@ -55,7 +55,7 @@ _.extend(TemplateCache, {
 // TemplateCache instance methods, allowing each
 // template cache object to manage its own state
 // and know whether or not it has been loaded
-_.extend(TemplateCache.prototype, {
+_.extend(TemplateCache.prototype, DomMixin, {
 
   // Internal method to load the template
   load(options) {
@@ -77,7 +77,7 @@ _.extend(TemplateCache.prototype, {
   // using a template-loader plugin as described here:
   // https://github.com/marionettejs/backbone.marionette/wiki/Using-marionette-with-requirejs
   loadTemplate(templateId, options) {
-    const $template = Backbone.$(templateId);
+    const $template = this.findEls(templateId);
 
     if (!$template.length) {
       throw new MarionetteError({

--- a/src/view.js
+++ b/src/view.js
@@ -179,7 +179,7 @@ const View = Backbone.View.extend({
   // }
   // ```
   attachElContent(html) {
-    this.$el.html(html);
+    this.setInnerContent(this.el, html);
 
     return this;
   },

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -146,7 +146,7 @@ describe('collection view', function() {
       this.sinon.spy(this.collectionView, 'onRender');
       this.sinon.spy(this.collectionView, 'trigger');
       this.sinon.spy(this.collectionView, 'attachHtml');
-      this.sinon.spy(this.collectionView.$el, 'append');
+      this.sinon.spy(this.collectionView, 'attachBuffer');
       this.sinon.spy(this.collectionView, '_startBuffering');
       this.sinon.spy(this.collectionView, '_endBuffering');
       this.sinon.spy(this.collectionView, 'addChildView');
@@ -154,8 +154,8 @@ describe('collection view', function() {
       this.collectionView.render();
     });
 
-    it('should only call $el.append once', function() {
-      expect(this.collectionView.$el.append.callCount).to.equal(1);
+    it('should only call attachBuffer once', function() {
+      expect(this.collectionView.attachBuffer.callCount).to.equal(1);
     });
 
     it('should only call clear render buffer once', function() {
@@ -781,7 +781,7 @@ describe('collection view', function() {
 
       this.sinon.spy(this.childView, 'destroy');
       this.sinon.spy(this.collectionView, 'stopListening');
-      this.sinon.spy(this.collectionView, '_removeElement');
+      this.sinon.spy(this.collectionView, 'removeEl');
       this.sinon.spy(this.collectionView, 'someCallback');
       this.sinon.spy(this.collectionView, 'someViewCallback');
       this.sinon.spy(this.collectionView, 'destroy');
@@ -829,7 +829,7 @@ describe('collection view', function() {
     });
 
     it('should remove the views EL from the DOM', function() {
-      expect(this.collectionView._removeElement).to.have.been.called;
+      expect(this.collectionView.removeEl).to.have.been.called;
     });
 
     it('should call "onDestroy" if provided', function() {

--- a/test/unit/utils/view.spec.js
+++ b/test/unit/utils/view.spec.js
@@ -41,7 +41,7 @@ describe('view mixin', function() {
 
       this.view = new Marionette.View();
 
-      sinon.spy(this.view, '_removeElement');
+      sinon.spy(this.view, 'removeEl');
       sinon.spy(this.view, 'destroy');
 
       this.onDestroyStub = sinon.stub();
@@ -64,7 +64,7 @@ describe('view mixin', function() {
     });
 
     it('should remove the view', function() {
-      expect(this.view._removeElement).to.have.been.calledOnce;
+      expect(this.view.removeEl).to.have.been.calledOnce;
     });
 
     it('should set the view _isDestroyed to true', function() {
@@ -105,7 +105,7 @@ describe('view mixin', function() {
     beforeEach(function() {
       this.view = new Marionette.View();
 
-      this.removeSpy = sinon.spy(this.view, '_removeElement');
+      this.removeSpy = sinon.spy(this.view, 'removeEl');
 
       this.destroyStub = sinon.stub();
       this.view.on('destroy', this.destroyStub);
@@ -136,7 +136,7 @@ describe('view mixin', function() {
 
       this.view = new Marionette.View();
 
-      this.removeSpy = sinon.spy(this.view, '_removeElement');
+      this.removeSpy = sinon.spy(this.view, 'removeEl');
 
       this.destroyStub = sinon.stub();
       this.view.on('destroy', this.destroyStub);
@@ -236,7 +236,7 @@ describe('view mixin', function() {
     beforeEach(function() {
       this.view = new Marionette.View();
 
-      this.removeSpy = sinon.spy(this.view, '_removeElement');
+      this.removeSpy = sinon.spy(this.view, 'removeEl');
       this.destroyStub = sinon.stub();
       this.view.on('destroy', this.destroyStub);
 

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -283,7 +283,7 @@ describe('item view', function() {
       this.view = new this.View();
       this.view.render();
 
-      this.removeSpy = this.sinon.spy(this.view, '_removeElement');
+      this.removeSpy = this.sinon.spy(this.view, 'removeEl');
       this.stopListeningSpy = this.sinon.spy(this.view, 'stopListening');
       this.triggerSpy = this.sinon.spy(this.view, 'trigger');
 


### PR DESCRIPTION
# Separate Mn DOM interaction into a mixin for DOM plugin ease.

closes #3145 

**mixins/dom.js**
- containsEl
- findEls
- createBuffer
- appendChildren
- replaceEl
- detachContents
- setInnerContent
- beforeEl
- removeEl

**composite-view.js**
- findEls

**region.js**
- findEls

**template-cache.js**
- findEls

**src/collection-view**
- appendChildren
- beforeEl
- createBuffer
- test update

**src/composite-view**
- appendChildren

**src/view.js**
- setInnerContent

**src/mixins/view**
- removeEl

**src/region**
- replaceEl
- detachContents
- appendChildren
