### PR TITLE
Remove unnecessary variable

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -144,7 +144,7 @@ const View = Backbone.View.extend({
     const data = this.mixinTemplateContext(this.serializeData());
 
     // Render and add to el
-    const html = Renderer.render(template, data, this);
+    const html = Renderer.render(template, data);
     this.attachElContent(html);
   },
 

--- a/test/unit/composite-view.spec.js
+++ b/test/unit/composite-view.spec.js
@@ -162,8 +162,8 @@ describe('composite view', function() {
       expect(this.compositeView.$el).to.contain.$text('baz');
     });
 
-    it('should pass template fn, data, and view instance to Marionette.Renderer.Render', function() {
-      expect(Marionette.Renderer.render).to.have.been.calledWith(this.templateFn, {foo: 'bar'}, this.compositeView);
+    it('should pass template fn and data to Marionette.Renderer.Render', function() {
+      expect(Marionette.Renderer.render).to.have.been.calledWith(this.templateFn, {foo: 'bar'});
     });
   });
 

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -136,8 +136,8 @@ describe('item view', function() {
       expect(this.attachElContentStub).to.have.been.calledOnce.and.calledWith(this.template);
     });
 
-    it('should pass template stub, data and view instance to `Marionette.Renderer.Render`', function() {
-      expect(Marionette.Renderer.render).to.have.been.calledWith(this.templateStub, {}, this.itemView);
+    it('should pass template stub and data to `Marionette.Renderer.Render`', function() {
+      expect(Marionette.Renderer.render).to.have.been.calledWith(this.templateStub, {});
     });
   });
 


### PR DESCRIPTION
### Proposed changes
 - This removes unnecessary variable.

The `this` in the  following code is not used in [Renderer.(template, data)](https://github.com/marionettejs/backbone.marionette/blob/5f5e74b7936a35f3f0aebad20079434241360d06/src/config/renderer.js#L16-L27).

```
    const html = Renderer.render(template, data, this);
```
 

