### PR TITLE
Remove ViewDestroyError from Views

### DIFF
--- a/src/behavior.js
+++ b/src/behavior.js
@@ -82,7 +82,6 @@ const Behavior = MarionetteObject.extend({
   },
 
   getUI(name) {
-    this.view._ensureViewIsIntact();
     return this._getUI(name);
   },
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -221,7 +221,7 @@ const CollectionView = Backbone.View.extend({
   // Render children views. Override this method to provide your own implementation of a
   // render function for the collection view.
   render() {
-    this._ensureViewIsIntact();
+    if (this._isDestroyed) { return this; }
     this.triggerMethod('before:render', this);
     this._renderChildren();
     this._isRendered = true;

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -85,7 +85,7 @@ const CompositeView = CollectionView.extend({
 
   // Renders the model and the collection.
   render() {
-    this._ensureViewIsIntact();
+    if (this._isDestroyed) { return this; }
     this._isRendering = true;
     this.resetChildViewContainer();
 

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -7,10 +7,10 @@ import { triggerMethod } from '../common/trigger-method';
 import BehaviorsMixin from './behaviors';
 import CommonMixin from './common';
 import DelegateEntityEventsMixin from './delegate-entity-events';
+import DomMixin from './dom';
 import TriggersMixin from './triggers';
 import UIMixin from './ui';
 import MarionetteError from '../error';
-import DomMixin from './dom';
 
 // MixinOptions
 // - behaviors
@@ -113,16 +113,6 @@ const ViewMixin = {
     return this;
   },
 
-  // Internal helper method to verify whether the view hasn't been destroyed
-  _ensureViewIsIntact() {
-    if (this._isDestroyed) {
-      throw new MarionetteError({
-        name: 'ViewDestroyedError',
-        message: `View (cid: "${this.cid}") has already been destroyed and cannot be used.`
-      });
-    }
-  },
-
   // Handle destroying the view and its children.
   destroy(...args) {
     if (this._isDestroyed) { return this; }
@@ -174,7 +164,6 @@ const ViewMixin = {
   },
 
   getUI(name) {
-    this._ensureViewIsIntact();
     return this._getUI(name);
   },
 

--- a/src/view.js
+++ b/src/view.js
@@ -111,7 +111,7 @@ const View = Backbone.View.extend({
   // Subsequent renders after the first will re-render all nested
   // views.
   render() {
-    this._ensureViewIsIntact();
+    if (this._isDestroyed) { return this; }
 
     this.triggerMethod('before:render', this);
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -852,11 +852,6 @@ describe('collection view', function() {
       expect(this.destroyHandler).to.have.been.called;
     });
 
-    it('should throw an error saying the views been destroyed if render is attempted again', function() {
-      expect(this.collectionView.render).to.throw('View (cid: "' + this.collectionView.cid +
-          '") has already been destroyed and cannot be used.');
-    });
-
     it('should return the collection view', function() {
       expect(this.collectionView.destroy).to.have.returned(this.collectionView);
     });

--- a/test/unit/destroying-views.spec.js
+++ b/test/unit/destroying-views.spec.js
@@ -43,18 +43,6 @@ describe('destroying views', function() {
     });
   });
 
-  describe('when rendering a Marionette.View that was previously destroyed', function() {
-    beforeEach(function() {
-      this.itemView = new Marionette.View();
-      this.itemView.destroy();
-    });
-
-    it('should throw an error', function() {
-      expect(this.itemView.render).to.throw('View (cid: "' + this.itemView.cid +
-          '") has already been destroyed and cannot be used.');
-    });
-  });
-
   describe('when destroying a Marionette.CollectionView multiple times', function() {
     beforeEach(function() {
       this.onDestroyStub = this.sinon.stub();
@@ -75,18 +63,6 @@ describe('destroying views', function() {
     });
   });
 
-  describe('when rendering a Marionette.CollectionView that was previously destroyed', function() {
-    beforeEach(function() {
-      this.collectionView = new Marionette.CollectionView();
-      this.collectionView.destroy();
-    });
-
-    it('should throw an error', function() {
-      expect(this.collectionView.render).to.throw('View (cid: "' + this.collectionView.cid +
-          '") has already been destroyed and cannot be used.');
-    });
-  });
-
   describe('when destroying a Marionette.CompositeView multiple times', function() {
     beforeEach(function() {
       this.onDestroyStub = this.sinon.stub();
@@ -104,18 +80,6 @@ describe('destroying views', function() {
 
     it('should mark the view as destroyed', function() {
       expect(this.compositeView).to.have.property('_isDestroyed', true);
-    });
-  });
-
-  describe('when rendering a Marionette.CompositeView that was previously destroyed', function() {
-    beforeEach(function() {
-      this.compositeView = new Marionette.CompositeView();
-      this.compositeView.destroy();
-    });
-
-    it('should throw an error', function() {
-      expect(this.compositeView.render).to.throw('View (cid: "' + this.compositeView.cid +
-          '") has already been destroyed and cannot be used.');
     });
   });
 });

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -456,30 +456,6 @@ describe('layoutView', function() {
     });
   });
 
-  describe('when re-rendering a destroyed layoutView', function() {
-    beforeEach(function() {
-      this.layoutView = new this.View();
-      this.layoutView.render();
-      this.region = this.layoutView.getRegion('regionOne');
-
-      this.view = new Backbone.View();
-      this.view.destroy = function() {};
-      this.layoutView.getRegion('regionOne').show(this.view);
-      this.layoutView.destroy();
-
-      this.sinon.spy(this.region, 'empty');
-      this.sinon.spy(this.view, 'destroy');
-
-      this.layoutView.onBeforeRender = this.sinon.stub();
-      this.layoutView.onRender = this.sinon.stub();
-    });
-
-    it('should throw an error', function() {
-      expect(this.layoutView.render).to.throw('View (cid: "' + this.layoutView.cid +
-          '") has already been destroyed and cannot be used.');
-    });
-  });
-
   describe('has a valid inheritance chain back to Backbone.View', function() {
     beforeEach(function() {
       this.constructor = this.sinon.spy(Backbone.View.prototype, 'constructor');

--- a/test/unit/view.ui-bindings.spec.js
+++ b/test/unit/view.ui-bindings.spec.js
@@ -124,18 +124,6 @@ describe('view ui elements', function() {
     it('should unbind UI elements and reset them to the selector', function() {
       expect(this.view.ui).to.deep.equal(this.uiHash);
     });
-
-    it('should throw ViewDestroyedError when accessing ui bindings through getUI', function() {
-      expect(
-        _.bind(function() { return this.view.getUI('foo');}, this)
-      ).to.throw(
-        Marionette.Error,
-        new Marionette.Error({
-          name: 'ViewDestroyedError',
-          message: 'View (cid: "' + this.view.id + '") has already been destroyed and cannot be used.'
-        })
-      );
-    });
   });
 
   describe('when calling delegateEvents', function() {


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2719

I’ve brought up this issue before https://github.com/marionettejs/backbone.marionette/issues/1736 https://github.com/marionettejs/backbone.marionette/issues/1744

In v3 showing a view in a region (or via collectionView) is very important for setting up the view’s lifecycle.  Even if you’re using a `Backbone.View`, you’re not getting much value out of Marionette if you are not using regions.  Even though we are working to abstract them further, they are the glue that make things work.  The region `show` [already checks for this error](https://github.com/marionettejs/backbone.marionette/blob/v3.1.0/src/region.js#L54).  And so it is very unlikely that the view’s error will get called outside of rendering the view directly.

And rendering it directly after it has been destroyed mean that most likely it’s not in the DOM (as destroying the view will remove it from any region)

Making the view `render` no-op after the view is destroyed is consistent with the view `destroy` function.

Making it a no-op is harmless.  The biggest issue this _might_ introduce is the error you would get from `getUI` will be less descriptive. However I do not think this is a strong enough reason to keep this around, and the error you’d get should be easily traceable.