### PR TITLE
Add childViewEventPrefix false to disable magic auto-proxy

### DIFF
--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -223,10 +223,6 @@ const ViewMixin = {
   },
 
   _childViewEventHandler(eventName, ...args) {
-    const prefix = _.result(this, 'childViewEventPrefix');
-
-    const childEventName = prefix + ':' + eventName;
-
     const childViewEvents = this.normalizeMethods(this._childViewEvents);
 
     // call collectionView childViewEvent if defined
@@ -242,7 +238,13 @@ const ViewMixin = {
       this.triggerMethod(childViewTriggers[eventName], ...args);
     }
 
-    this.triggerMethod(childEventName, ...args);
+    const prefix = _.result(this, 'childViewEventPrefix');
+
+    if (prefix !== false) {
+      const childEventName = prefix + ':' + eventName;
+
+      this.triggerMethod(childEventName, ...args);
+    }
   }
 };
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -1066,6 +1066,35 @@ describe('collection view', function() {
     });
   });
 
+  describe('when setting childViewEventPrefix false', function() {
+    beforeEach(function() {
+      this.CollectionView = this.CollectionView.extend({
+        childViewEventPrefix: false
+      });
+
+      this.someEventSpy = this.sinon.stub();
+
+      this.model = new Backbone.Model({foo: 'bar'});
+      this.collection = new Backbone.Collection([this.model]);
+
+      this.collectionView = new this.CollectionView({collection: this.collection});
+      this.collectionView.on('childview:some:event', this.someEventSpy);
+      this.collectionView.render();
+
+      this.sinon.spy(this.collectionView, 'trigger');
+      this.childView = this.collectionView.children.findByIndex(0);
+      this.childView.trigger('some:event', 'test', this.model);
+    });
+
+    it('should not bubble up through the parent collection view', function() {
+      expect(this.collectionView.trigger).to.not.have.been.called;
+    });
+
+    it('should not trigger a childview event', function() {
+      expect(this.someEventSpy).to.not.have.been.called;
+    });
+  });
+
   describe('when a child view triggers the default', function() {
     beforeEach(function() {
       this.model = new Backbone.Model({foo: 'bar'});

--- a/test/unit/utils/view.spec.js
+++ b/test/unit/utils/view.spec.js
@@ -403,5 +403,17 @@ describe('view mixin', function() {
           .and.CalledOnce;
       });
     });
+
+    describe('when childViewEventPrefix is false', function() {
+      beforeEach(function() {
+        this.layoutView.showChildView('child', this.childView);
+        this.layoutView.childViewEventPrefix = false;
+        this.childView.triggerMethod('boom', 'foo', 'bar');
+      });
+
+      it('should not emit the event on the layout', function() {
+        expect(this.layoutEventHandler).not.to.have.been.called;
+      });
+    });
   });
 });


### PR DESCRIPTION
https://github.com/marionettejs/backbone.marionette/issues/3201

@marionettejs/marionette-core I think this is a small change with a big win, and I'd like to squeeze it into v3.1 if possible.  This still needs docs, but the doc changes need to be pulled back from master before they can be added. (The relevant section to modify doesn't exist atm)  But that'd make this one among almost all 3.1 features that'll need documentation.  I'm also willing to take that on.

Auto proxying is actually biting me right now because I have a very complicated view structure in one case and I am exceeding the call stack due to https://github.com/marionettejs/backbone.marionette/issues/2667

