### PR TITLE
Clarify Underscore templates are used by default

### DIFF
--- a/docs/marionette.renderer.md
+++ b/docs/marionette.renderer.md
@@ -14,8 +14,8 @@ without data.
 ## Basic Usage
 
 The basic usage of the `Renderer` is to call the `render` method. This method
-returns a string containing the result of applying the template using the `data`
-object as the context.
+returns a string containing the result of applying the Underscore template 
+using the `data` object as the context.
 
 ```javascript
 var Mn = require('backbone.marionette');

--- a/docs/template.md
+++ b/docs/template.md
@@ -42,8 +42,9 @@ a `<h1>` tag.
 
 ### jQuery Selector
 
-If your index page contains a pre-formatted template, you can simply pass in the
-jQuery selector for it to `template` and Marionette will look it up:
+If your index page contains a template element formatted for Underscore, you can
+simply pass in the jQuery selector for it to `template` and Marionette will look
+it up:
 
 ```javascript
 var Mn = require('backbone.marionette');
@@ -61,8 +62,8 @@ export.MyView = Mn.View.extend({
 
 [Live example](https://jsfiddle.net/marionettejs/z4sd7ssh/)
 
-Marionette will look up the template above and render it for you when `MyView`
-gets rendered.
+Marionette compiles the template above using `_.template` and renders it for
+you when `MyView` gets rendered.
 
 ### Template Function
 


### PR DESCRIPTION
The redundant "will look up" was replaced with specifics about what render actually does with Underscore.