### PR TITLE
Document removed getEmptyView

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -53,6 +53,15 @@ which now accepts a function.
 
 Simply replace all instances of `getChildView` with `childView`.
 
+### Removing `CollectionView.getEmptyView()`
+
+The `getEmptyView` method has been removed in favor of the `emptyView` property,
+which now accepts a function.
+
+#### Upgrading to Marionette 3
+
+Simply replace all instances of `getEmptyView` with `emptyView`.
+
 ### Child event handlers
 
 The `childEvents` attribute was renamed to `childViewEvents`.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -47,7 +47,7 @@ for detail on upgrading to Marionette 3. This technique works in both Marionette
 ### Removing `CollectionView.getChildView()`
 
 The `getChildView` method has been removed in favor of the `childView` property,
-which now accepts a function.
+[which now accepts a function](basics.md#functions-returning-values).
 
 #### Upgrading to Marionette 3
 
@@ -56,7 +56,7 @@ Simply replace all instances of `getChildView` with `childView`.
 ### Removing `CollectionView.getEmptyView()`
 
 The `getEmptyView` method has been removed in favor of the `emptyView` property,
-which now accepts a function.
+[which now accepts a function](basics.md#functions-returning-values).
 
 #### Upgrading to Marionette 3
 


### PR DESCRIPTION
### Proposed changes
 - Document `getEmptyView` changed to `emptyView`

Link to the issue: #3193