### PR TITLE
Updated the region docs

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -174,6 +174,9 @@ Both forms take an `options` object that will be passed to the
 For more information on `showChildView` and `getChildView`, see the
 [Documentation for Views](./marionette.view.md#managing-sub-views)
 
+If you show a view in a region with an existing view, Marionette will
+[remove the existing View](#hiding-a-view) before showing the new one.
+
 ### Hiding a View
 
 You can remove a view from a region (effectively "unshowing" it) with
@@ -189,6 +192,7 @@ mainRegion.empty();
 
 This will destroy the view, cleaning up any event handlers and remove it from
 the DOM.
+[Howevever, any HTML that doesn't belong to the View will remain](./upgrade.md#changes-to-regionshow).
 
 ### Preserving Existing Views
 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -261,18 +261,22 @@ This can be useful in unit testing your views.
 Override the region's `attachHtml` method to change how the view is attached
 to the DOM. This method receives one parameter - the view to show.
 
-The default implementation of `attachHtml` is:
+The default implementation of `attachHtml` works a bit like the following:
 
 ```javascript
 var Mn = require('backbone.marionette');
 
 Mn.Region.prototype.attachHtml = function(view){
-  this.$el.empty().append(view.el);
+  if (this.isShowingAView()) {
+    this.removeRenderedView();
+  }
+  this.$el.append(view.el);
 }
 ```
 
-This replaces the contents of the region with the view's
-`el` / content. You can override `attachHtml` for transition effects and more.
+If there's a view being displayed, this code replaces it and renders then
+attaches the new view's HTML. You can override `attachHtml` for transition
+effects and more.
 
 ```javascript
 var Mn = require('backbone.marionette');

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -267,16 +267,12 @@ The default implementation of `attachHtml` works a bit like the following:
 var Mn = require('backbone.marionette');
 
 Mn.Region.prototype.attachHtml = function(view){
-  if (this.isShowingAView()) {
-    this.removeRenderedView();
-  }
-  this.$el.append(view.el);
+  this.el.appendChild(view.el);
 }
 ```
 
-If there's a view being displayed, this code replaces it and renders then
-attaches the new view's HTML. You can override `attachHtml` for transition
-effects and more.
+The existing `attachHtml` takes an extra `shouldReplace` argument, however if
+you are overriding `attachHtml`, you won't be able to use this argument.
 
 ```javascript
 var Mn = require('backbone.marionette');

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -192,7 +192,7 @@ mainRegion.empty();
 
 This will destroy the view, cleaning up any event handlers and remove it from
 the DOM.
-[Howevever, any HTML that doesn't belong to the View will remain](./upgrade.md#changes-to-regionshow).
+[However, any HTML that doesn't belong to the View will remain](./upgrade.md#changes-to-regionshow).
 
 ### Preserving Existing Views
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -102,6 +102,14 @@ Replace all instances of `show` and `before:show` with `render` and
 `before:render`. If you want the view to be visible in the DOM, then listen to
 the `dom:refresh` event.
 
+### Changes to `region.show()`
+
+The `region.show()` method (and by extension `showChildView()`) made a change to
+how it displays views. Any HTML inside the region that *isn't* in a View will
+not be removed from the region and the View's HTML will be appended after this
+HTML. In Marionette 2, the `region.show()` method would call `$el.empty()`
+before adding the new HTML.
+
 ## Templates
 
 The biggest change to templates is renaming `templateHelpers` to


### PR DESCRIPTION
### Proposed changes
 - Document region el not emptied in docs
 - Document upgrade guide difference between 2 & 3
 - Link back to upgrade guide

Link to the issue: #3210

I'm not sure whether to put information in for emulating the behaviour or if we should be discouraging this. I'm leaning towards the latter, as most of the time, we don't want developers setting up their own lifecycle outside of views/regions.