### PR TITLE
View childViewEvents should support trigger

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -199,7 +199,6 @@ const CollectionView = Backbone.View.extend({
       destroyBackboneView(view);
     }
 
-    delete view._parent;
     this.stopListening(view);
     this.triggerMethod('remove:child', this, view);
   },
@@ -388,12 +387,10 @@ const CollectionView = Backbone.View.extend({
   },
 
   _setupChildView(view, index) {
-    view._parent = this;
-
     monitorViewEvents(view);
 
     // set up the child view event forwarding
-    this._proxyChildEvents(view);
+    this._proxyChildViewEvents(view);
 
     if (this.sort) {
       view._index = index;
@@ -758,11 +755,6 @@ const CollectionView = Backbone.View.extend({
   _shouldAddChild(child, index) {
     const filter = this.filter;
     return !_.isFunction(filter) || filter.call(this, child, index, this.collection);
-  },
-
-  // Set up the child view event forwarding. Uses a "childview:" prefix in front of all forwarded events.
-  _proxyChildEvents(view) {
-    this.listenTo(view, 'all', this._childViewEventHandler);
   }
 });
 

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -68,7 +68,7 @@ export default {
   _addRegion(region, name) {
     this.triggerMethod('before:add:region', this, name, region);
 
-    region._parent = this;
+    region._parentView = this;
 
     this._regions[name] = region;
 

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -9,7 +9,6 @@ import CommonMixin from './common';
 import DelegateEntityEventsMixin from './delegate-entity-events';
 import TriggersMixin from './triggers';
 import UIMixin from './ui';
-import View from '../view';
 import MarionetteError from '../error';
 import DomMixin from './dom';
 
@@ -189,7 +188,6 @@ const ViewMixin = {
     const ret = triggerMethod.apply(this, arguments);
 
     this._triggerEventOnBehaviors.apply(this, arguments);
-    this._triggerEventOnParentLayout.apply(this, arguments);
 
     return ret;
   },
@@ -198,28 +196,6 @@ const ViewMixin = {
   _buildEventProxies() {
     this._childViewEvents = _.result(this, 'childViewEvents');
     this._childViewTriggers = _.result(this, 'childViewTriggers');
-  },
-
-  _triggerEventOnParentLayout() {
-    const layoutView = this._parentView();
-    if (!layoutView) {
-      return;
-    }
-
-    layoutView._childViewEventHandler.apply(layoutView, arguments);
-  },
-
-  // Walk the _parent tree until we find a view (if one exists).
-  // Returns the parent view hierarchically closest to this view.
-  _parentView() {
-    let parent = this._parent;
-
-    while (parent) {
-      if (parent instanceof View) {
-        return parent;
-      }
-      parent = parent._parent;
-    }
   },
 
   _childViewEventHandler(eventName, ...args) {

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -198,6 +198,10 @@ const ViewMixin = {
     this._childViewTriggers = _.result(this, 'childViewTriggers');
   },
 
+  _proxyChildViewEvents(view) {
+    this.listenTo(view, 'all', this._childViewEventHandler);
+  },
+
   _childViewEventHandler(eventName, ...args) {
     const childViewEvents = this.normalizeMethods(this._childViewEvents);
 

--- a/src/region.js
+++ b/src/region.js
@@ -71,12 +71,24 @@ const Region = MarionetteObject.extend({
     // the child may trigger during render can also be triggered on the child's ancestor views.
     view._parent = this;
 
+    this._proxyChildViewEvents(view);
+
     this._renderView(view);
 
     this._attachView(view, options);
 
     this.triggerMethod('show', this, view, options);
     return this;
+  },
+
+  _proxyChildViewEvents(view) {
+    const parentView = this._parent;
+
+    if (!parentView) {
+      return;
+    }
+
+    parentView.listenTo(view, 'all', parentView._childViewEventHandler);
   },
 
   _renderView(view) {
@@ -230,6 +242,9 @@ const Region = MarionetteObject.extend({
     if (!view._isDestroyed) {
       this._removeView(view, shouldDestroy);
       delete view._parent;
+      if (this._parent) {
+        this._parent.stopListening(view);
+      }
     }
 
     this.triggerMethod('empty', this, view);

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -186,12 +186,6 @@ describe('collection view', function() {
       expect(_.size(this.collectionView.children)).to.equal(2);
     });
 
-    it('children should reference collectionView', function() {
-      var children = this.collectionView._getImmediateChildren();
-      expect(children[0]._parent).to.deep.equal(this.collectionView);
-      expect(children[1]._parent).to.deep.equal(this.collectionView);
-    });
-
     it('should call "onBeforeRender" before rendering', function() {
       expect(this.collectionView.onBeforeRender).to.have.been.called;
     });
@@ -500,12 +494,6 @@ describe('collection view', function() {
 
     it('should trigger the childview:render event from the collectionView', function() {
       expect(this.childViewRender).to.have.been.called;
-    });
-
-    it('children should reference collectionView', function() {
-      var children = this.collectionView._getImmediateChildren();
-      expect(children[0]._parent).to.deep.equal(this.collectionView);
-      expect(children[1]._parent).to.deep.equal(this.collectionView);
     });
   });
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -166,15 +166,6 @@ describe('region', function() {
       expect(this.region.hasView()).to.equal(true);
     });
 
-    it('should reference region', function() {
-      expect(this.view._parent).to.deep.equal(this.region);
-    });
-
-    it('should reference region, when same view was passed', function() {
-      this.region.show(this.view);
-      expect(this.view._parent).to.deep.equal(this.region);
-    });
-
     it('should set $el and el', function() {
       expect(this.region.$el[0]).to.equal(this.region.el);
     });
@@ -228,14 +219,6 @@ describe('region', function() {
 
       it('should still have a view', function() {
         expect(this.region.hasView()).to.equal(true);
-      });
-
-      it('should reference region', function() {
-        expect(this.view2._parent).to.deep.equal(this.region);
-      });
-
-      it('old view should not reference region', function() {
-        expect(this.view._parent).to.be.undefined;
       });
     });
 

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -287,11 +287,13 @@ describe('layoutView', function() {
   describe('when showing a childView as a View', function() {
     beforeEach(function() {
       this.layoutView = new this.View();
-      this.childEventsHandler = this.sinon.spy();
+      this.childEventsHandlerTrigger = this.sinon.spy();
+      this.childEventsHandlerTriggerMethod = this.sinon.spy();
 
       // add child events to listen for
       this.layoutView.childViewEvents = {
-        'content:rendered': this.childEventsHandler
+        'before:content:rendered': this.childEventsHandlerTrigger,
+        'content:rendered': this.childEventsHandlerTriggerMethod
       };
       this.layoutView.delegateEvents();
       this.layoutView.render();
@@ -299,6 +301,9 @@ describe('layoutView', function() {
       // create a child view which triggers an event on render
       var ChildView = Marionette.View.extend({
         template: false,
+        onBeforeRender: function() {
+          this.trigger('before:content:rendered');
+        },
         onRender: function() {
           this.triggerMethod('content:rendered');
         }
@@ -313,7 +318,11 @@ describe('layoutView', function() {
     });
 
     it('childViewEvents are triggered', function() {
-      expect(this.childEventsHandler).to.have.been.calledOnce;
+      expect(this.childEventsHandlerTrigger).to.have.been.calledOnce;
+    });
+
+    it('childViewEvents are triggered', function() {
+      expect(this.childEventsHandlerTriggerMethod).to.have.been.calledOnce;
     });
 
     describe('and the view is detached', function() {


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2667 and https://github.com/marionettejs/backbone.marionette/issues/2464

This makes child events consistently work between both views for both `triggerMethod` and `trigger`  Currently some bubbling exists between view types.  This will add additional bubbling.  Previous to having `childViewEventPrefix: false` I would have been against the bubbling, but it can be managed easily now.

However we _may_ want to wait until `childViewEventPrefix: false` is the default?

@rafde any other perf concerns?  I like the consistency, but realize this might be doing more now.. however since it's regions on a view it is _probably_ not an issue.  If you think it is an issue perhaps we should consider breaking CollectionView such that it too only works with `triggerMethod` ?

I'm bringing this up now as we _could_ introduce this https://github.com/marionettejs/backbone.marionette/pull/3244