### PR TITLE
Consistent homepage field in bower.json & package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "backbone.marionette",
   "description": "The Backbone Framework",
-  "homepage": "http://marionettejs.org",
+  "homepage": "https://marionettejs.com/",
   "main": "./lib/backbone.marionette.js",
   "version": "3.1.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "backbone.marionette",
   "description": "The Backbone Framework",
   "version": "3.1.0",
-  "homepage": "https://github.com/marionettejs/backbone.marionette",
+  "homepage": "https://marionettejs.com/",
   "main": "lib/backbone.marionette.js",
   "keywords": [
     "backbone",


### PR DESCRIPTION
### Proposed changes
 - ```homepage``` field in ```package.json``` & ```bower.json``` updated to ```https://marionettejs.com```
 
Link to the issue: [#3239 - Update homepage for package.json and bower.json](https://github.com/marionettejs/backbone.marionette/issues/3239)
