### PR TITLE
When a preexisting node is given to the view it needs to bind the ui

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -96,6 +96,10 @@ const View = Backbone.View.extend({
       this._isAttached = isNodeAttached(this.el);
     }
 
+    if (this._isRendered) {
+      this.bindUIElements();
+    }
+
     return this;
   },
 

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -13,9 +13,12 @@ describe('item view', function() {
 
   describe('when instantiating a view with a DOM element', function() {
     beforeEach(function() {
-      this.setFixtures('<div id="foo">bar</div>');
+      this.setFixtures('<div id="foo"><span class="element">bar</span></div>');
       this.view = new Marionette.View({
-        el: '#foo'
+        el: '#foo',
+        ui: {
+          element: '.element'
+        }
       });
     });
 
@@ -28,7 +31,11 @@ describe('item view', function() {
     });
 
     it('should contain the DOM content', function() {
-      expect(this.view.el.innerHTML).to.contain('bar');
+      expect(this.view.el.innerHTML).to.contain('<span class="element">bar</span>');
+    });
+
+    it('should bind ui elements', function() {
+      expect(this.view.ui.element.text()).to.contain('bar');
     });
   });
 


### PR DESCRIPTION
One more change for `v3.1`.  While working on the docs I noticed one more inconsistency.

It is correctly setting `isRendered` and `isAttached` but not the `ui` hash.

This only affects `View`.  `CollectionView`'s `setElement` is different.