### PR TITLE
Upgrade doc: `getChildView` was removed in M3

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -44,6 +44,15 @@ See [`CollectionView`](./marionette.collectionview.md#rendering-collectionviews)
 for detail on upgrading to Marionette 3. This technique works in both Marionette
 2.x and Marionette 3.
 
+### Removing `CollectionView.getChildView()`
+
+The `getChildView` method has been removed in favor of the `childView` property,
+which now accepts a function.
+
+#### Upgrading to Marionette 3
+
+Simply replace all instances of `getChildView` with `childView`.
+
 ### Child event handlers
 
 The `childEvents` attribute was renamed to `childViewEvents`.


### PR DESCRIPTION
I'm working on migrating an M2 codebase to M3 and noticed that the `getChildView` method was dropped and I needed to change it to `childView`.

This PR adds a note to the upgrade.md doc.