### PR TITLE
Overridding attachhtml should not break replaceElement

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -103,7 +103,11 @@ const Region = MarionetteObject.extend({
       triggerMethodOn(view, 'before:attach', view);
     }
 
-    this.attachHtml(view, shouldReplaceEl);
+    if (shouldReplaceEl) {
+      this._replaceEl(view);
+    } else {
+      this.attachHtml(view);
+    }
 
     if (shouldTriggerAttach) {
       view._isAttached = true;
@@ -193,13 +197,8 @@ const Region = MarionetteObject.extend({
 
   // Override this method to change how the new view is appended to the `$el` that the
   // region is managing
-  attachHtml(view, shouldReplace) {
-    if (shouldReplace) {
-      // replace the region's node with the view's node
-      this._replaceEl(view);
-    } else {
-      this.el.appendChild(view.el);
-    }
+  attachHtml(view) {
+    this.el.appendChild(view.el);
   },
 
   // Destroy the current view, if there is one. If there is no current view, it does

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -472,20 +472,6 @@ describe('region', function() {
           expect(this.$parentEl).to.contain.$html(this.view2.$el.html());
         });
       });
-
-      describe('and calling attachHtml a second time', function() {
-        beforeEach(function() {
-          this.region.attachHtml(this.view, true);
-        });
-
-        it('should append the view HTML to the parent "el"', function() {
-          expect(this.$parentEl).to.contain.$html(this.view.$el.html());
-        });
-
-        it('should remove the region\'s "el" from the DOM', function() {
-          expect(this.$parentEl).to.not.contain.$html(this.regionHtml);
-        });
-      });
     });
 
     describe('and the view is detached', function() {


### PR DESCRIPTION
Related to https://github.com/marionettejs/backbone.marionette/pull/3211

I think `attachHtml` containing the `shouldRemove` logic is a bad idea.  People may very well want to override `attachHtml` with a more performant attach (like skipping jquery) that has caveats for other browsers or whatever..  But doing so breaks the `replaceElement` functionality.  Now the user could reimplement replace, but that would require them to call a private function.  This is no good.  

Now it could be argued that the user needs to be able to handle how the view gets replaced.  Valid argument, but almost impossible to do inside of `attachHtml`. https://github.com/marionettejs/backbone.marionette/pull/3165 will fix that use case.

Before we document the argument and logic, let's remove it.

Also I remove a test block, one of which breaks for this change.. but I cannot figure out the point of the test at all. It seems to be testing for something no one should do ever.