### PR TITLE
ensure onBeforeRender and onRender are fired when showing views with …

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -78,10 +78,6 @@ const Region = MarionetteObject.extend({
   },
 
   _renderView(view) {
-    if (view._isRendered) {
-      return;
-    }
-
     if (!view.supportsRenderLifecycle) {
       triggerMethodOn(view, 'before:render', view);
     }

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -1159,4 +1159,33 @@ describe('region', function() {
       });
     });
   });
+
+  describe('when showing a view with `template: false`', function() {
+    beforeEach(function() {
+      this.MyRegion = Marionette.Region.extend({
+        el: '#region'
+      });
+
+      this.MyView = Marionette.View.extend({
+        template: false,
+        el: '#existing',
+        onBeforeRender: this.sinon.stub(),
+        onRender: this.sinon.stub()
+      });
+
+      this.setFixtures('<div id="region"><div id="existing">Preexisting HTML</div></div>');
+      this.region = new this.MyRegion();
+      this.view = new this.MyView();
+      this.region.show(this.view);
+    });
+
+    it('should fire onBeforeRender on the view', function() {
+      expect(this.view.onBeforeRender).to.have.been.calledOnce;
+    });
+
+    it('should fire onRender on the view', function() {
+      expect(this.view.onRender).to.have.been.calledOnce;
+    });
+  });
+
 });


### PR DESCRIPTION
### Proposed changes
 - Remove `view._isRendered` check in Region::_renderView (originally added in this commit: https://github.com/marionettejs/backbone.marionette/commit/e92273ec29ccbb8b4d6a07220b8ff2548b56b385)

From the issue: 

> Consider the following situation. There is a region attached to an existing DOM tree so that the region's "el" has some child nodes. Then a view is attached to the region, with "el" property set to an immediate child of the region's element and "template" property set to false. According to the docs (View => Managing an Existing Page) it should fire "render" and "before:render" events if shown in the region, even though no actual rendering happens. This is not so.

Link to the issue: https://github.com/marionettejs/backbone.marionette/issues/3162
