### PR TITLE
Deprecate Region definition selector

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -108,6 +108,23 @@ removed from the DOM and replaced with an element of `.new-class` - this lets
 us do things like rendering views inside `table` or `select` more easily -
 these elements are usually very strict on what content they will allow.
 
+**_DEPRECATED: The `selector` option of a region is deprecated in favor of using `el`_**
+
+```js
+var MyView = Mn.View.extend({
+  regions: {
+    deprecatedRegionDefinition: {
+      selector: '.foo',
+      replaceElement: true
+    },
+    regionDefinition: {
+      selector: '.bar',
+      replaceElement: true
+    }
+  }
+});
+```
+
 ### Specifying regions as a Function
 
 The `regions` attribute on a view can be a

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -1,4 +1,5 @@
 import _                    from 'underscore';
+import deprecate       from '../utils/deprecate';
 import _invoke              from '../utils/invoke';
 import Region               from '../region';
 import MarionetteError      from '../error';
@@ -92,6 +93,10 @@ export default {
     const RegionClass = definition.regionClass || this.regionClass;
 
     const options = _.omit(definition, 'regionClass');
+
+    if (definition.selector) {
+      deprecate('The selector option on a Region definition object is deprecated. Use el to pass a selector string');
+    }
 
     _.defaults(options, {
       el: definition.selector,

--- a/test/unit/region.build-region.spec.js
+++ b/test/unit/region.build-region.spec.js
@@ -77,6 +77,27 @@ describe('Region', function() {
         it('uses the selector', function() {
           expect(this.region.el).to.equal(this.fooSelector);
         });
+
+        describe('when DEV_MODE is true', function() {
+          beforeEach(function() {
+            Marionette.DEV_MODE = true;
+            this.sinon.spy(Marionette.deprecate, '_warn');
+            this.sinon.stub(Marionette.deprecate, '_console', {
+              warn: this.sinon.stub()
+            });
+            Marionette.deprecate._cache = {};
+
+            this.region = this.view._buildRegion(this.definition);
+          });
+
+          it('should call Marionette.deprecate', function() {
+            expect(Marionette.deprecate._warn).to.be.calledWith('Deprecation warning: The selector option on a Region definition object is deprecated. Use el to pass a selector string');
+          });
+
+          afterEach(function() {
+            Marionette.DEV_MODE = false;
+          });
+        });
       });
 
       describe('with `el` defined', function() {


### PR DESCRIPTION
Gets ready for https://github.com/marionettejs/backbone.marionette/issues/2289