### PR TITLE
Cleanup Application and Behavior tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,3 +128,7 @@ to discuss further.
 * in the browser by running `npm run test-browser`
 
 To see the test matrix - run `npm run coverage`
+
+## Writing Tests and Code Style
+
+[More information]('test/unit/README.md')

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -44,12 +44,18 @@ function parseBehaviors(view, behaviors) {
 }
 
 export default {
+  _behaviors: {},
+
   _initBehaviors() {
+    this._behaviors = this._getBehaviors();
+  },
+
+  _getBehaviors() {
     const behaviors = _.result(this, 'behaviors');
 
     // Behaviors defined on a view can be a flat object literal
     // or it can be a function that returns an object.
-    this._behaviors = _.isObject(behaviors) ? parseBehaviors(this, behaviors) : {};
+    return _.isObject(behaviors) ? parseBehaviors(this, behaviors) : {};
   },
 
   _getBehaviorTriggers() {

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -44,8 +44,6 @@ function parseBehaviors(view, behaviors) {
 }
 
 export default {
-  _behaviors: {},
-
   _initBehaviors() {
     this._behaviors = this._getBehaviors();
   },

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -3,40 +3,105 @@
 
 ### Running unit tests
 
-1. via the command line
+1. Running just unit tests - `npm run test`
 
+2. Running coverage reporter - `npm run coverage`. 
+To check coverage, open `./coverage/lcov-report/index.html`.
+
+3. Running tests in browser - `test-browser`.
+
+
+### Common concepts for writing tests
+
+1. Test suites should cover only public API.
+
+2. Code style.
+
+- Each `describe` should have name of tested method. 
+
+> There are should be not more then 1 nested describe for on method.
+ 
+Wrong way.
+ 
+ ```javascript
+ 
+ describe('some events in myMethod', function() {
+   describe('some logic', function() {
+     it('do something', function() {
+      ...  
+     })
+     
+     describe('some other logic', function() {
+       etc...
+     })
+   })
+ })
 ```
-grunt test
+
+
+Wright way.
+
+
+```javascript
+ 
+  describe('#myMethod', function() {
+    describe('when some logic', function() {
+      it('should do something', function() {
+        ...  
+      })
+    })
+   
+    describe('when some other logic', function() {
+      it('should do something', function() {
+        ...  
+      })
+    })
+ })
 ```
 
-2. in the browser
-```
-open SpecRunner.html
-```
 
+- `before/beforeEach` should consist only some preparation logic 
+but not call methods you expect to test.
 
-### Adding a new test file
+Wrong way.
 
-New test files are added as a script tag to the SpecRunner.html
-
-```html
-<script src="test/unit/application.app-regions.spec.js"></script>
-<script src="test/unit/application.spec.js"></script>
-```
-
-
-### Adding a new source file
-
-When you want to add a new source file to be tested, the file needs to be added in two places
-
-1. SpecRunner.html
-
-```html
-<script src="src/item-view.js"></script>
+```javascript
+  describe('#myMethod', function() {
+    let myInstance;
+    
+    beforeEach(function() {
+      myInstance = new MyClass({
+        render: this.sinon.spy
+      });
+      myInstance.render();
+    })
+   
+    it('should do something', function() {
+      expect(myInstance.render).to.have.been.called;
+    })
+ })
 ```
 
-2. unit/setup/node.js file
+Wright way.
 
-```js
-requireHelper('composite-view');
+```javascript
+  describe('#myMethod', function() {
+    let myInstance;
+    let renderSpy;
+    
+    beforeEach(function() {
+      renderSpy = this.sinon.spy();
+      
+      myInstance = new MyClass({
+        render: renderSpy
+      });
+    })
+   
+    it('should do something', function() {
+      myInstance.render();
+      
+      expect(renderSpy).to.have.been.called;
+    })
+ })
 ```
+

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -8,100 +8,124 @@
 2. Running coverage reporter - `npm run coverage`. 
 To check coverage, open `./coverage/lcov-report/index.html`.
 
-3. Running tests in browser - `test-browser`.
+3. Running tests in browser - `npm run test-browser`.
 
 
 ### Common concepts for writing tests
 
-1. Test suites should cover only public API.
+1. Test suites should cover public API.
+
+> In most cases it will be public API testing,
+but sometimes we should test something like: When models added to collection,
+hence, in this case we are adding needed suites.
 
 2. Code style.
 
-- Each `describe` should have name of tested method. 
+- Each `describe` should have name of tested method.
 
-> There are should be not more then 1 nested describe for on method.
+> If it's possible, there should be not more then one nested describe for one method.
  
-Wrong way.
+_Wrong way_
  
- ```javascript
- 
- describe('some events in myMethod', function() {
-   describe('some logic', function() {
-     it('do something', function() {
-      ...  
-     })
-     
-     describe('some other logic', function() {
-       etc...
-     })
-   })
- })
+```javascript
+  describe('#MyClass', function() {
+    describe('some events in myMethod', function() {
+      describe('some logic', function() {
+        it('do something', function() {
+          ...  
+        });
+         
+        describe('some other logic', function() {
+          // other nested describes
+        });
+      });
+    });
+  });
 ```
 
 
-Wright way.
-
+**Correct way**
 
 ```javascript
- 
-  describe('#myMethod', function() {
-    describe('when some logic', function() {
-      it('should do something', function() {
-        ...  
-      })
-    })
+  describe('#MyClass', function() {
+    describe('#myMethod', function() {
+      describe('when some logic', function() {
+        it('should do something', function() {
+          ...  
+        });
+      });
    
-    describe('when some other logic', function() {
-      it('should do something', function() {
-        ...  
-      })
-    })
- })
+      describe('when some other logic', function() {
+        it('should do something', function() {
+          ...  
+        });
+      });
+    });
+  });
 ```
 
+- In case of testing some behavior
+
+> behavior means not Marionette Behavior class
+
+**Correct way**
+
+```javascript
+  describe('#MyClass', function() {
+    describe('when some data was changed', function() {
+      it('should do something', function() {
+        ...
+      });
+    });
+  });
+```
 
 - `before/beforeEach` should consist only some preparation logic 
-but not call methods you expect to test.
+but inside it should not present calling methods you expect to test.
 
-Wrong way.
-
-```javascript
-  describe('#myMethod', function() {
-    let myInstance;
-    
-    beforeEach(function() {
-      myInstance = new MyClass({
-        render: this.sinon.spy
-      });
-      myInstance.render();
-    })
-   
-    it('should do something', function() {
-      expect(myInstance.render).to.have.been.called;
-    })
- })
-```
-
-Wright way.
+_Wrong way_
 
 ```javascript
-  describe('#myMethod', function() {
-    let myInstance;
-    let renderSpy;
+  describe('#MyClass', function() {
+    describe('#myMethod', function() {
+      let myInstance;
     
-    beforeEach(function() {
-      renderSpy = this.sinon.spy();
-      
-      myInstance = new MyClass({
-        render: renderSpy
+      beforeEach(function() {
+        myInstance = new MyClass({
+          render: this.sinon.spy
+        });
+        myInstance.render();
       });
-    })
-   
-    it('should do something', function() {
-      myInstance.render();
-      
-      expect(renderSpy).to.have.been.called;
-    })
- })
+
+      it('should do something', function() {
+        expect(myInstance.render).to.have.been.calledOnce;
+      });
+    });
+  });
 ```
 
+
+**Correct way**
+
+```javascript
+  describe('#MyClass', function() {
+    describe('#myMethod', function() {
+      let myInstance;
+      let renderSpy;
+    
+      beforeEach(function() {
+        renderSpy = this.sinon.spy();
+      
+        myInstance = new MyClass({
+          render: renderSpy
+        });
+      });
+   
+      it('should do something', function() {
+        myInstance.render();
+      
+        expect(renderSpy).to.have.been.calledOnce;
+      });
+    });
+  });
+```

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -1,73 +1,103 @@
-describe('marionette application', function() {
-  'use strict';
+'use strict';
+
+import Application from '../../src/application';
+import View from '../../src/view';
+
+describe('Marionette Application', function() {
 
   describe('when instantiating an app with options specified', function() {
+    let app;
+    let fooOption;
+    let appOptions;
+    let initializeStub;
+
     beforeEach(function() {
-      this.fooOption = 'bar';
-      this.appOptions = {fooOption: this.fooOption};
-      this.initializeStub = this.sinon.stub(Marionette.Application.prototype, 'initialize');
-      this.app = new Marionette.Application(this.appOptions, 'fooArg');
+      fooOption = 'bar';
+      appOptions = {fooOption: fooOption};
+      initializeStub = this.sinon.stub(Application.prototype, 'initialize');
+
+      app = new Application(appOptions, 'fooArg');
     });
 
     it('should pass all arguments to the initialize method', function() {
-      expect(this.initializeStub).to.have.been.calledOn(this.app).and.calledWith(this.appOptions, 'fooArg');
+      expect(initializeStub).to.have.been.calledOn(app).and.calledWith(appOptions, 'fooArg');
     });
   });
 
   describe('when specifying an on start callback, and starting the app', function() {
+    let app;
+    let fooOptions;
+    let beforeStartStub;
+    let startStub;
+
     beforeEach(function() {
-      this.fooOptions = {foo: 'bar'};
-      this.app = new Marionette.Application();
+      beforeStartStub = this.sinon.stub();
+      startStub = this.sinon.stub();
+      fooOptions = {foo: 'bar'};
+      app = new Application();
 
-      this.startStub = this.sinon.stub();
-      this.app.on('start', this.startStub);
+      app.on('before:start', beforeStartStub);
+      app.on('start', startStub);
 
-      this.app.start(this.fooOptions);
+      app.start(fooOptions);
+    });
+
+    it('should run the onBeforeStart callback', function() {
+      expect(beforeStartStub).to.have.been.called;
+    });
+
+    it('should pass the startup option to the onBeforeStart callback', function() {
+      expect(beforeStartStub).to.have.been.calledOnce.and.calledWith(app, fooOptions);
     });
 
     it('should run the onStart callback', function() {
-      expect(this.startStub).to.have.been.called;
+      expect(startStub).to.have.been.called;
     });
 
     it('should pass the startup option to the callback', function() {
-      expect(this.startStub).to.have.been.calledOnce.and.calledWith(this.app, this.fooOptions);
+      expect(startStub).to.have.been.calledOnce.and.calledWith(app, fooOptions);
     });
 
     it('should have a cidPrefix', function() {
-      expect(this.app.cidPrefix).to.equal('mna');
+      expect(app.cidPrefix).to.equal('mna');
     });
 
     it('should have a cid', function() {
-      expect(this.app.cid).to.exist;
+      expect(app.cid).to.exist;
     });
   });
 
   describe('when initializing with regions', function() {
+    let app;
+    let view;
+    let fooOptions;
+
     beforeEach(function() {
-      this.fooOptions = {
+      fooOptions = {
         region: '#fixtures'
       };
-      this.view = new Marionette.View({
+      view = new View({
         template: _.template('ohai')
       });
 
-      this.app = new Marionette.Application(this.fooOptions);
-      this.app.showView(this.view);
+      app = new Application(fooOptions);
+      app.showView(view);
     });
+
     it('should be able to define region selectors as strings', function() {
-      expect(this.app._region.$el).to.have.length(1);
+      expect(app.getRegion().$el).to.have.length(1);
     });
 
     it('should get the region selector with getRegion', function() {
-      expect(this.app.getRegion().$el).to.have.length(1);
+      expect(app.getRegion().$el).to.have.length(1);
     });
 
     it('can show a view in its region', function() {
-      expect(this.app._region.el.innerHTML).to.contain('ohai');
+      expect(app.getRegion().el.innerHTML).to.contain('ohai');
     });
 
     it('can use the getView function', function() {
-      expect(this.app.getView()).to.deep.equal(this.view);
+      expect(app.getView()).to.equal(view);
     });
 
   });

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -5,16 +5,14 @@ import View from '../../src/view';
 
 describe('Marionette Application', function() {
 
-  describe('#_initialize', () => {
-    describe('when instantiating an app with options specified', function() {
+  describe('#initialize', () => {
+    describe('when instantiating an app with specified options', function() {
       let app;
-      let fooOption;
       let appOptions;
       let initializeStub;
 
       beforeEach(function() {
-        fooOption = 'bar';
-        appOptions = {fooOption: fooOption};
+        appOptions = {fooOption: 'foo'};
         initializeStub = this.sinon.stub(Application.prototype, 'initialize');
       });
 
@@ -23,104 +21,106 @@ describe('Marionette Application', function() {
 
         expect(initializeStub).to.have.been.calledOn(app).and.calledWith(appOptions, 'fooArg');
       });
+
+      it('should have a cidPrefix', function() {
+        app = new Application(appOptions);
+
+        expect(app.cidPrefix).to.equal('mna');
+      });
+
+      it('should have a cid', function() {
+        app = new Application(appOptions);
+
+        expect(app.cid).to.exist;
+      });
     });
   });
 
-  describe('#_start', function() {
+  describe('#start', function() {
     let app;
     let fooOptions;
-    let triggerMethodSpy;
 
     beforeEach(function() {
       fooOptions = {foo: 'bar'};
       app = new Application();
-      triggerMethodSpy = this.sinon.stub(app, 'triggerMethod');
-    });
-
-    it('should trigger before:start event', function() {
-      app.start(fooOptions);
-
-      expect(triggerMethodSpy).to.have.been.calledWith('before:start', app, fooOptions);
-    });
-
-    it('should trigger start event', function() {
-      app.start(fooOptions);
-
-      expect(triggerMethodSpy).to.have.been.calledWith('start', app, fooOptions);
     });
 
     it('should return current application context', function() {
       const result = app.start(fooOptions);
 
-      expect(result).to.have.been.deep.equal(app);
+      expect(result).to.have.been.equal(app);
     });
   });
 
-  describe('#_onBeforeStart', function() {
-    let app;
+  describe('#onBeforeStart', function() {
+    let fooApp;
     let fooOptions;
     let beforeStartStub;
+    let onBeforeStartStub;
 
     beforeEach(function() {
-      beforeStartStub = this.sinon.stub();
       fooOptions = {foo: 'bar'};
-      app = new Application();
+      beforeStartStub = this.sinon.stub();
+      onBeforeStartStub = this.sinon.stub();
 
-      app.on('before:start', beforeStartStub);
+      const FooApp = Application.extend({
+        onBeforeStart: onBeforeStartStub
+      });
+
+      fooApp = new FooApp();
+      fooApp.on('before:start', beforeStartStub);
     });
 
     it('should run the onBeforeStart callback', function() {
-      app.start(fooOptions);
+      fooApp.start(fooOptions);
 
       expect(beforeStartStub).to.have.been.called;
+      expect(onBeforeStartStub).to.have.been.called;
     });
 
     it('should pass the startup option to the onBeforeStart callback', function() {
-      app.start(fooOptions);
+      fooApp.start(fooOptions);
 
-      expect(beforeStartStub).to.have.been.calledOnce.and.calledWith(app, fooOptions);
+      expect(beforeStartStub).to.have.been.calledOnce.and.calledWith(fooApp, fooOptions);
+      expect(onBeforeStartStub).to.have.been.calledOnce.and.calledWith(fooApp, fooOptions);
     });
   });
 
-  describe('#_onStart', function() {
-    let app;
+  describe('#onStart', function() {
+    let fooApp;
     let fooOptions;
     let startStub;
+    let onStartStub;
 
     beforeEach(function() {
-      startStub = this.sinon.stub();
       fooOptions = {foo: 'bar'};
-      app = new Application();
+      startStub = this.sinon.stub();
+      onStartStub = this.sinon.stub();
 
-      app.on('start', startStub);
+      const FooApp = Application.extend({
+        onStart: onStartStub
+      });
+
+      fooApp = new FooApp();
+      fooApp.on('start', startStub);
     });
 
     it('should run the onStart callback', function() {
-      app.start(fooOptions);
+      fooApp.start(fooOptions);
 
       expect(startStub).to.have.been.called;
+      expect(onStartStub).to.have.been.called;
     });
 
     it('should pass the startup option to the callback', function() {
-      app.start(fooOptions);
+      fooApp.start(fooOptions);
 
-      expect(startStub).to.have.been.calledOnce.and.calledWith(app, fooOptions);
-    });
-
-    it('should have a cidPrefix', function() {
-      app.start(fooOptions);
-
-      expect(app.cidPrefix).to.equal('mna');
-    });
-
-    it('should have a cid', function() {
-      app.start(fooOptions);
-
-      expect(app.cid).to.exist;
+      expect(startStub).to.have.been.calledOnce.and.calledWith(fooApp, fooOptions);
+      expect(onStartStub).to.have.been.calledOnce.and.calledWith(fooApp, fooOptions);
     });
   });
 
-  describe('#_getRegion', function() {
+  describe('#getRegion', function() {
     let app;
     let fooOptions;
 
@@ -131,18 +131,15 @@ describe('Marionette Application', function() {
       app = new Application(fooOptions);
     });
 
-    it('should be able to define region selectors as strings', function() {
-      expect(app.getRegion().$el).to.have.length(1);
-    });
-
     it('should get the region selector with getRegion', function() {
       expect(app.getRegion().$el).to.have.length(1);
     });
   });
 
-  describe('#_showView', function() {
+  describe('#showView', function() {
     let app;
     let view;
+    let appRegion;
     let fooOptions;
     let showViewInRegionSpy;
 
@@ -155,7 +152,7 @@ describe('Marionette Application', function() {
       });
       app = new Application(fooOptions);
 
-      const appRegion = app.getRegion();
+      appRegion = app.getRegion();
 
       showViewInRegionSpy = this.sinon.spy(appRegion, 'show');
     });
@@ -164,19 +161,19 @@ describe('Marionette Application', function() {
       let fooArgs;
 
       beforeEach(function() {
-        fooArgs = ['foo', 'bar'];
+        fooArgs = {foo: 'bar'};
       });
 
       it('should call show method in region with additional arguments', function() {
         app.showView(view, fooArgs);
 
-        expect(showViewInRegionSpy).to.have.been.called;
+        expect(showViewInRegionSpy).to.have.been.calledWith(view, fooArgs);
       });
 
       it('should show a view in its region', function() {
         app.showView(view, fooArgs);
 
-        expect(app.getRegion().el.innerHTML).to.contain('ohai');
+        expect(appRegion.el.innerHTML).to.contain('ohai');
       });
     });
 
@@ -184,7 +181,7 @@ describe('Marionette Application', function() {
       it('should show a view in its region', function() {
         app.showView(view);
 
-        expect(app.getRegion().el.innerHTML).to.contain('ohai');
+        expect(appRegion.el.innerHTML).to.contain('ohai');
       });
 
       it('should call show method in region', function() {
@@ -195,7 +192,7 @@ describe('Marionette Application', function() {
     });
   });
 
-  describe('#_getView', function() {
+  describe('#getView', function() {
     let app;
     let view;
     let fooOptions;
@@ -213,7 +210,7 @@ describe('Marionette Application', function() {
     it('should return View which was shown', function() {
       app.showView(view);
 
-      expect(app.getView()).to.have.been.deep.equal(view);
+      expect(app.getView()).to.have.deep.equal(view);
     });
   });
 });

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -5,69 +5,197 @@ import View from '../../src/view';
 
 describe('Marionette Application', function() {
 
-  describe('when instantiating an app with options specified', function() {
-    let app;
-    let fooOption;
-    let appOptions;
-    let initializeStub;
+  describe('#_initialize', () => {
+    describe('when instantiating an app with options specified', function() {
+      let app;
+      let fooOption;
+      let appOptions;
+      let initializeStub;
 
-    beforeEach(function() {
-      fooOption = 'bar';
-      appOptions = {fooOption: fooOption};
-      initializeStub = this.sinon.stub(Application.prototype, 'initialize');
+      beforeEach(function() {
+        fooOption = 'bar';
+        appOptions = {fooOption: fooOption};
+        initializeStub = this.sinon.stub(Application.prototype, 'initialize');
+      });
 
-      app = new Application(appOptions, 'fooArg');
-    });
+      it('should pass all arguments to the initialize method', function() {
+        app = new Application(appOptions, 'fooArg');
 
-    it('should pass all arguments to the initialize method', function() {
-      expect(initializeStub).to.have.been.calledOn(app).and.calledWith(appOptions, 'fooArg');
+        expect(initializeStub).to.have.been.calledOn(app).and.calledWith(appOptions, 'fooArg');
+      });
     });
   });
 
-  describe('when specifying an on start callback, and starting the app', function() {
+  describe('#_start', function() {
+    let app;
+    let fooOptions;
+    let triggerMethodSpy;
+
+    beforeEach(function() {
+      fooOptions = {foo: 'bar'};
+      app = new Application();
+      triggerMethodSpy = this.sinon.stub(app, 'triggerMethod');
+    });
+
+    it('should trigger before:start event', function() {
+      app.start(fooOptions);
+
+      expect(triggerMethodSpy).to.have.been.calledWith('before:start', app, fooOptions);
+    });
+
+    it('should trigger start event', function() {
+      app.start(fooOptions);
+
+      expect(triggerMethodSpy).to.have.been.calledWith('start', app, fooOptions);
+    });
+
+    it('should return current application context', function() {
+      const result = app.start(fooOptions);
+
+      expect(result).to.have.been.deep.equal(app);
+    });
+  });
+
+  describe('#_onBeforeStart', function() {
     let app;
     let fooOptions;
     let beforeStartStub;
-    let startStub;
 
     beforeEach(function() {
       beforeStartStub = this.sinon.stub();
-      startStub = this.sinon.stub();
       fooOptions = {foo: 'bar'};
       app = new Application();
 
       app.on('before:start', beforeStartStub);
-      app.on('start', startStub);
-
-      app.start(fooOptions);
     });
 
     it('should run the onBeforeStart callback', function() {
+      app.start(fooOptions);
+
       expect(beforeStartStub).to.have.been.called;
     });
 
     it('should pass the startup option to the onBeforeStart callback', function() {
+      app.start(fooOptions);
+
       expect(beforeStartStub).to.have.been.calledOnce.and.calledWith(app, fooOptions);
+    });
+  });
+
+  describe('#_onStart', function() {
+    let app;
+    let fooOptions;
+    let startStub;
+
+    beforeEach(function() {
+      startStub = this.sinon.stub();
+      fooOptions = {foo: 'bar'};
+      app = new Application();
+
+      app.on('start', startStub);
     });
 
     it('should run the onStart callback', function() {
+      app.start(fooOptions);
+
       expect(startStub).to.have.been.called;
     });
 
     it('should pass the startup option to the callback', function() {
+      app.start(fooOptions);
+
       expect(startStub).to.have.been.calledOnce.and.calledWith(app, fooOptions);
     });
 
     it('should have a cidPrefix', function() {
+      app.start(fooOptions);
+
       expect(app.cidPrefix).to.equal('mna');
     });
 
     it('should have a cid', function() {
+      app.start(fooOptions);
+
       expect(app.cid).to.exist;
     });
   });
 
-  describe('when initializing with regions', function() {
+  describe('#_getRegion', function() {
+    let app;
+    let fooOptions;
+
+    beforeEach(function() {
+      fooOptions = {
+        region: '#fixtures'
+      };
+      app = new Application(fooOptions);
+    });
+
+    it('should be able to define region selectors as strings', function() {
+      expect(app.getRegion().$el).to.have.length(1);
+    });
+
+    it('should get the region selector with getRegion', function() {
+      expect(app.getRegion().$el).to.have.length(1);
+    });
+  });
+
+  describe('#_showView', function() {
+    let app;
+    let view;
+    let fooOptions;
+    let showViewInRegionSpy;
+
+    beforeEach(function() {
+      fooOptions = {
+        region: '#fixtures'
+      };
+      view = new View({
+        template: _.template('ohai')
+      });
+      app = new Application(fooOptions);
+
+      const appRegion = app.getRegion();
+
+      showViewInRegionSpy = this.sinon.spy(appRegion, 'show');
+    });
+
+    describe('when additional arguments was passed', function() {
+      let fooArgs;
+
+      beforeEach(function() {
+        fooArgs = ['foo', 'bar'];
+      });
+
+      it('should call show method in region with additional arguments', function() {
+        app.showView(view, fooArgs);
+
+        expect(showViewInRegionSpy).to.have.been.called;
+      });
+
+      it('should show a view in its region', function() {
+        app.showView(view, fooArgs);
+
+        expect(app.getRegion().el.innerHTML).to.contain('ohai');
+      });
+    });
+
+    describe('when just view as argument was passed', function() {
+      it('should show a view in its region', function() {
+        app.showView(view);
+
+        expect(app.getRegion().el.innerHTML).to.contain('ohai');
+      });
+
+      it('should call show method in region', function() {
+        app.showView(view);
+
+        expect(showViewInRegionSpy).to.have.been.called;
+      });
+    });
+  });
+
+  describe('#_getView', function() {
     let app;
     let view;
     let fooOptions;
@@ -79,26 +207,13 @@ describe('Marionette Application', function() {
       view = new View({
         template: _.template('ohai')
       });
-
       app = new Application(fooOptions);
+    });
+
+    it('should return View which was shown', function() {
       app.showView(view);
-    });
 
-    it('should be able to define region selectors as strings', function() {
-      expect(app.getRegion().$el).to.have.length(1);
+      expect(app.getView()).to.have.been.deep.equal(view);
     });
-
-    it('should get the region selector with getRegion', function() {
-      expect(app.getRegion().$el).to.have.length(1);
-    });
-
-    it('can show a view in its region', function() {
-      expect(app.getRegion().el.innerHTML).to.contain('ohai');
-    });
-
-    it('can use the getView function', function() {
-      expect(app.getView()).to.equal(view);
-    });
-
   });
 });

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -49,13 +49,11 @@ describe('Behaviors', function() {
   describe('behavior parsing', function() {
     let behaviors;
     let FooView;
-    let fooView;
-    let Bar;
-    let Baz;
 
     beforeEach(function() {
-      Bar = Behavior.extend({});
-      Baz = Behavior.extend({});
+      const Bar = Behavior.extend({});
+      const Baz = Behavior.extend({});
+
       behaviors = {
         foo: this.sinon.spy(Marionette, 'Behavior'),
         bar: this.sinon.spy(Bar),
@@ -72,11 +70,11 @@ describe('Behaviors', function() {
         FooView = View.extend({
           behaviors: {foo: {}}
         });
-
-        fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
+        const fooView = new FooView();
+
         expect(behaviors.foo).to.have.been.calledOnce;
       });
     });
@@ -86,11 +84,11 @@ describe('Behaviors', function() {
         FooView = View.extend({
           behaviors: {foo: {}}
         });
-
-        fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
+        const fooView = new FooView();
+
         expect(behaviors.foo).to.have.been.calledOnce;
       });
     });
@@ -102,18 +100,21 @@ describe('Behaviors', function() {
         behaviorsStub = this.sinon.stub().returns({
           foo: {behaviorClass: behaviors.foo}
         });
+
         FooView = View.extend({
           behaviors: behaviorsStub
         });
-
-        fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
+        const fooView = new FooView();
+
         expect(behaviors.foo).to.have.been.calledOnce;
       });
 
       it('should call the behaviors method with the view context', function() {
+        const fooView = new FooView();
+
         expect(behaviorsStub).to.have.been.calledOnce.and.calledOn(fooView);
       });
     });
@@ -123,11 +124,11 @@ describe('Behaviors', function() {
         FooView = View.extend({
           behaviors: {foo: {behaviorClass: behaviors.foo}}
         });
-
-        fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
+        const fooView = new FooView();
+
         expect(behaviors.foo).to.have.been.calledOnce;
       });
     });
@@ -139,32 +140,28 @@ describe('Behaviors', function() {
             behaviorClass: behaviors.baz
           }]
         });
-
-        fooView = new FooView();
       });
 
       it('should instantiate behaviors passed directly as a class', function() {
+        const fooView = new FooView();
+
         expect(behaviors.foo).to.have.been.calledOnce;
         expect(behaviors.bar).to.have.been.calledOnce;
       });
 
       it('should instantiate behaviors passed with behaviorClass', function() {
+        const fooView = new FooView();
+
         expect(behaviors.baz).to.have.been.calledOnce;
       });
-    });
-
-    afterEach(function() {
-      Marionette.Behavior.restore();
-      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior initialize', function() {
+    let behaviors;
     let behaviorOptions;
     let initializeStub;
-    let behaviors;
     let FooView;
-    let fooView;
 
     beforeEach(function() {
       behaviorOptions = {foo: 'bar'};
@@ -181,46 +178,46 @@ describe('Behaviors', function() {
       FooView = View.extend({
         behaviors: {foo: behaviorOptions}
       });
-      fooView = new FooView();
     });
 
     it('should have a cidPrefix', function() {
-      var fooBehavior = new behaviors.foo();
+      const fooView = new FooView();
+      const fooBehavior = new behaviors.foo();
+
       expect(fooBehavior.cidPrefix).to.equal('mnb');
     });
 
     it('should have a cid', function() {
-      var fooBehavior = new behaviors.foo();
+      const fooView = new FooView();
+      const fooBehavior = new behaviors.foo();
 
       expect(fooBehavior.cid).to.exist;
     });
 
     it('should call initialize when a behavior is created', function() {
+      const fooView = new FooView();
+
       expect(initializeStub).to.have.been.calledOnce;
     });
 
     it('should call initialize when a behavior is created', function() {
-      expect(initializeStub).to.have.been.calledOnce.and.calledWith(behaviorOptions, fooView);
-    });
+      const fooView = new FooView();
 
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
+      expect(initializeStub).to.have.been.calledOnce.and.calledWith(behaviorOptions, fooView);
     });
   });
 
   describe('behavior initialize from constructor args', function() {
-    let behaviorOptions;
     let fooStub;
     let barStub;
-    let behaviors;
     let FooView;
 
     beforeEach(function() {
-      behaviorOptions = {foo: 'bar'};
       fooStub = this.sinon.stub();
       barStub = this.sinon.stub();
 
-      behaviors = {
+      const behaviorOptions = {foo: 'bar'};
+      const behaviors = {
         foo: Behavior.extend({initialize: fooStub}),
         bar: Behavior.extend({initialize: barStub})
       };
@@ -232,18 +229,13 @@ describe('Behaviors', function() {
       FooView = Marionette.View.extend({
         behaviors: {foo: behaviorOptions}
       });
-
-      /* eslint-disable no-new */
-      new FooView({behaviors: {bar: {}}});
     });
 
     it('should call initialize when a behavior is created', function() {
+      const fooView = new FooView({behaviors: {bar: {}}});
+
       expect(barStub).to.have.been.calledOnce;
       expect(fooStub).not.to.have.been.called;
-    });
-
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
@@ -264,20 +256,32 @@ describe('Behaviors', function() {
 
       behaviors = {
         foo: Marionette.Behavior.extend({
-          events: {'click': fooClickStub}
+          events: {
+            'click': fooClickStub
+          }
         }),
         bar: Marionette.Behavior.extend({
-          events: {'click': barClickStub}
+          events: {
+            'click': barClickStub
+          }
         }),
         baz: Marionette.Behavior.extend({
-          events: {'click': 'handleClick'},
+          events: {
+            'click': 'handleClick'
+          },
           handleClick: bazClickStub
         })
       };
 
       FooView = Marionette.View.extend({
-        events: {'click': viewClickStub},
-        behaviors: {foo: {}, bar: {}, baz: {}}
+        events: {
+          'click': viewClickStub
+        },
+        behaviors: {
+          foo: {},
+          bar: {},
+          baz: {}
+        }
       });
 
       this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
@@ -285,27 +289,30 @@ describe('Behaviors', function() {
       });
 
       fooView = new FooView();
-      fooView.$el.click();
     });
 
     it('should call first behaviors event', function() {
+      fooView.$el.click();
+
       expect(fooClickStub).to.have.been.calledOnce.and.calledOn(this.sinon.match.instanceOf(behaviors.foo));
     });
 
     it('should call second behaviors event', function() {
+      fooView.$el.click();
+
       expect(barClickStub).to.have.been.calledOnce.and.calledOn(this.sinon.match.instanceOf(behaviors.bar));
     });
 
     it('should call third behaviors event', function() {
+      fooView.$el.click();
+
       expect(bazClickStub).to.have.been.calledOnce.and.calledOn(this.sinon.match.instanceOf(behaviors.baz));
     });
 
     it('should call the view click handler', function() {
-      expect(viewClickStub).to.have.been.calledOnce.and.calledOn(fooView);
-    });
+      fooView.$el.click();
 
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
+      expect(viewClickStub).to.have.been.calledOnce.and.calledOn(fooView);
     });
   });
 
@@ -313,9 +320,6 @@ describe('Behaviors', function() {
     let onClickFooStub;
     let triggerMethodSpy;
     let behaviors;
-    let fooModel;
-    let fooCollection;
-    let FooView;
     let fooView;
 
     beforeEach(function() {
@@ -328,16 +332,16 @@ describe('Behaviors', function() {
         })
       };
 
-      fooModel = new Backbone.Model();
-      fooCollection = new Backbone.Collection();
-
-      FooView = Marionette.View.extend({
+      const FooView = Marionette.View.extend({
         behaviors: {foo: {}}
       });
 
       this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
         return behaviors;
       });
+
+      const fooModel = new Backbone.Model();
+      const fooCollection = new Backbone.Collection();
 
       fooView = new FooView({
         model: fooModel,
@@ -347,37 +351,35 @@ describe('Behaviors', function() {
       triggerMethodSpy = this.sinon.spy();
 
       fooView.on('click:foo', triggerMethodSpy);
-
-      fooView.$el.click();
     });
 
-    it('calls `triggerMethod` with the triggered event', function() {
+    it('should call `triggerMethod` with the triggered event', function() {
+      fooView.$el.click();
+
       expect(triggerMethodSpy)
         .to.have.been.calledOnce
         .and.calledOn(fooView);
     });
 
-    it('calls the triggered method', function() {
+    it('should call the triggered method', function() {
+      fooView.$el.click();
+
       expect(onClickFooStub)
         .to.have.been.calledOnce
         .and.have.been.calledOn(this.sinon.match.instanceOf(behaviors.foo));
-    });
-
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior $el', function() {
     let fooBehavior;
-    let behaviors;
-    let FooView;
     let fooView;
 
     beforeEach(function() {
-      behaviors = {
+      const behaviors = {
         foo: Marionette.Behavior.extend({
-          initialize: function() {fooBehavior = this;}
+          initialize: function() {
+            fooBehavior = this;
+          }
         })
       };
 
@@ -385,24 +387,23 @@ describe('Behaviors', function() {
         return behaviors;
       });
 
-      FooView = Marionette.View.extend({
+      const FooView = Marionette.View.extend({
         behaviors: {foo: {}}
       });
 
       fooView = new FooView();
-      fooView.setElement(document.createElement('bar'));
     });
 
     it('should proxy the views $el', function() {
+      fooView.setElement(document.createElement('bar'));
+
       expect(fooBehavior.$el).to.equal(fooView.$el);
     });
 
     it('should proxy the views el', function() {
-      expect(fooBehavior.el).to.equal(fooView.el);
-    });
+      fooView.setElement(document.createElement('bar'));
 
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
+      expect(fooBehavior.el).to.equal(fooView.el);
     });
   });
 
@@ -456,12 +457,12 @@ describe('Behaviors', function() {
     });
 
     describe('should call onAttach when inside a CollectionView', function() {
+      let region;
       let fooCollection;
-      let FooCollectionView;
       let fooCollectionView;
 
       beforeEach(function() {
-        FooCollectionView = CollectionView.extend({
+        const FooCollectionView = CollectionView.extend({
           childView: FooView
         });
 
@@ -469,23 +470,27 @@ describe('Behaviors', function() {
         fooCollectionView = new FooCollectionView({collection: fooCollection});
 
         this.setFixtures('<div id="region"></div>');
-        var region = new Region({
+
+        region = new Region({
           el: '#region'
         });
-        region.show(fooCollectionView);
       });
 
       it('should call onAttach when inside a CollectionView', function() {
+        region.show(fooCollectionView);
+
         expect(onAttachStub).to.have.been.called;
       });
 
       it('should call onAttach when already shown and reset', function() {
+        region.show(fooCollectionView);
         fooCollection.reset([{id: 1}, {id: 2}]);
 
         expect(onAttachStub.callCount).to.equal(3);
       });
 
       it('should call onAttach when a single model is added and the collectionView is already shown', function() {
+        region.show(fooCollectionView);
         fooCollection.add({id: 3});
 
         expect(onAttachStub.callCount).to.equal(2);
@@ -493,11 +498,10 @@ describe('Behaviors', function() {
     });
 
     describe('view should be able to override predefined behavior ui', function() {
-      let BarView;
       let barView;
 
       beforeEach(function() {
-        BarView = View.extend({
+        const BarView = View.extend({
           template: _.template('<div class="zip"></div><div class="bar"></div>'),
           ui: {
             bar: '.bar',
@@ -510,16 +514,17 @@ describe('Behaviors', function() {
 
         barView = new BarView();
         barView.render();
-
-        barView.$el.find('.zip').click();
-        barView.$el.find('.bar').click();
       });
 
       it('should handle behavior ui click event', function() {
+        barView.$el.find('.zip').click();
+
         expect(onFooClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
       });
 
       it('should handle view ui click event', function() {
+        barView.$el.find('.bar').click();
+
         expect(onBarClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
       });
     });
@@ -527,44 +532,55 @@ describe('Behaviors', function() {
     describe('within a view', function() {
       let fooView;
 
-      beforeEach(function() {
-        fooView = new FooView();
-        fooView.render();
-      });
-
       it('should not clobber the event prototype', function() {
+        fooView = new FooView();
+
         expect(behaviors.foo.prototype.events).to.have.property('click @ui.bar', 'onBarClick');
       });
 
       it('should handle click events after calling delegateEvents', function() {
+        fooView = new FooView();
+        fooView.render();
         fooView.delegateEvents();
+
         expect(fooBehavior.ui.foo.click.bind(fooView.ui.bar)).to.not.throw(Error);
         expect(fooView.ui.bar.click.bind(fooView.ui.bar)).to.not.throw(Error);
       });
 
       it('should set the behavior UI element', function() {
+        fooView = new FooView();
+        fooView.render();
+
         expect(onRenderStub).to.have.been.calledOnce;
       });
 
       it('should make the view\'s ui hash available to callbacks', function() {
+        fooView = new FooView();
+
         expect(fooBehavior.testViewUI.bind(fooBehavior)).to.not.throw(Error);
       });
 
       it('should make the behavior\'s ui hash available to callbacks', function() {
+        fooView = new FooView();
+
         expect(fooBehavior.testBehaviorUI.bind(fooBehavior)).to.not.throw(Error);
       });
 
       describe('the $el', function() {
         beforeEach(function() {
-          fooView.$el.find('.foo').click();
-          fooView.$el.find('.bar').click();
+          fooView = new FooView();
+          fooView.render();
         });
 
         it('should handle behavior ui click event', function() {
+          fooView.$el.find('.foo').click();
+
           expect(onFooClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
         });
 
         it('should handle view ui click event', function() {
+          fooView.$el.find('.bar').click();
+
           expect(onBarClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
         });
 
@@ -575,63 +591,72 @@ describe('Behaviors', function() {
 
       describe('the el', function() {
         beforeEach(function() {
-          $(fooView.el).find('.foo').click();
-          $(fooView.el).find('.bar').click();
+          fooView = new FooView();
+          fooView.render();
         });
 
         it('should handle behavior ui click event', function() {
+          $(fooView.el).find('.foo').click();
+
           expect(onFooClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
         });
 
         it('should handle view ui click event', function() {
+          $(fooView.el).find('.bar').click();
+
           expect(onBarClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
         });
       });
     });
 
     describe('within a layout', function() {
+      let barView;
+
       beforeEach(function() {
         this.setFixtures('<div id="layout"></div>');
-        let BarView = View.extend({
+
+        const BarView = View.extend({
           el: '#layout',
           template: _.template('<div class="baz"></div>'),
           regions: {bazRegion: '.baz'}
         });
 
-        let barView = new BarView();
+        barView = new BarView();
         barView.render();
-        barView.getRegion('bazRegion').show(new FooView());
-        barView.destroy();
       });
 
       it('should call onBeforeAttach', function() {
+        barView.getRegion('bazRegion').show(new FooView());
+
         expect(onBeforeAttachStub).to.have.been.calledOnce;
       });
 
       it('should call onAttach', function() {
+        barView.getRegion('bazRegion').show(new FooView());
+
         expect(onAttachStub).to.have.been.calledOnce;
       });
 
       it('should call onDestroy', function() {
+        barView.getRegion('bazRegion').show(new FooView());
+        barView.destroy();
+
         expect(onDestroyStub).to.have.been.calledOnce;
       });
-    });
-
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('showing a view in a layout', function() {
     let onAttachStub;
     let onDestroyStub;
-    let behaviors;
+    let fooView;
+    let region;
 
     beforeEach(function() {
       onAttachStub = this.sinon.stub();
       onDestroyStub = this.sinon.stub();
 
-      behaviors = {
+      const behaviors = {
         foo: Behavior.extend({
           onAttach: onAttachStub,
           onDestroy: onDestroyStub
@@ -648,58 +673,65 @@ describe('Behaviors', function() {
       });
 
       this.setFixtures('<div id="region"></div>');
-      let region = new Region({el: '#region'});
-      let fooView = new FooView();
 
-      region.show(fooView);
-      region.empty();
+      region = new Region({el: '#region'});
+      fooView = new FooView();
     });
 
     it('behavior onAttach is called once', function() {
+      region.show(fooView);
+
       expect(onAttachStub).to.have.been.calledOnce;
     });
 
     it('behavior onClose is called once', function() {
-      expect(onDestroyStub).to.have.been.calledOnce;
-    });
+      region.show(fooView);
+      region.empty();
 
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
+      expect(onDestroyStub).to.have.been.calledOnce;
     });
   });
 
   describe('behavior instance events', function() {
     let listenToChangeStub;
     let onFooStub;
+    let fooModel;
+    let fooView;
 
     beforeEach(function() {
-      let model = new Backbone.Model();
+      fooModel = new Backbone.Model();
 
       listenToChangeStub = this.sinon.stub();
       onFooStub = this.sinon.stub();
 
-      let FooBehavior = Behavior.extend({
+      const FooBehavior = Behavior.extend({
         initialize: function() {
-          this.listenTo(model, 'change', listenToChangeStub);
+          this.listenTo(fooModel, 'change', listenToChangeStub);
           this.on('foo', onFooStub);
         }
       });
 
-      let FooView = View.extend({
-        behaviors: {foo: {behaviorClass: FooBehavior}}
+      const FooView = View.extend({
+        behaviors: {
+          foo: {
+            behaviorClass: FooBehavior
+          }
+        }
       });
 
-      let fooView = new FooView();
+      fooView = new FooView();
       fooView.destroy();
-      model.set('bar', 'baz');
-      fooView.triggerMethod('foo');
     });
 
     it('should unbind listenTo on destroy', function() {
+      fooModel.set('bar', 'baz');
+
       expect(listenToChangeStub).not.to.have.been.calledOnce;
     });
 
     it('should still be bound to "on" on destroy', function() {
+      fooView.triggerMethod('foo');
+
       expect(onFooStub).to.have.been.calledOnce;
     });
   });
@@ -708,12 +740,9 @@ describe('Behaviors', function() {
     let handleModelChangeStub;
     let handleCollectionResetStub;
     let handleModelFooChangeStub;
-    let behaviors;
     let fooBehavior;
     let FooView;
-    let fooView;
     let FooCollectionView;
-    let fooCollectionView;
     let fooModel;
     let fooCollection;
 
@@ -722,9 +751,11 @@ describe('Behaviors', function() {
       handleCollectionResetStub = this.sinon.stub();
       handleModelFooChangeStub = this.sinon.stub();
 
-      behaviors = {
+      const behaviors = {
         foo: Marionette.Behavior.extend({
-          initialize: function() {fooBehavior = this;},
+          initialize: function() {
+            fooBehavior = this;
+          },
           modelEvents: {
             'change': handleModelChangeStub,
             'change:foo': 'handleModelFooChange'
@@ -752,50 +783,51 @@ describe('Behaviors', function() {
     });
 
     it('should proxy model events', function() {
-      fooView = new FooView({model: fooModel});
+      const fooView = new FooView({model: fooModel});
       fooModel.set('foo', 'baz');
+
       expect(handleModelChangeStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
     });
 
     it('should proxy model events w/ string cbk', function() {
-      fooView = new FooView({model: fooModel});
+      const fooView = new FooView({model: fooModel});
       fooModel.set('foo', 'baz');
+
       expect(handleModelFooChangeStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
     });
 
     it('should proxy collection events', function() {
-      fooCollectionView = new FooCollectionView({collection: fooCollection});
+      const fooCollectionView = new FooCollectionView({collection: fooCollection});
       fooCollection.reset();
+
       expect(handleCollectionResetStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
     });
 
     it('should unbind model events on view undelegateEntityEvents', function() {
-      fooView = new FooView({model: fooModel});
+      const fooView = new FooView({model: fooModel});
       fooView.undelegateEntityEvents();
       fooModel.set('foo', 'doge');
+
       expect(handleModelFooChangeStub).not.to.have.been.called;
     });
 
     it('should unbind collection events on view undelegateEntityEvents', function() {
-      fooCollectionView = new FooCollectionView({collection: fooCollection});
+      const fooCollectionView = new FooCollectionView({collection: fooCollection});
       fooCollectionView.undelegateEntityEvents();
       fooCollection.reset();
-      expect(handleCollectionResetStub).not.to.have.been.called;
-    });
 
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
+      expect(handleCollectionResetStub).not.to.have.been.called;
     });
   });
 
   describe('behavior trigger calls', function() {
     let onRenderStub;
-    let behaviors;
+    let fooView;
 
     beforeEach(function() {
       onRenderStub = this.sinon.stub();
 
-      behaviors = {
+      const behaviors = {
         foo: Marionette.Behavior.extend({
           onRender: onRenderStub
         })
@@ -805,29 +837,25 @@ describe('Behaviors', function() {
         return behaviors;
       });
 
-      let FooView = View.extend({
+      const FooView = View.extend({
         behaviors: {foo: {}}
       });
 
-      let fooView = new FooView();
-      fooView.triggerMethod('render');
+      fooView = new FooView();
     });
 
     it('should call onRender when a view is rendered', function() {
-      expect(onRenderStub).to.have.been.calledOnce;
-    });
+      fooView.triggerMethod('render');
 
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
+      expect(onRenderStub).to.have.been.calledOnce;
     });
   });
 
   describe('behavior triggerMethod calls', function() {
-    let behaviors;
     let fooView;
 
     beforeEach(function() {
-      behaviors = {
+      const behaviors = {
         foo: Marionette.Behavior.extend({
           onFoo: function() {
             return 'behavior foo';
@@ -839,7 +867,7 @@ describe('Behaviors', function() {
         return behaviors;
       });
 
-      let FooView = View.extend({
+      const FooView = View.extend({
         behaviors: {foo: {}},
 
         onFoo: function() {
@@ -853,42 +881,43 @@ describe('Behaviors', function() {
     it('onFoo should return "foo"', function() {
       expect(fooView.triggerMethod('foo')).to.equal('view foo');
     });
-
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
-    });
   });
 
   describe('behavior is evented', function() {
     let listenToStub;
     let changeStub;
     let behavior;
+    let fooModel;
 
     beforeEach(function() {
       listenToStub = this.sinon.stub();
       changeStub = this.sinon.stub();
-      behavior = new Marionette.Behavior({}, {});
 
-      let fooModel = new Backbone.Model();
+      behavior = new Marionette.Behavior({}, {});
+      fooModel = new Backbone.Model();
 
       Marionette.bindEvents(behavior, fooModel, {
         'change': changeStub
       });
 
       behavior.listenTo(fooModel, 'foo', listenToStub);
-      fooModel.trigger('foo');
-      fooModel.set('foo', 'bar');
     });
 
     it('should listenTo events', function() {
+      fooModel.trigger('foo');
+
       expect(listenToStub).to.have.been.calledOnce;
     });
 
     it('should support bindEntityEvents', function() {
+      fooModel.set('foo', 'bar');
+
       expect(changeStub).to.have.been.calledOnce;
     });
 
     it('should execute in the specified context', function() {
+      fooModel.trigger('foo');
+
       expect(listenToStub).to.have.been.calledOnce.and.calledOn(behavior);
     });
   });
@@ -902,7 +931,6 @@ describe('Behaviors', function() {
     let barCollectionSyncStub;
     let viewOnRenderStub;
     let bazClickStub;
-    let behaviors;
     let fooBehavior;
     let barBehavior;
     let FooView;
@@ -920,11 +948,17 @@ describe('Behaviors', function() {
       barCollectionSyncStub = this.sinon.stub();
       bazClickStub = this.sinon.stub();
 
-      behaviors = {
+      const behaviors = {
         foo: Marionette.Behavior.extend({
-          initialize: function() { fooBehavior = this; },
-          behaviors: {bar: {}},
-          ui: {foo: '.foo'},
+          initialize: function() {
+            fooBehavior = this;
+          },
+          behaviors: {
+            bar: {}
+          },
+          ui: {
+            foo: '.foo'
+          },
           events: {
             'click @ui.foo': fooClickStub
           }
@@ -935,7 +969,9 @@ describe('Behaviors', function() {
             barBehavior = this;
           },
           onRender: barOnRenderStub,
-          ui: {bar: '.bar'},
+          ui: {
+            bar: '.bar'
+          },
           events: {
             'click @ui.bar': barClickStub
           },
@@ -980,70 +1016,73 @@ describe('Behaviors', function() {
 
     it('should call onRender on grouped behaviors', function() {
       fooView.triggerMethod('render');
+
       expect(barOnRenderStub).to.have.been.calledOnce.and.calledOn(barBehavior);
     });
 
     it('should call onRender on the view', function() {
       fooView.triggerMethod('render');
+
       expect(viewOnRenderStub).to.have.been.calledOnce.and.calledOn(fooView);
     });
 
     it('should call undelegateEvents once', function() {
       fooView.undelegateEvents();
+
       expect(fooView.undelegateEvents).to.have.been.calledOnce;
     });
 
     it('should call undelegateEntityEvents once', function() {
       fooView.undelegateEntityEvents();
+
       expect(fooView.undelegateEntityEvents).to.have.been.calledOnce;
     });
 
     it('should proxy modelEvents to grouped behaviors', function() {
       fooModel.trigger('change');
+
       expect(barModelChangeStub).to.have.been.calledOnce.and.calledOn(barBehavior);
     });
 
     it('should proxy collectionEvents to grouped behaviors', function() {
       fooCollection.trigger('sync');
+
       expect(barCollectionSyncStub).to.have.been.calledOnce.and.calledOn(barBehavior);
     });
 
     it('should proxy child behavior UI events to grouped behaviors', function() {
       fooView.render();
       barBehavior.ui.bar.click();
+
       expect(barClickStub).to.have.been.calledOnce.and.calledOn(barBehavior);
     });
 
     it('should proxy base behavior UI events to base behavior', function() {
       fooView.render();
       fooBehavior.ui.foo.click();
+
       expect(fooClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
     });
 
     it('should proxy view UI events to view', function() {
       fooView.render();
       fooView.ui.baz.click();
-      expect(bazClickStub).to.have.been.calledOnce.and.calledOn(fooView);
-    });
 
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
+      expect(bazClickStub).to.have.been.calledOnce.and.calledOn(fooView);
     });
   });
 
   describe('return values of wrapped methods', function() {
-    let behaviors;
-    let FooView;
     let fooView;
 
     beforeEach(function() {
-      behaviors = {foo: Behavior};
+      const behaviors = {foo: Behavior};
 
       this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
         return behaviors;
       });
 
-      FooView = View.extend({
+      const FooView = View.extend({
         behaviors: {foo: {}}
       });
 
@@ -1053,41 +1092,43 @@ describe('Behaviors', function() {
     it('destroy should return the view', function() {
       this.sinon.spy(fooView, 'destroy');
       fooView.destroy();
+
       expect(fooView.destroy).to.have.returned(fooView);
     });
 
     it('setElement should return the view', function() {
       this.sinon.spy(fooView, 'setElement');
       fooView.setElement(fooView.$el);
+
       expect(fooView.setElement).to.have.returned(fooView);
     });
 
     it('delegateEvents should return the view', function() {
       this.sinon.spy(fooView, 'delegateEvents');
       fooView.delegateEvents();
+
       expect(fooView.delegateEvents).to.have.returned(fooView);
     });
 
     it('undelegateEvents should return the view', function() {
       this.sinon.spy(fooView, 'undelegateEvents');
       fooView.undelegateEvents({});
+
       expect(fooView.undelegateEvents).to.have.returned(fooView);
     });
 
     it('delegateEntityEvents should return the view', function() {
       this.sinon.spy(fooView, 'delegateEntityEvents');
       fooView.delegateEntityEvents();
+
       expect(fooView.delegateEntityEvents).to.have.returned(fooView);
     });
 
     it('undelegateEntityEvents should return the view', function() {
       this.sinon.spy(fooView, 'undelegateEntityEvents');
       fooView.undelegateEntityEvents({});
-      expect(fooView.undelegateEntityEvents).to.have.returned(fooView);
-    });
 
-    afterEach(function() {
-      Marionette.Behaviors.behaviorsLookup.restore();
+      expect(fooView.undelegateEntityEvents).to.have.returned(fooView);
     });
   });
 
@@ -1097,10 +1138,11 @@ describe('Behaviors', function() {
     beforeEach(function() {
       behavior = new Behavior();
       this.sinon.spy(behavior, 'destroy');
-      behavior.destroy();
     });
 
     it('should return the behavior', function() {
+      behavior.destroy();
+
       expect(behavior.destroy).to.have.returned(behavior);
     });
   });

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -36,7 +36,8 @@ describe('Behaviors', function() {
           behaviors: [FooBehavior]
         });
 
-        let fooView = new FooView();
+        /* eslint-disable no-new */
+        new FooView();
       });
 
       it('should instantiate the behavior', function() {
@@ -231,7 +232,9 @@ describe('Behaviors', function() {
       FooView = Marionette.View.extend({
         behaviors: {foo: behaviorOptions}
       });
-      let fooView = new FooView({behaviors: {bar: {}}});
+
+      /* eslint-disable no-new */
+      new FooView({behaviors: {bar: {}}});
     });
 
     it('should call initialize when a behavior is created', function() {

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -56,7 +56,7 @@ describe('Behaviors', function() {
       Bar = Behavior.extend({});
       Baz = Behavior.extend({});
       behaviors = {
-        foo: this.sinon.spy('Behavior'),
+        foo: this.sinon.spy(Marionette, 'Behavior'),
         bar: this.sinon.spy(Bar),
         baz: this.sinon.spy(Baz)
       };
@@ -153,7 +153,7 @@ describe('Behaviors', function() {
     });
 
     afterEach(function() {
-      Behavior.restore();
+      Marionette.Behavior.restore();
       Marionette.Behaviors.behaviorsLookup.restore();
     });
   });

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -1,13 +1,21 @@
+'use strict';
+
+import Error from '../../src/error';
+import Behavior from '../../src/behavior';
+import Region from '../../src/region';
+import View from '../../src/view';
+import CollectionView from '../../src/collection-view';
+import behaviorsLookup from '../../src/config/behaviors-lookup';
+
 describe('Behaviors', function() {
-  'use strict';
 
   describe('behavior lookup', function() {
     it('should throw if behavior lookup is not defined', function() {
       expect(
-        function() { Marionette.Behaviors.behaviorsLookup(); }
+        function() { behaviorsLookup(); }
       ).to.throw(
-        Marionette.Error,
-        new Marionette.Error({
+        Error,
+        new Error({
           message: 'You must define where your behaviors are stored.',
           url: 'marionette.behaviors.md#behaviorslookup'
         })
@@ -16,329 +24,408 @@ describe('Behaviors', function() {
   });
 
   describe('behavior parsing with a functional behavior lookup', function() {
+    let FooBehavior;
+
     beforeEach(function() {
-      this.behaviors = {
-        foo: this.sinon.spy(Marionette, 'Behavior')
-      };
-      Marionette.Behaviors.behaviorsLookup = _.bind(function() {
-        return this.behaviors;
-      }, this);
+      FooBehavior = this.sinon.spy(Behavior);
     });
 
     describe('when one behavior', function() {
       beforeEach(function() {
-        this.View = Marionette.View.extend({
-          behaviors: {foo: {}}
+        let FooView = View.extend({
+          behaviors: [FooBehavior]
         });
 
-        this.view = new this.View();
+        let fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
-        expect(this.behaviors.foo).to.have.been.calledOnce;
+        expect(FooBehavior).to.have.been.calledOnce;
       });
     });
   });
 
   describe('behavior parsing', function() {
+    let behaviors;
+    let FooView;
+    let fooView;
+    let Bar;
+    let Baz;
+
     beforeEach(function() {
-      this.Bar = Marionette.Behavior.extend({});
-      this.Baz = Marionette.Behavior.extend({});
-      this.behaviors = {
-        foo: this.sinon.spy(Marionette, 'Behavior'),
-        bar: this.sinon.spy(this, 'Bar'),
-        baz: this.sinon.spy(this, 'Baz')
+      Bar = Behavior.extend({});
+      Baz = Behavior.extend({});
+      behaviors = {
+        foo: this.sinon.spy('Behavior'),
+        bar: this.sinon.spy(Bar),
+        baz: this.sinon.spy(Baz)
       };
 
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
     });
 
     describe('when one behavior', function() {
       beforeEach(function() {
-        this.View = Marionette.View.extend({
+        FooView = View.extend({
           behaviors: {foo: {}}
         });
 
-        this.view = new this.View();
+        fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
-        expect(this.behaviors.foo).to.have.been.calledOnce;
+        expect(behaviors.foo).to.have.been.calledOnce;
       });
     });
 
     describe('when multiple behaviors', function() {
       beforeEach(function() {
-        this.View = Marionette.View.extend({
+        FooView = View.extend({
           behaviors: {foo: {}}
         });
 
-        this.view = new this.View();
+        fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
-        expect(this.behaviors.foo).to.have.been.calledOnce;
+        expect(behaviors.foo).to.have.been.calledOnce;
       });
     });
 
     describe('when functional behavior', function() {
+      let behaviorsStub;
+
       beforeEach(function() {
-        this.behaviorsStub = this.sinon.stub().returns({
-          foo: {behaviorClass: this.behaviors.foo}
+        behaviorsStub = this.sinon.stub().returns({
+          foo: {behaviorClass: behaviors.foo}
         });
-        this.View = Marionette.View.extend({
-          behaviors: this.behaviorsStub
+        FooView = View.extend({
+          behaviors: behaviorsStub
         });
 
-        this.view = new this.View();
+        fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
-        expect(this.behaviors.foo).to.have.been.calledOnce;
+        expect(behaviors.foo).to.have.been.calledOnce;
       });
 
       it('should call the behaviors method with the view context', function() {
-        expect(this.behaviorsStub).to.have.been.calledOnce.and.calledOn(this.view);
+        expect(behaviorsStub).to.have.been.calledOnce.and.calledOn(fooView);
       });
     });
 
     describe('when behavior class is provided', function() {
       beforeEach(function() {
-        this.View = Marionette.View.extend({
-          behaviors: {foo: {behaviorClass: this.behaviors.foo}}
+        FooView = View.extend({
+          behaviors: {foo: {behaviorClass: behaviors.foo}}
         });
 
-        this.view = new this.View();
+        fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
-        expect(this.behaviors.foo).to.have.been.calledOnce;
+        expect(behaviors.foo).to.have.been.calledOnce;
       });
     });
 
     describe('when behaviors are specified as an array', function() {
       beforeEach(function() {
-        this.View = Marionette.View.extend({
-          behaviors: [this.behaviors.foo, this.behaviors.bar, {
-            behaviorClass: this.behaviors.baz
+        FooView = View.extend({
+          behaviors: [behaviors.foo, behaviors.bar, {
+            behaviorClass: behaviors.baz
           }]
         });
 
-        this.view = new this.View();
+        fooView = new FooView();
       });
 
       it('should instantiate behaviors passed directly as a class', function() {
-        expect(this.behaviors.foo).to.have.been.calledOnce;
-        expect(this.behaviors.bar).to.have.been.calledOnce;
+        expect(behaviors.foo).to.have.been.calledOnce;
+        expect(behaviors.bar).to.have.been.calledOnce;
       });
 
       it('should instantiate behaviors passed with behaviorClass', function() {
-        expect(this.behaviors.baz).to.have.been.calledOnce;
+        expect(behaviors.baz).to.have.been.calledOnce;
       });
+    });
+
+    afterEach(function() {
+      Behavior.restore();
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior initialize', function() {
+    let behaviorOptions;
+    let initializeStub;
+    let behaviors;
+    let FooView;
+    let fooView;
+
     beforeEach(function() {
-      this.behaviorOptions = {foo: 'bar'};
-      this.initializeStub = this.sinon.stub();
+      behaviorOptions = {foo: 'bar'};
+      initializeStub = this.sinon.stub();
 
-      this.behaviors = {
-        foo: Marionette.Behavior.extend({initialize: this.initializeStub})
+      behaviors = {
+        foo: Behavior.extend({initialize: initializeStub})
       };
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
 
-      this.View = Marionette.View.extend({
-        behaviors: {foo: this.behaviorOptions}
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
       });
-      this.view = new this.View();
+
+      FooView = View.extend({
+        behaviors: {foo: behaviorOptions}
+      });
+      fooView = new FooView();
     });
 
     it('should have a cidPrefix', function() {
-      var fooBehavior = new this.behaviors.foo();
+      var fooBehavior = new behaviors.foo();
       expect(fooBehavior.cidPrefix).to.equal('mnb');
     });
 
     it('should have a cid', function() {
-      var fooBehavior = new this.behaviors.foo();
+      var fooBehavior = new behaviors.foo();
 
       expect(fooBehavior.cid).to.exist;
     });
 
     it('should call initialize when a behavior is created', function() {
-      expect(this.initializeStub).to.have.been.calledOnce;
+      expect(initializeStub).to.have.been.calledOnce;
     });
 
     it('should call initialize when a behavior is created', function() {
-      expect(this.initializeStub).to.have.been.calledOnce.and.calledWith(this.behaviorOptions, this.view);
+      expect(initializeStub).to.have.been.calledOnce.and.calledWith(behaviorOptions, fooView);
     });
 
-    it('should set _behaviors', function() {
-      expect(this.view._behaviors.length).to.be.equal(1);
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior initialize from constructor args', function() {
+    let behaviorOptions;
+    let fooStub;
+    let barStub;
+    let behaviors;
+    let FooView;
+
     beforeEach(function() {
-      this.behaviorOptions = {foo: 'bar'};
-      this.fooStub = this.sinon.stub();
-      this.barStub = this.sinon.stub();
+      behaviorOptions = {foo: 'bar'};
+      fooStub = this.sinon.stub();
+      barStub = this.sinon.stub();
 
-      this.behaviors = {
-        foo: Marionette.Behavior.extend({initialize: this.fooStub}),
-        bar: Marionette.Behavior.extend({initialize: this.barStub})
+      behaviors = {
+        foo: Behavior.extend({initialize: fooStub}),
+        bar: Behavior.extend({initialize: barStub})
       };
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
 
-      this.View = Marionette.View.extend({
-        behaviors: {foo: this.behaviorOptions}
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
       });
-      this.view = new this.View({behaviors: {bar: {}}});
+
+      FooView = Marionette.View.extend({
+        behaviors: {foo: behaviorOptions}
+      });
+      let fooView = new FooView({behaviors: {bar: {}}});
     });
 
     it('should call initialize when a behavior is created', function() {
-      expect(this.barStub).to.have.been.calledOnce;
-      expect(this.fooStub).not.to.have.been.called;
+      expect(barStub).to.have.been.calledOnce;
+      expect(fooStub).not.to.have.been.called;
     });
 
-    it('should set _behaviors', function() {
-      expect(this.view._behaviors.length).to.be.equal(1);
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior events', function() {
-    beforeEach(function() {
-      this.fooClickStub = this.sinon.stub();
-      this.barClickStub = this.sinon.stub();
-      this.bazClickStub = this.sinon.stub();
-      this.viewClickStub = this.sinon.stub();
+    let fooClickStub;
+    let barClickStub;
+    let bazClickStub;
+    let viewClickStub;
+    let behaviors;
+    let FooView;
+    let fooView;
 
-      this.behaviors = {
+    beforeEach(function() {
+      fooClickStub = this.sinon.stub();
+      barClickStub = this.sinon.stub();
+      bazClickStub = this.sinon.stub();
+      viewClickStub = this.sinon.stub();
+
+      behaviors = {
         foo: Marionette.Behavior.extend({
-          events: {'click': this.fooClickStub}
+          events: {'click': fooClickStub}
         }),
         bar: Marionette.Behavior.extend({
-          events: {'click': this.barClickStub}
+          events: {'click': barClickStub}
         }),
         baz: Marionette.Behavior.extend({
           events: {'click': 'handleClick'},
-          handleClick: this.bazClickStub
+          handleClick: bazClickStub
         })
       };
 
-      this.View = Marionette.View.extend({
-        events: {'click': this.viewClickStub},
+      FooView = Marionette.View.extend({
+        events: {'click': viewClickStub},
         behaviors: {foo: {}, bar: {}, baz: {}}
       });
 
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
-      this.view = new this.View();
-      this.view.$el.click();
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
+
+      fooView = new FooView();
+      fooView.$el.click();
     });
 
     it('should call first behaviors event', function() {
-      expect(this.fooClickStub).to.have.been.calledOnce.and.calledOn(sinon.match.instanceOf(this.behaviors.foo));
+      expect(fooClickStub).to.have.been.calledOnce.and.calledOn(this.sinon.match.instanceOf(behaviors.foo));
     });
 
     it('should call second behaviors event', function() {
-      expect(this.barClickStub).to.have.been.calledOnce.and.calledOn(sinon.match.instanceOf(this.behaviors.bar));
+      expect(barClickStub).to.have.been.calledOnce.and.calledOn(this.sinon.match.instanceOf(behaviors.bar));
     });
 
     it('should call third behaviors event', function() {
-      expect(this.bazClickStub).to.have.been.calledOnce.and.calledOn(sinon.match.instanceOf(this.behaviors.baz));
+      expect(bazClickStub).to.have.been.calledOnce.and.calledOn(this.sinon.match.instanceOf(behaviors.baz));
     });
 
     it('should call the view click handler', function() {
-      expect(this.viewClickStub).to.have.been.calledOnce.and.calledOn(this.view);
+      expect(viewClickStub).to.have.been.calledOnce.and.calledOn(fooView);
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior triggers', function() {
-    beforeEach(function() {
-      this.onClickFooStub = this.sinon.stub();
+    let onClickFooStub;
+    let triggerMethodSpy;
+    let behaviors;
+    let fooModel;
+    let fooCollection;
+    let FooView;
+    let fooView;
 
-      this.behaviors = {
-        foo: Marionette.Behavior.extend({
+    beforeEach(function() {
+      onClickFooStub = this.sinon.stub();
+
+      behaviors = {
+        foo: Behavior.extend({
           triggers: {'click': 'click:foo'},
-          onClickFoo: this.onClickFooStub
+          onClickFoo: onClickFooStub
         })
       };
 
-      this.model = new Backbone.Model();
-      this.collection = new Backbone.Collection();
+      fooModel = new Backbone.Model();
+      fooCollection = new Backbone.Collection();
 
-      this.View = Marionette.View.extend({
+      FooView = Marionette.View.extend({
         behaviors: {foo: {}}
       });
 
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
-
-      this.view = new this.View({
-        model: this.model,
-        collection: this.collection
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
       });
 
-      this.triggerMethodSpy = this.sinon.spy();
+      fooView = new FooView({
+        model: fooModel,
+        collection: fooCollection
+      });
 
-      this.view.on('click:foo', this.triggerMethodSpy);
+      triggerMethodSpy = this.sinon.spy();
 
-      this.view.$el.click();
+      fooView.on('click:foo', triggerMethodSpy);
+
+      fooView.$el.click();
     });
 
     it('calls `triggerMethod` with the triggered event', function() {
-      expect(this.triggerMethodSpy)
+      expect(triggerMethodSpy)
         .to.have.been.calledOnce
-        .and.calledOn(this.view);
+        .and.calledOn(fooView);
     });
 
     it('calls the triggered method', function() {
-      expect(this.onClickFooStub)
+      expect(onClickFooStub)
         .to.have.been.calledOnce
-        .and.have.been.calledOn(sinon.match.instanceOf(this.behaviors.foo));
+        .and.have.been.calledOn(this.sinon.match.instanceOf(behaviors.foo));
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior $el', function() {
+    let fooBehavior;
+    let behaviors;
+    let FooView;
+    let fooView;
+
     beforeEach(function() {
-      var suite = this;
-      this.behaviors = {
+      behaviors = {
         foo: Marionette.Behavior.extend({
-          initialize: function() {suite.fooBehavior = this;}
+          initialize: function() {fooBehavior = this;}
         })
       };
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
 
-      this.View = Marionette.View.extend({
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
+
+      FooView = Marionette.View.extend({
         behaviors: {foo: {}}
       });
 
-      this.view = new this.View();
-      this.view.setElement(document.createElement('bar'));
+      fooView = new FooView();
+      fooView.setElement(document.createElement('bar'));
     });
 
     it('should proxy the views $el', function() {
-      expect(this.fooBehavior.$el).to.equal(this.view.$el);
+      expect(fooBehavior.$el).to.equal(fooView.$el);
     });
 
     it('should proxy the views el', function() {
-      expect(this.fooBehavior.el).to.equal(this.view.el);
+      expect(fooBehavior.el).to.equal(fooView.el);
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior UI', function() {
-    beforeEach(function() {
-      var suite = this;
-      this.onRenderStub = this.sinon.stub();
-      this.onBeforeAttachStub = this.sinon.stub();
-      this.onAttachStub = this.sinon.stub();
-      this.onDestroyStub = this.sinon.stub();
-      this.onFooClickStub = this.sinon.stub();
-      this.onBarClickStub = this.sinon.stub();
+    let fooBehavior;
+    let onRenderStub;
+    let onBeforeAttachStub;
+    let onAttachStub;
+    let onDestroyStub;
+    let onFooClickStub;
+    let onBarClickStub;
+    let behaviors;
+    let FooView;
 
-      this.behaviors = {
-        foo: Marionette.Behavior.extend({
+    beforeEach(function() {
+      onRenderStub = this.sinon.stub();
+      onBeforeAttachStub = this.sinon.stub();
+      onAttachStub = this.sinon.stub();
+      onDestroyStub = this.sinon.stub();
+      onFooClickStub = this.sinon.stub();
+      onBarClickStub = this.sinon.stub();
+
+      behaviors = {
+        foo: Behavior.extend({
           ui: {foo: '.foo'},
-          initialize: function() {suite.fooBehavior = this;},
+          initialize: function() {fooBehavior = this;},
           events: {
             'click @ui.foo': 'onFooClick',
             'click @ui.bar': 'onBarClick'
@@ -346,17 +433,19 @@ describe('Behaviors', function() {
 
           testViewUI: function() { this.ui.bar.trigger('test'); },
           testBehaviorUI: function() { this.ui.foo.trigger('test'); },
-          onRender: this.onRenderStub,
-          onBeforeAttach: this.onBeforeAttachStub,
-          onAttach: this.onAttachStub,
-          onDestroy: this.onDestroyStub,
-          onFooClick: this.onFooClickStub,
-          onBarClick: this.onBarClickStub
+          onRender: onRenderStub,
+          onBeforeAttach: onBeforeAttachStub,
+          onAttach: onAttachStub,
+          onDestroy: onDestroyStub,
+          onFooClick: onFooClickStub,
+          onBarClick: onBarClickStub
         })
       };
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
 
-      this.View = Marionette.View.extend({
+      FooView = View.extend({
         template: _.template('<div class="foo"></div><div class="bar"></div>'),
         ui: {bar: '.bar'},
         behaviors: {foo: {}}
@@ -364,42 +453,48 @@ describe('Behaviors', function() {
     });
 
     describe('should call onAttach when inside a CollectionView', function() {
+      let fooCollection;
+      let FooCollectionView;
+      let fooCollectionView;
 
       beforeEach(function() {
-        var CollectionView = Marionette.CollectionView.extend({
-          childView: this.View
+        FooCollectionView = CollectionView.extend({
+          childView: FooView
         });
 
-        this.collection = new Backbone.Collection([{}]);
-        this.collectionView = new CollectionView({collection: this.collection});
+        fooCollection = new Backbone.Collection([{}]);
+        fooCollectionView = new FooCollectionView({collection: fooCollection});
 
         this.setFixtures('<div id="region"></div>');
-        var region = new Marionette.Region({
+        var region = new Region({
           el: '#region'
         });
-        region.show(this.collectionView);
+        region.show(fooCollectionView);
       });
 
       it('should call onAttach when inside a CollectionView', function() {
-        expect(this.onAttachStub).to.have.been.called;
+        expect(onAttachStub).to.have.been.called;
       });
 
       it('should call onAttach when already shown and reset', function() {
-        this.collection.reset([{id: 1}, {id: 2}]);
+        fooCollection.reset([{id: 1}, {id: 2}]);
 
-        expect(this.onAttachStub.callCount).to.equal(3);
+        expect(onAttachStub.callCount).to.equal(3);
       });
 
       it('should call onAttach when a single model is added and the collectionView is already shown', function() {
-        this.collection.add({id: 3});
+        fooCollection.add({id: 3});
 
-        expect(this.onAttachStub.callCount).to.equal(2);
+        expect(onAttachStub.callCount).to.equal(2);
       });
     });
 
     describe('view should be able to override predefined behavior ui', function() {
+      let BarView;
+      let barView;
+
       beforeEach(function() {
-        var AnotherView = Marionette.View.extend({
+        BarView = View.extend({
           template: _.template('<div class="zip"></div><div class="bar"></div>'),
           ui: {
             bar: '.bar',
@@ -410,81 +505,83 @@ describe('Behaviors', function() {
           }
         });
 
-        this.view = new AnotherView();
-        this.view.render();
+        barView = new BarView();
+        barView.render();
 
-        this.view.$el.find('.zip').click();
-        this.view.$el.find('.bar').click();
+        barView.$el.find('.zip').click();
+        barView.$el.find('.bar').click();
       });
 
       it('should handle behavior ui click event', function() {
-        expect(this.onFooClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+        expect(onFooClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
       });
 
       it('should handle view ui click event', function() {
-        expect(this.onBarClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+        expect(onBarClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
       });
     });
 
     describe('within a view', function() {
+      let fooView;
+
       beforeEach(function() {
-        this.view = new this.View();
-        this.view.render();
+        fooView = new FooView();
+        fooView.render();
       });
 
       it('should not clobber the event prototype', function() {
-        expect(this.behaviors.foo.prototype.events).to.have.property('click @ui.bar', 'onBarClick');
+        expect(behaviors.foo.prototype.events).to.have.property('click @ui.bar', 'onBarClick');
       });
 
       it('should handle click events after calling delegateEvents', function() {
-        this.view.delegateEvents();
-        expect(this.fooBehavior.ui.foo.click.bind(this.view.ui.bar)).to.not.throw(Error);
-        expect(this.view.ui.bar.click.bind(this.view.ui.bar)).to.not.throw(Error);
+        fooView.delegateEvents();
+        expect(fooBehavior.ui.foo.click.bind(fooView.ui.bar)).to.not.throw(Error);
+        expect(fooView.ui.bar.click.bind(fooView.ui.bar)).to.not.throw(Error);
       });
 
       it('should set the behavior UI element', function() {
-        expect(this.onRenderStub).to.have.been.calledOnce;
+        expect(onRenderStub).to.have.been.calledOnce;
       });
 
       it('should make the view\'s ui hash available to callbacks', function() {
-        expect(this.fooBehavior.testViewUI.bind(this.fooBehavior)).to.not.throw(Error);
+        expect(fooBehavior.testViewUI.bind(fooBehavior)).to.not.throw(Error);
       });
 
       it('should make the behavior\'s ui hash available to callbacks', function() {
-        expect(this.fooBehavior.testBehaviorUI.bind(this.fooBehavior)).to.not.throw(Error);
+        expect(fooBehavior.testBehaviorUI.bind(fooBehavior)).to.not.throw(Error);
       });
 
       describe('the $el', function() {
         beforeEach(function() {
-          this.view.$el.find('.foo').click();
-          this.view.$el.find('.bar').click();
+          fooView.$el.find('.foo').click();
+          fooView.$el.find('.bar').click();
         });
 
         it('should handle behavior ui click event', function() {
-          expect(this.onFooClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+          expect(onFooClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
         });
 
         it('should handle view ui click event', function() {
-          expect(this.onBarClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+          expect(onBarClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
         });
 
         it('has a getUI method which returns the selector', function() {
-          expect(this.fooBehavior.getUI('foo')).to.have.length(1);
+          expect(fooBehavior.getUI('foo')).to.have.length(1);
         });
       });
 
       describe('the el', function() {
         beforeEach(function() {
-          $(this.view.el).find('.foo').click();
-          $(this.view.el).find('.bar').click();
+          $(fooView.el).find('.foo').click();
+          $(fooView.el).find('.bar').click();
         });
 
         it('should handle behavior ui click event', function() {
-          expect(this.onFooClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+          expect(onFooClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
         });
 
         it('should handle view ui click event', function() {
-          expect(this.onBarClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+          expect(onBarClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
         });
       });
     });
@@ -492,202 +589,254 @@ describe('Behaviors', function() {
     describe('within a layout', function() {
       beforeEach(function() {
         this.setFixtures('<div id="layout"></div>');
-        this.ItemView = Marionette.View.extend({
+        let BarView = View.extend({
           el: '#layout',
           template: _.template('<div class="baz"></div>'),
           regions: {bazRegion: '.baz'}
         });
 
-        this.layoutView = new this.ItemView();
-        this.layoutView.render();
-        this.layoutView.getRegion('bazRegion').show(new this.View());
-        this.layoutView.destroy();
+        let barView = new BarView();
+        barView.render();
+        barView.getRegion('bazRegion').show(new FooView());
+        barView.destroy();
       });
 
       it('should call onBeforeAttach', function() {
-        expect(this.onBeforeAttachStub).to.have.been.calledOnce;
+        expect(onBeforeAttachStub).to.have.been.calledOnce;
       });
 
       it('should call onAttach', function() {
-        expect(this.onAttachStub).to.have.been.calledOnce;
+        expect(onAttachStub).to.have.been.calledOnce;
       });
 
       it('should call onDestroy', function() {
-        expect(this.onDestroyStub).to.have.been.calledOnce;
+        expect(onDestroyStub).to.have.been.calledOnce;
       });
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('showing a view in a layout', function() {
-    beforeEach(function() {
-      this.onAttachStub = this.sinon.stub();
-      this.onDestroyStub = this.sinon.stub();
+    let onAttachStub;
+    let onDestroyStub;
+    let behaviors;
 
-      this.behaviors = {
-        foo: Marionette.Behavior.extend({
-          onAttach: this.onAttachStub,
-          onDestroy: this.onDestroyStub
+    beforeEach(function() {
+      onAttachStub = this.sinon.stub();
+      onDestroyStub = this.sinon.stub();
+
+      behaviors = {
+        foo: Behavior.extend({
+          onAttach: onAttachStub,
+          onDestroy: onDestroyStub
         })
       };
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
 
-      this.View = Marionette.View.extend({
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
+
+      let FooView = View.extend({
         template: _.template('foo'),
         behaviors: {foo: {}}
       });
 
       this.setFixtures('<div id="region"></div>');
-      this.region = new Backbone.Marionette.Region({el: '#region'});
-      this.view = new this.View();
+      let region = new Region({el: '#region'});
+      let fooView = new FooView();
 
-      this.region.show(this.view);
-      this.region.empty();
+      region.show(fooView);
+      region.empty();
     });
 
     it('behavior onAttach is called once', function() {
-      expect(this.onAttachStub).to.have.been.calledOnce;
+      expect(onAttachStub).to.have.been.calledOnce;
     });
 
     it('behavior onClose is called once', function() {
-      expect(this.onDestroyStub).to.have.been.calledOnce;
+      expect(onDestroyStub).to.have.been.calledOnce;
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior instance events', function() {
-    beforeEach(function() {
-      var suite = this;
-      this.listenToChangeStub = this.sinon.stub();
-      this.onFooStub = this.sinon.stub();
-      this.model = new Backbone.Model();
+    let listenToChangeStub;
+    let onFooStub;
 
-      this.FooBehavior = Marionette.Behavior.extend({
+    beforeEach(function() {
+      let model = new Backbone.Model();
+
+      listenToChangeStub = this.sinon.stub();
+      onFooStub = this.sinon.stub();
+
+      let FooBehavior = Behavior.extend({
         initialize: function() {
-          this.listenTo(suite.model, 'change', suite.listenToChangeStub);
-          this.on('foo', suite.onFooStub);
+          this.listenTo(model, 'change', listenToChangeStub);
+          this.on('foo', onFooStub);
         }
       });
 
-      this.View = Marionette.View.extend({
-        behaviors: {foo: {behaviorClass: this.FooBehavior}}
+      let FooView = View.extend({
+        behaviors: {foo: {behaviorClass: FooBehavior}}
       });
 
-      this.view = new this.View();
-      this.view.destroy();
-      this.model.set('bar', 'baz');
-      this.view.triggerMethod('foo');
+      let fooView = new FooView();
+      fooView.destroy();
+      model.set('bar', 'baz');
+      fooView.triggerMethod('foo');
     });
 
     it('should unbind listenTo on destroy', function() {
-      expect(this.listenToChangeStub).not.to.have.been.calledOnce;
+      expect(listenToChangeStub).not.to.have.been.calledOnce;
     });
 
     it('should still be bound to "on" on destroy', function() {
-      expect(this.onFooStub).to.have.been.calledOnce;
+      expect(onFooStub).to.have.been.calledOnce;
     });
   });
 
   describe('behavior model events', function() {
-    beforeEach(function() {
-      var suite = this;
-      this.handleModelChangeStub = this.sinon.stub();
-      this.handleCollectionResetStub = this.sinon.stub();
-      this.handleModelFooChangeStub = this.sinon.stub();
+    let handleModelChangeStub;
+    let handleCollectionResetStub;
+    let handleModelFooChangeStub;
+    let behaviors;
+    let fooBehavior;
+    let FooView;
+    let fooView;
+    let FooCollectionView;
+    let fooCollectionView;
+    let fooModel;
+    let fooCollection;
 
-      this.behaviors = {
+    beforeEach(function() {
+      handleModelChangeStub = this.sinon.stub();
+      handleCollectionResetStub = this.sinon.stub();
+      handleModelFooChangeStub = this.sinon.stub();
+
+      behaviors = {
         foo: Marionette.Behavior.extend({
-          initialize: function() {suite.fooBehavior = this;},
+          initialize: function() {fooBehavior = this;},
           modelEvents: {
-            'change': this.handleModelChangeStub,
+            'change': handleModelChangeStub,
             'change:foo': 'handleModelFooChange'
           },
           collectionEvents: {
-            'reset': this.handleCollectionResetStub
+            'reset': handleCollectionResetStub
           },
-          handleModelFooChange: this.handleModelFooChangeStub
+          handleModelFooChange: handleModelFooChangeStub
         })
       };
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
 
-      this.CollectionView = Marionette.CollectionView.extend({
-        behaviors: {foo: {}}
-      });
-      this.ItemView = Marionette.View.extend({
-        behaviors: {foo: {}}
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
       });
 
-      this.model = new Backbone.Model({foo: 'bar'});
-      this.collection = new Backbone.Collection([]);
+      FooCollectionView = CollectionView.extend({
+        behaviors: {foo: {}}
+      });
+      FooView = View.extend({
+        behaviors: {foo: {}}
+      });
+
+      fooModel = new Backbone.Model({foo: 'bar'});
+      fooCollection = new Backbone.Collection([]);
     });
 
     it('should proxy model events', function() {
-      this.view = new this.ItemView({model: this.model});
-      this.model.set('foo', 'baz');
-      expect(this.handleModelChangeStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+      fooView = new FooView({model: fooModel});
+      fooModel.set('foo', 'baz');
+      expect(handleModelChangeStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
     });
 
     it('should proxy model events w/ string cbk', function() {
-      this.view = new this.ItemView({model: this.model});
-      this.model.set('foo', 'baz');
-      expect(this.handleModelFooChangeStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+      fooView = new FooView({model: fooModel});
+      fooModel.set('foo', 'baz');
+      expect(handleModelFooChangeStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
     });
 
     it('should proxy collection events', function() {
-      this.view = new this.CollectionView({collection: this.collection});
-      this.collection.reset();
-      expect(this.handleCollectionResetStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+      fooCollectionView = new FooCollectionView({collection: fooCollection});
+      fooCollection.reset();
+      expect(handleCollectionResetStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
     });
 
     it('should unbind model events on view undelegateEntityEvents', function() {
-      this.view = new this.ItemView({model: this.model});
-      this.view.undelegateEntityEvents();
-      this.model.set('foo', 'doge');
-      expect(this.handleModelFooChangeStub).not.to.have.been.called;
+      fooView = new FooView({model: fooModel});
+      fooView.undelegateEntityEvents();
+      fooModel.set('foo', 'doge');
+      expect(handleModelFooChangeStub).not.to.have.been.called;
     });
 
     it('should unbind collection events on view undelegateEntityEvents', function() {
-      this.view = new this.CollectionView({collection: this.collection});
-      this.view.undelegateEntityEvents();
-      this.collection.reset();
-      expect(this.handleCollectionResetStub).not.to.have.been.called;
+      fooCollectionView = new FooCollectionView({collection: fooCollection});
+      fooCollectionView.undelegateEntityEvents();
+      fooCollection.reset();
+      expect(handleCollectionResetStub).not.to.have.been.called;
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior trigger calls', function() {
-    beforeEach(function() {
-      this.onRenderStub = this.sinon.stub();
+    let onRenderStub;
+    let behaviors;
 
-      this.behaviors = {
+    beforeEach(function() {
+      onRenderStub = this.sinon.stub();
+
+      behaviors = {
         foo: Marionette.Behavior.extend({
-          onRender: this.onRenderStub
+          onRender: onRenderStub
         })
       };
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
 
-      this.View = Marionette.View.extend({
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
+
+      let FooView = View.extend({
         behaviors: {foo: {}}
       });
 
-      this.view = new this.View();
-      this.view.triggerMethod('render');
+      let fooView = new FooView();
+      fooView.triggerMethod('render');
     });
 
     it('should call onRender when a view is rendered', function() {
-      expect(this.onRenderStub).to.have.been.calledOnce;
+      expect(onRenderStub).to.have.been.calledOnce;
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior triggerMethod calls', function() {
+    let behaviors;
+    let fooView;
+
     beforeEach(function() {
-      this.behaviors = {
+      behaviors = {
         foo: Marionette.Behavior.extend({
           onFoo: function() {
             return 'behavior foo';
           }
         })
       };
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
 
-      this.View = Marionette.View.extend({
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
+
+      let FooView = View.extend({
         behaviors: {foo: {}},
 
         onFoo: function() {
@@ -695,224 +844,261 @@ describe('Behaviors', function() {
         }
       });
 
-      this.view = new this.View();
+      fooView = new FooView();
     });
 
     it('onFoo should return "foo"', function() {
-      expect(this.view.triggerMethod('foo')).to.equal('view foo');
+      expect(fooView.triggerMethod('foo')).to.equal('view foo');
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('behavior is evented', function() {
-    beforeEach(function() {
-      this.listenToStub = this.sinon.stub();
-      this.changeStub = this.sinon.stub();
-      this.behavior = new Marionette.Behavior({}, {});
-      this.model = new Backbone.Model();
+    let listenToStub;
+    let changeStub;
+    let behavior;
 
-      Marionette.bindEvents(this.behavior, this.model, {
-        'change': this.changeStub
+    beforeEach(function() {
+      listenToStub = this.sinon.stub();
+      changeStub = this.sinon.stub();
+      behavior = new Marionette.Behavior({}, {});
+
+      let fooModel = new Backbone.Model();
+
+      Marionette.bindEvents(behavior, fooModel, {
+        'change': changeStub
       });
 
-      this.behavior.listenTo(this.model, 'foo', this.listenToStub);
-      this.model.trigger('foo');
-      this.model.set('foo', 'bar');
+      behavior.listenTo(fooModel, 'foo', listenToStub);
+      fooModel.trigger('foo');
+      fooModel.set('foo', 'bar');
     });
 
     it('should listenTo events', function() {
-      expect(this.listenToStub).to.have.been.calledOnce;
+      expect(listenToStub).to.have.been.calledOnce;
     });
 
     it('should support bindEntityEvents', function() {
-      expect(this.changeStub).to.have.been.calledOnce;
+      expect(changeStub).to.have.been.calledOnce;
     });
 
     it('should execute in the specified context', function() {
-      expect(this.listenToStub).to.have.been.calledOnce.and.calledOn(this.behavior);
+      expect(listenToStub).to.have.been.calledOnce.and.calledOn(behavior);
     });
   });
 
   describe('behavior with behavior', function() {
+    let initializeStub;
+    let fooClickStub;
+    let barOnRenderStub;
+    let barClickStub;
+    let barModelChangeStub;
+    let barCollectionSyncStub;
+    let viewOnRenderStub;
+    let bazClickStub;
+    let behaviors;
+    let fooBehavior;
+    let barBehavior;
+    let FooView;
+    let fooView;
+    let fooModel;
+    let fooCollection;
+
     beforeEach(function() {
-      var suite = this;
+      initializeStub = this.sinon.stub();
+      viewOnRenderStub = this.sinon.stub();
+      fooClickStub = this.sinon.stub();
+      barOnRenderStub = this.sinon.stub();
+      barClickStub = this.sinon.stub();
+      barModelChangeStub = this.sinon.stub();
+      barCollectionSyncStub = this.sinon.stub();
+      bazClickStub = this.sinon.stub();
 
-      this.initializeStub = this.sinon.stub();
-      this.viewOnRenderStub = this.sinon.stub();
-      this.fooClickStub = this.sinon.stub();
-      this.barOnRenderStub = this.sinon.stub();
-      this.barClickStub = this.sinon.stub();
-      this.barModelChangeStub = this.sinon.stub();
-      this.barCollectionSyncStub = this.sinon.stub();
-      this.viewOnRenderStub = this.sinon.stub();
-      this.bazClickStub = this.sinon.stub();
-
-      this.behaviors = {
+      behaviors = {
         foo: Marionette.Behavior.extend({
-          initialize: function() { suite.fooBehavior = this; },
+          initialize: function() { fooBehavior = this; },
           behaviors: {bar: {}},
           ui: {foo: '.foo'},
           events: {
-            'click @ui.foo': this.fooClickStub
+            'click @ui.foo': fooClickStub
           }
         }),
         bar: Marionette.Behavior.extend({
           initialize: function() {
-            suite.initializeStub();
-            suite.barBehavior = this;
+            initializeStub();
+            barBehavior = this;
           },
-          onRender: this.barOnRenderStub,
+          onRender: barOnRenderStub,
           ui: {bar: '.bar'},
           events: {
-            'click @ui.bar': this.barClickStub
+            'click @ui.bar': barClickStub
           },
           modelEvents: {
-            'change': this.barModelChangeStub
+            'change': barModelChangeStub
           },
           collectionEvents: {
-            'sync': this.barCollectionSyncStub
+            'sync': barCollectionSyncStub
           }
         })
       };
 
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
 
-      this.View = Marionette.CompositeView.extend({
+      FooView = View.extend({
         template: _.template('<div class="baz"></div><div class="foo"></div><div class="bar"></div>'),
         behaviors: {foo: {}},
-        onRender: this.viewOnRenderStub,
+        onRender: viewOnRenderStub,
         ui: {baz: '.baz'},
         events: {
-          'click @ui.baz': this.bazClickStub,
+          'click @ui.baz': bazClickStub,
         }
       });
 
-      this.model = new Backbone.Model();
-      this.collection = new Backbone.Collection();
+      fooModel = new Backbone.Model();
+      fooCollection = new Backbone.Collection();
 
-      this.view = new this.View({
-        model: this.model,
-        collection: this.collection
+      fooView = new FooView({
+        model: fooModel,
+        collection: fooCollection
       });
 
-      this.sinon.spy(this.view, 'undelegateEvents');
-      this.sinon.spy(this.view, 'undelegateEntityEvents');
+      this.sinon.spy(fooView, 'undelegateEvents');
+      this.sinon.spy(fooView, 'undelegateEntityEvents');
     });
 
     it('should call initialize on grouped behaviors', function() {
-      expect(this.initializeStub).to.have.been.calledOnce;
-    });
-
-    it('should set _behaviors', function() {
-      expect(this.view._behaviors.length).to.be.equal(2);
+      expect(initializeStub).to.have.been.calledOnce;
     });
 
     it('should call onRender on grouped behaviors', function() {
-      this.view.triggerMethod('render');
-      expect(this.barOnRenderStub).to.have.been.calledOnce.and.calledOn(this.barBehavior);
+      fooView.triggerMethod('render');
+      expect(barOnRenderStub).to.have.been.calledOnce.and.calledOn(barBehavior);
     });
 
     it('should call onRender on the view', function() {
-      this.view.triggerMethod('render');
-      expect(this.viewOnRenderStub).to.have.been.calledOnce.and.calledOn(this.view);
+      fooView.triggerMethod('render');
+      expect(viewOnRenderStub).to.have.been.calledOnce.and.calledOn(fooView);
     });
 
     it('should call undelegateEvents once', function() {
-      this.view.undelegateEvents();
-      expect(this.view.undelegateEvents).to.have.been.calledOnce;
+      fooView.undelegateEvents();
+      expect(fooView.undelegateEvents).to.have.been.calledOnce;
     });
 
     it('should call undelegateEntityEvents once', function() {
-      this.view.undelegateEntityEvents();
-      expect(this.view.undelegateEntityEvents).to.have.been.calledOnce;
+      fooView.undelegateEntityEvents();
+      expect(fooView.undelegateEntityEvents).to.have.been.calledOnce;
     });
 
     it('should proxy modelEvents to grouped behaviors', function() {
-      this.model.trigger('change');
-      expect(this.barModelChangeStub).to.have.been.calledOnce.and.calledOn(this.barBehavior);
+      fooModel.trigger('change');
+      expect(barModelChangeStub).to.have.been.calledOnce.and.calledOn(barBehavior);
     });
 
     it('should proxy collectionEvents to grouped behaviors', function() {
-      this.collection.trigger('sync');
-      expect(this.barCollectionSyncStub).to.have.been.calledOnce.and.calledOn(this.barBehavior);
+      fooCollection.trigger('sync');
+      expect(barCollectionSyncStub).to.have.been.calledOnce.and.calledOn(barBehavior);
     });
 
     it('should proxy child behavior UI events to grouped behaviors', function() {
-      this.view.render();
-      this.barBehavior.ui.bar.click();
-      expect(this.barClickStub).to.have.been.calledOnce.and.calledOn(this.barBehavior);
+      fooView.render();
+      barBehavior.ui.bar.click();
+      expect(barClickStub).to.have.been.calledOnce.and.calledOn(barBehavior);
     });
 
     it('should proxy base behavior UI events to base behavior', function() {
-      this.view.render();
-      this.fooBehavior.ui.foo.click();
-      expect(this.fooClickStub).to.have.been.calledOnce.and.calledOn(this.fooBehavior);
+      fooView.render();
+      fooBehavior.ui.foo.click();
+      expect(fooClickStub).to.have.been.calledOnce.and.calledOn(fooBehavior);
     });
 
     it('should proxy view UI events to view', function() {
-      this.view.render();
-      this.view.ui.baz.click();
-      expect(this.bazClickStub).to.have.been.calledOnce.and.calledOn(this.view);
+      fooView.render();
+      fooView.ui.baz.click();
+      expect(bazClickStub).to.have.been.calledOnce.and.calledOn(fooView);
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('return values of wrapped methods', function() {
-    beforeEach(function() {
-      this.behaviors = {foo: Marionette.Behavior};
-      Marionette.Behaviors.behaviorsLookup = this.behaviors;
+    let behaviors;
+    let FooView;
+    let fooView;
 
-      this.View = Marionette.View.extend({
+    beforeEach(function() {
+      behaviors = {foo: Behavior};
+
+      this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+        return behaviors;
+      });
+
+      FooView = View.extend({
         behaviors: {foo: {}}
       });
 
-      this.view = new this.View();
+      fooView = new FooView();
     });
 
     it('destroy should return the view', function() {
-      this.sinon.spy(this.view, 'destroy');
-      this.view.destroy();
-      expect(this.view.destroy).to.have.returned(this.view);
+      this.sinon.spy(fooView, 'destroy');
+      fooView.destroy();
+      expect(fooView.destroy).to.have.returned(fooView);
     });
 
     it('setElement should return the view', function() {
-      this.sinon.spy(this.view, 'setElement');
-      this.view.setElement(this.view.$el);
-      expect(this.view.setElement).to.have.returned(this.view);
+      this.sinon.spy(fooView, 'setElement');
+      fooView.setElement(fooView.$el);
+      expect(fooView.setElement).to.have.returned(fooView);
     });
 
     it('delegateEvents should return the view', function() {
-      this.sinon.spy(this.view, 'delegateEvents');
-      this.view.delegateEvents();
-      expect(this.view.delegateEvents).to.have.returned(this.view);
+      this.sinon.spy(fooView, 'delegateEvents');
+      fooView.delegateEvents();
+      expect(fooView.delegateEvents).to.have.returned(fooView);
     });
 
     it('undelegateEvents should return the view', function() {
-      this.sinon.spy(this.view, 'undelegateEvents');
-      this.view.undelegateEvents({});
-      expect(this.view.undelegateEvents).to.have.returned(this.view);
+      this.sinon.spy(fooView, 'undelegateEvents');
+      fooView.undelegateEvents({});
+      expect(fooView.undelegateEvents).to.have.returned(fooView);
     });
 
     it('delegateEntityEvents should return the view', function() {
-      this.sinon.spy(this.view, 'delegateEntityEvents');
-      this.view.delegateEntityEvents();
-      expect(this.view.delegateEntityEvents).to.have.returned(this.view);
+      this.sinon.spy(fooView, 'delegateEntityEvents');
+      fooView.delegateEntityEvents();
+      expect(fooView.delegateEntityEvents).to.have.returned(fooView);
     });
 
     it('undelegateEntityEvents should return the view', function() {
-      this.sinon.spy(this.view, 'undelegateEntityEvents');
-      this.view.undelegateEntityEvents({});
-      expect(this.view.undelegateEntityEvents).to.have.returned(this.view);
+      this.sinon.spy(fooView, 'undelegateEntityEvents');
+      fooView.undelegateEntityEvents({});
+      expect(fooView.undelegateEntityEvents).to.have.returned(fooView);
+    });
+
+    afterEach(function() {
+      Marionette.Behaviors.behaviorsLookup.restore();
     });
   });
 
   describe('.destroy', function() {
+    let behavior;
+
     beforeEach(function() {
-      this.behavior = new Marionette.Behavior();
-      this.sinon.spy(this.behavior, 'destroy');
-      this.behavior.destroy();
+      behavior = new Behavior();
+      this.sinon.spy(behavior, 'destroy');
+      behavior.destroy();
     });
 
     it('should return the behavior', function() {
-      expect(this.behavior.destroy).to.have.returned(this.behavior);
+      expect(behavior.destroy).to.have.returned(behavior);
     });
   });
 });

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -32,12 +32,12 @@ describe('Behaviors', function() {
 
     describe('when one behavior', function() {
       beforeEach(function() {
-        let FooView = View.extend({
+        const FooView = View.extend({
           behaviors: [FooBehavior]
         });
 
-        /* eslint-disable no-new */
-        new FooView();
+        /* eslint-disable no-unused-vars */
+        const fooView = new FooView();
       });
 
       it('should instantiate the behavior', function() {
@@ -73,6 +73,7 @@ describe('Behaviors', function() {
       });
 
       it('should instantiate the behavior', function() {
+        /* eslint-disable no-unused-vars */
         const fooView = new FooView();
 
         expect(behaviors.foo).to.have.been.calledOnce;
@@ -87,6 +88,7 @@ describe('Behaviors', function() {
       });
 
       it('should instantiate the behavior', function() {
+        /* eslint-disable no-unused-vars */
         const fooView = new FooView();
 
         expect(behaviors.foo).to.have.been.calledOnce;
@@ -107,6 +109,7 @@ describe('Behaviors', function() {
       });
 
       it('should instantiate the behavior', function() {
+        /* eslint-disable no-unused-vars */
         const fooView = new FooView();
 
         expect(behaviors.foo).to.have.been.calledOnce;
@@ -127,6 +130,7 @@ describe('Behaviors', function() {
       });
 
       it('should instantiate the behavior', function() {
+        /* eslint-disable no-unused-vars */
         const fooView = new FooView();
 
         expect(behaviors.foo).to.have.been.calledOnce;
@@ -143,6 +147,7 @@ describe('Behaviors', function() {
       });
 
       it('should instantiate behaviors passed directly as a class', function() {
+        /* eslint-disable no-unused-vars */
         const fooView = new FooView();
 
         expect(behaviors.foo).to.have.been.calledOnce;
@@ -150,6 +155,7 @@ describe('Behaviors', function() {
       });
 
       it('should instantiate behaviors passed with behaviorClass', function() {
+        /* eslint-disable no-unused-vars */
         const fooView = new FooView();
 
         expect(behaviors.baz).to.have.been.calledOnce;
@@ -181,6 +187,7 @@ describe('Behaviors', function() {
     });
 
     it('should have a cidPrefix', function() {
+      /* eslint-disable no-unused-vars */
       const fooView = new FooView();
       const fooBehavior = new behaviors.foo();
 
@@ -188,6 +195,7 @@ describe('Behaviors', function() {
     });
 
     it('should have a cid', function() {
+      /* eslint-disable no-unused-vars */
       const fooView = new FooView();
       const fooBehavior = new behaviors.foo();
 
@@ -195,6 +203,7 @@ describe('Behaviors', function() {
     });
 
     it('should call initialize when a behavior is created', function() {
+      /* eslint-disable no-unused-vars */
       const fooView = new FooView();
 
       expect(initializeStub).to.have.been.calledOnce;
@@ -232,6 +241,7 @@ describe('Behaviors', function() {
     });
 
     it('should call initialize when a behavior is created', function() {
+      /* eslint-disable no-unused-vars */
       const fooView = new FooView({behaviors: {bar: {}}});
 
       expect(barStub).to.have.been.calledOnce;
@@ -783,6 +793,7 @@ describe('Behaviors', function() {
     });
 
     it('should proxy model events', function() {
+      /* eslint-disable no-unused-vars */
       const fooView = new FooView({model: fooModel});
       fooModel.set('foo', 'baz');
 
@@ -790,6 +801,7 @@ describe('Behaviors', function() {
     });
 
     it('should proxy model events w/ string cbk', function() {
+      /* eslint-disable no-unused-vars */
       const fooView = new FooView({model: fooModel});
       fooModel.set('foo', 'baz');
 
@@ -797,6 +809,7 @@ describe('Behaviors', function() {
     });
 
     it('should proxy collection events', function() {
+      /* eslint-disable no-unused-vars */
       const fooCollectionView = new FooCollectionView({collection: fooCollection});
       fooCollection.reset();
 

--- a/test/unit/mixins/behaviors.spec.js
+++ b/test/unit/mixins/behaviors.spec.js
@@ -460,7 +460,4 @@ describe('Behaviors Mixin', function() {
       expect(BarBehavior.prototype.unbindUIElements).to.have.been.calledOnce;
     });
   });
-
-  //@todo
-  // _triggerEventOnBehaviors
 });

--- a/test/unit/mixins/behaviors.spec.js
+++ b/test/unit/mixins/behaviors.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import _ from 'underscore';
+import Backbone from 'backbone';
 import BehaviorsMixin from '../../../src/mixins/behaviors';
 import Behavior from '../../../src/behavior';
 
@@ -9,8 +10,7 @@ describe('Behaviors Mixin', function() {
 
   beforeEach(function() {
     Behaviors = function() {};
-    Behaviors.extend = Marionette.extend;
-    _.extend(Behaviors.prototype, BehaviorsMixin);
+    _.extend(Behaviors.prototype, Backbone.View, BehaviorsMixin);
   });
 
   describe('#_initBehaviors', function() {
@@ -33,80 +33,434 @@ describe('Behaviors Mixin', function() {
 
   describe('#_getBehaviors', function() {
     let behaviorsInstance;
-    let initializeStub;
-    let actualBehaviors;
+    let fooInitializeStub;
     let FooBehavior;
 
     beforeEach(function() {
-      initializeStub = this.sinon.stub();
-      behaviorsInstance = new Behaviors()
-      FooBehavior = Behavior.extend({initialize: initializeStub});
+      fooInitializeStub = this.sinon.stub();
+      behaviorsInstance = new Behaviors();
+      FooBehavior = Behavior.extend({initialize: fooInitializeStub});
     });
 
-    describe('should work with behaviorClass option', function() {
+    describe('with behaviorClass option', function() {
       beforeEach(function() {
         behaviorsInstance.behaviors = [
           {
             behaviorClass: FooBehavior
           }
         ];
-        actualBehaviors = behaviorsInstance._getBehaviors();
       });
 
       it('should call initialize when a behavior is created', function() {
-        expect(initializeStub).to.be.calledOnce;
+        behaviorsInstance._getBehaviors();
+
+        expect(fooInitializeStub).to.be.calledOnce;
       });
 
       it('should have behaviors', function() {
-        expect(actualBehaviors.length).to.be.equal(1);
+        behaviorsInstance._getBehaviors();
+
+        expect(behaviorsInstance._getBehaviors().length).to.be.equal(1);
       });
     });
 
-    describe('should work without behaviorClass option', function() {
+    describe('without behaviorClass option', function() {
       beforeEach(function() {
         behaviorsInstance.behaviors = [FooBehavior];
-        actualBehaviors = behaviorsInstance._getBehaviors();
       });
 
       it('should call initialize when a behavior is created', function() {
-        expect(initializeStub).to.be.calledOnce;
+        behaviorsInstance._getBehaviors();
+
+        expect(fooInitializeStub).to.be.calledOnce;
       });
 
       it('should have behaviors', function() {
-        expect(actualBehaviors.length).to.be.equal(1);
+        expect(behaviorsInstance._getBehaviors().length).to.be.equal(1);
       });
     });
 
-    describe('should work with behaviorsLookup', function() {
+    describe('with behaviorsLookup as object', function() {
       beforeEach(function() {
-        let behaviorOptions = {foo: 'bar'};
-        let behaviors = {
+        let behaviorOptions = {foo: {}};
+
+        Marionette.Behaviors.behaviorsLookup = {
           'foo': FooBehavior
         };
-        Marionette.Behaviors.behaviorsLookup = behaviors;
 
         behaviorsInstance.behaviors = {foo: behaviorOptions};
-        actualBehaviors = behaviorsInstance._getBehaviors();
       });
 
       it('should call initialize when a behavior is created', function() {
-        expect(initializeStub).to.be.calledOnce;
+        behaviorsInstance._getBehaviors();
+
+        expect(fooInitializeStub).to.be.calledOnce;
       });
 
       it('should have behaviors', function() {
-        expect(actualBehaviors.length).to.be.equal(1);
+        expect(behaviorsInstance._getBehaviors().length).to.be.equal(1);
+      });
+    });
+
+    describe('with nested behaviors', function() {
+      let barInitializeStub;
+      let bazInitializeStub;
+
+      beforeEach(function() {
+        barInitializeStub = this.sinon.stub();
+        bazInitializeStub = this.sinon.stub();
+
+        let BarBehavior = Behavior.extend({
+          initialize: barInitializeStub,
+        });
+
+        let BazBehavior = Behavior.extend({
+          initialize: bazInitializeStub,
+        });
+
+        FooBehavior = Behavior.extend({
+          initialize: fooInitializeStub,
+          behaviors: {bar: {}}
+        });
+
+        let behaviors = {
+          'foo': FooBehavior,
+          'bar': BarBehavior,
+          'baz': BazBehavior
+        };
+
+        this.sinon.stub(Marionette.Behaviors, 'behaviorsLookup', function() {
+          return behaviors;
+        });
+
+        behaviorsInstance.behaviors = {foo: 'foo'};
+      });
+
+      it('should call initialize when a behavior is created', function() {
+        behaviorsInstance._getBehaviors();
+
+        expect(fooInitializeStub).to.be.calledOnce;
+        expect(bazInitializeStub).not.to.have.been.called;
+      });
+
+      it('should call initialize when a nested behavior is created', function() {
+        behaviorsInstance._getBehaviors();
+
+        expect(barInitializeStub).to.be.calledOnce;
+      });
+
+      it('should have behaviors', function() {
+        expect(behaviorsInstance._getBehaviors().length).to.be.equal(2);
+      });
+    });
+
+    describe('with nested behaviors and without behaviorsLookup', function() {
+      let barInitializeStub;
+
+      beforeEach(function() {
+        barInitializeStub = this.sinon.stub();
+
+        let BarBehavior = Behavior.extend({
+          initialize: barInitializeStub,
+        });
+
+        FooBehavior = Behavior.extend({
+          initialize: fooInitializeStub,
+          behaviors: [BarBehavior]
+        });
+
+        behaviorsInstance.behaviors = {foo: FooBehavior};
+      });
+
+      it('should call initialize when a behavior is created', function() {
+        behaviorsInstance._getBehaviors();
+
+        expect(fooInitializeStub).to.be.calledOnce;
+      });
+
+      it('should call initialize when a nested behavior is created', function() {
+        behaviorsInstance._getBehaviors();
+
+        expect(barInitializeStub).to.be.calledOnce;
+      });
+
+      it('should have behaviors', function() {
+        expect(behaviorsInstance._getBehaviors().length).to.be.equal(2);
       });
     });
   });
 
+  describe('#_getBehaviorTriggers', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+    let triggers;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      triggers = {
+        'click @ui.foo': 'bar'
+      };
+      FooBehavior = Behavior.extend({});
+
+      this.sinon.stub(FooBehavior.prototype, 'getTriggers', function() {
+        if (this.triggers) {
+          return this.triggers;
+        } else {
+          return;
+        }
+      });
+
+      BarBehavior = FooBehavior.extend({
+        triggers: triggers
+      });
+    });
+
+    describe('when triggers are set', function() {
+
+      beforeEach(function() {
+        behaviorsInstance.behaviors = {bar: BarBehavior};
+        behaviorsInstance._initBehaviors();
+      });
+
+      it('should return behavior triggers', function() {
+        const result = behaviorsInstance._getBehaviorTriggers();
+
+        expect(result).to.have.been.deep.equal(triggers);
+      });
+    });
+
+    describe('when triggers are not set', function() {
+
+      beforeEach(function() {
+        behaviorsInstance.behaviors = {foo: FooBehavior};
+        behaviorsInstance._initBehaviors();
+      });
+
+      it('should return empty object', function() {
+        const result = behaviorsInstance._getBehaviorTriggers();
+
+        expect(result).to.have.been.deep.equal({});
+      });
+    });
+  });
+
+  describe('#__getBehaviorEvents', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+    let events;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      events = {
+        'click @ui.foo': 'bar'
+      };
+      FooBehavior = Behavior.extend({});
+
+      this.sinon.stub(FooBehavior.prototype, 'getEvents', function() {
+        if (this.events) {
+          return this.events;
+        } else {
+          return;
+        }
+      });
+
+      BarBehavior = FooBehavior.extend({
+        events: events
+      });
+    });
+
+    describe('when events are set', function() {
+
+      beforeEach(function() {
+        behaviorsInstance.behaviors = {bar: BarBehavior};
+        behaviorsInstance._initBehaviors();
+      });
+
+      it('should return behavior events', function() {
+        const result = behaviorsInstance._getBehaviorEvents();
+
+        expect(result).to.have.been.deep.equal(events);
+      });
+    });
+
+    describe('when events are not set', function() {
+
+      beforeEach(function() {
+        behaviorsInstance.behaviors = {foo: FooBehavior};
+        behaviorsInstance._initBehaviors();
+      });
+
+      it('should return empty object', function() {
+        let result = behaviorsInstance._getBehaviorEvents();
+
+        expect(result).to.have.been.deep.equal({});
+      });
+    });
+  });
+
+  describe('#_proxyBehaviorViewProperties', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      FooBehavior = Behavior.extend({});
+      BarBehavior = Behavior.extend({});
+
+      this.sinon.spy(FooBehavior.prototype, 'proxyViewProperties');
+      this.sinon.spy(BarBehavior.prototype, 'proxyViewProperties');
+
+      behaviorsInstance.behaviors = {foo: FooBehavior, bar: BarBehavior};
+      behaviorsInstance._initBehaviors();
+    });
+
+    it('should invoke proxyViewProperties', function() {
+      behaviorsInstance._proxyBehaviorViewProperties();
+
+      expect(FooBehavior.prototype.proxyViewProperties).to.have.been.calledOnce;
+      expect(BarBehavior.prototype.proxyViewProperties).to.have.been.calledOnce;
+    });
+  });
+
+  describe('#_delegateBehaviorEntityEvents', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      FooBehavior = Behavior.extend({});
+      BarBehavior = Behavior.extend({});
+
+      this.sinon.spy(FooBehavior.prototype, 'delegateEntityEvents');
+      this.sinon.spy(BarBehavior.prototype, 'delegateEntityEvents');
+
+      behaviorsInstance.behaviors = {foo: FooBehavior, bar: BarBehavior};
+      behaviorsInstance._initBehaviors();
+    });
+
+    it('should invoke delegateEntityEvents', function() {
+      behaviorsInstance._delegateBehaviorEntityEvents();
+
+      expect(FooBehavior.prototype.delegateEntityEvents).to.have.been.calledOnce;
+      expect(BarBehavior.prototype.delegateEntityEvents).to.have.been.calledOnce;
+    });
+  });
+
+  describe('#_undelegateBehaviorEntityEvents', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      FooBehavior = Behavior.extend({});
+      BarBehavior = Behavior.extend({});
+
+      this.sinon.spy(FooBehavior.prototype, 'undelegateEntityEvents');
+      this.sinon.spy(BarBehavior.prototype, 'undelegateEntityEvents');
+
+      behaviorsInstance.behaviors = {foo: FooBehavior, bar: BarBehavior};
+      behaviorsInstance._initBehaviors();
+    });
+
+    it('should invoke undelegateEntityEvents', function() {
+      behaviorsInstance._undelegateBehaviorEntityEvents();
+
+      expect(FooBehavior.prototype.undelegateEntityEvents).to.have.been.calledOnce;
+      expect(BarBehavior.prototype.undelegateEntityEvents).to.have.been.calledOnce;
+    });
+  });
+
+  describe('#_destroyBehaviors', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      FooBehavior = Behavior.extend({});
+      BarBehavior = Behavior.extend({});
+
+      this.sinon.stub(FooBehavior.prototype, 'destroy');
+      this.sinon.stub(BarBehavior.prototype, 'destroy');
+
+      behaviorsInstance.behaviors = {foo: FooBehavior, bar: BarBehavior};
+      behaviorsInstance._initBehaviors();
+    });
+
+    it('should invoke destroy with arguments', function() {
+      let destroyArguments = ['foo', 'bar', 'baz'];
+
+      behaviorsInstance._destroyBehaviors(destroyArguments);
+
+      expect(FooBehavior.prototype.destroy)
+        .to.have.been.calledOnce.and.calledWith('foo', 'bar', 'baz');
+      expect(BarBehavior.prototype.destroy)
+        .to.have.been.calledOnce.and.calledWith('foo', 'bar', 'baz');
+    });
+
+    it('should invoke destroy without arguments', function() {
+      behaviorsInstance._destroyBehaviors([]);
+
+      expect(FooBehavior.prototype.destroy).to.have.been.calledOnce;
+      expect(BarBehavior.prototype.destroy).to.have.been.calledOnce;
+    });
+  });
+
+  describe('#_bindBehaviorUIElements', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      FooBehavior = Behavior.extend({});
+      BarBehavior = Behavior.extend({});
+
+      this.sinon.spy(FooBehavior.prototype, 'bindUIElements');
+      this.sinon.spy(BarBehavior.prototype, 'bindUIElements');
+
+      behaviorsInstance.behaviors = {foo: FooBehavior, bar: BarBehavior};
+      behaviorsInstance._initBehaviors();
+    });
+
+    it('should invoke bindUIElements', function() {
+      behaviorsInstance._bindBehaviorUIElements();
+
+      expect(FooBehavior.prototype.bindUIElements).to.have.been.calledOnce;
+      expect(BarBehavior.prototype.bindUIElements).to.have.been.calledOnce;
+    });
+  });
+
+  describe('#_unbindBehaviorUIElements', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      FooBehavior = Behavior.extend({});
+      BarBehavior = Behavior.extend({});
+
+      this.sinon.spy(FooBehavior.prototype, 'unbindUIElements');
+      this.sinon.spy(BarBehavior.prototype, 'unbindUIElements');
+
+      behaviorsInstance.behaviors = {foo: FooBehavior, bar: BarBehavior};
+      behaviorsInstance._initBehaviors();
+    });
+
+    it('should invoke unbindUIElements', function() {
+      behaviorsInstance._unbindBehaviorUIElements();
+
+      expect(FooBehavior.prototype.unbindUIElements).to.have.been.calledOnce;
+      expect(BarBehavior.prototype.unbindUIElements).to.have.been.calledOnce;
+    });
+  });
+
   //@todo
-  // _getBehaviorTriggers
-  // _getBehaviorEvents
-  // _proxyBehaviorViewProperties
-  // _delegateBehaviorEntityEvents
-  // _undelegateBehaviorEntityEvents
-  // _destroyBehaviors
-  // _bindBehaviorUIElements
-  // _unbindBehaviorUIElements
   // _triggerEventOnBehaviors
 });

--- a/test/unit/mixins/behaviors.spec.js
+++ b/test/unit/mixins/behaviors.spec.js
@@ -245,7 +245,7 @@ describe('Behaviors Mixin', function() {
     });
   });
 
-  describe('#__getBehaviorEvents', function() {
+  describe('#_getBehaviorEvents', function() {
     let behaviorsInstance;
     let FooBehavior;
     let BarBehavior;

--- a/test/unit/mixins/behaviors.spec.js
+++ b/test/unit/mixins/behaviors.spec.js
@@ -1,0 +1,112 @@
+'use strict';
+
+import _ from 'underscore';
+import BehaviorsMixin from '../../../src/mixins/behaviors';
+import Behavior from '../../../src/behavior';
+
+describe('Behaviors Mixin', function() {
+  let Behaviors;
+
+  beforeEach(function() {
+    Behaviors = function() {};
+    Behaviors.extend = Marionette.extend;
+    _.extend(Behaviors.prototype, BehaviorsMixin);
+  });
+
+  describe('#_initBehaviors', function() {
+    let behaviors;
+
+    beforeEach(function() {
+      behaviors = new Behaviors();
+      this.sinon.spy(behaviors, '_getBehaviors');
+      behaviors._initBehaviors();
+    });
+
+    it('should call _getBehaviors', function() {
+      expect(behaviors._getBehaviors).to.be.calledOnce;
+    });
+
+    it('should not have behaviors', function() {
+      expect(behaviors._getBehaviors()).to.be.deep.equal({});
+    });
+  });
+
+  describe('#_getBehaviors', function() {
+    let behaviorsInstance;
+    let initializeStub;
+    let actualBehaviors;
+    let FooBehavior;
+
+    beforeEach(function() {
+      initializeStub = this.sinon.stub();
+      behaviorsInstance = new Behaviors()
+      FooBehavior = Behavior.extend({initialize: initializeStub});
+    });
+
+    describe('should work with behaviorClass option', function() {
+      beforeEach(function() {
+        behaviorsInstance.behaviors = [
+          {
+            behaviorClass: FooBehavior
+          }
+        ];
+        actualBehaviors = behaviorsInstance._getBehaviors();
+      });
+
+      it('should call initialize when a behavior is created', function() {
+        expect(initializeStub).to.be.calledOnce;
+      });
+
+      it('should have behaviors', function() {
+        expect(actualBehaviors.length).to.be.equal(1);
+      });
+    });
+
+    describe('should work without behaviorClass option', function() {
+      beforeEach(function() {
+        behaviorsInstance.behaviors = [FooBehavior];
+        actualBehaviors = behaviorsInstance._getBehaviors();
+      });
+
+      it('should call initialize when a behavior is created', function() {
+        expect(initializeStub).to.be.calledOnce;
+      });
+
+      it('should have behaviors', function() {
+        expect(actualBehaviors.length).to.be.equal(1);
+      });
+    });
+
+    describe('should work with behaviorsLookup', function() {
+      beforeEach(function() {
+        let behaviorOptions = {foo: 'bar'};
+        let behaviors = {
+          'foo': FooBehavior
+        };
+        Marionette.Behaviors.behaviorsLookup = behaviors;
+
+        behaviorsInstance.behaviors = {foo: behaviorOptions};
+        actualBehaviors = behaviorsInstance._getBehaviors();
+      });
+
+      it('should call initialize when a behavior is created', function() {
+        expect(initializeStub).to.be.calledOnce;
+      });
+
+      it('should have behaviors', function() {
+        expect(actualBehaviors.length).to.be.equal(1);
+      });
+    });
+  });
+
+  //@todo
+  // _getBehaviorTriggers
+  // _getBehaviorEvents
+  // _proxyBehaviorViewProperties
+  // _delegateBehaviorEntityEvents
+  // _undelegateBehaviorEntityEvents
+  // _destroyBehaviors
+  // _bindBehaviorUIElements
+  // _unbindBehaviorUIElements
+  // _triggerEventOnBehaviors
+});

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -395,6 +395,7 @@ describe('item view', function() {
 
     it('should return an empty object without data', function() {
       expect(this.itemView.serializeData()).to.deep.equal({});
+      expect(this.itemView.serializeCollection()).to.deep.equal({});
     });
 
     describe('and the view has a model', function() {


### PR DESCRIPTION
### Proposed changes
 - Cleanup Application and Behavior tests

Link to the issue: #3248 

I have several concerns/questions about some stuff.
1. During cleanup I found out that it's hard to get rid of `this.sinon` or other `this. ...` variables. Idea was to import it like either `Application` or `View` but it's not so easy. We have [setup.js](https://github.com/marionettejs/backbone.marionette/blob/v3.1.0/test/setup/setup.js) file where stuff for sinon set  - https://github.com/marionettejs/backbone.marionette/blob/v3.1.0/test/setup/setup.js#L47-L52
So `sinon` has to became exported or smth.
2. Since `Behaviors` are deprecated we can 
either remove some of this functionality from tests - https://github.com/marionettejs/backbone.marionette/compare/next...denar90:tests-cleanup?expand=1#diff-31ea63470331c37566b6cd93d65fa730L20
or keep it with some small change 
https://github.com/marionettejs/backbone.marionette/compare/next...denar90:tests-cleanup?expand=1#diff-31ea63470331c37566b6cd93d65fa730L53
3. Some suits private functionality was removed, like https://github.com/marionettejs/backbone.marionette/compare/next...denar90:tests-cleanup?expand=1#diff-31ea63470331c37566b6cd93d65fa730L177, which cost coverage decreasing.
4. Test libraries are not included into build file for browser testing for example. Maybe we should make them part of the build.
Update:
5. Another this is mixing importing stuff and use global classes like Backbone or Marionette. Here good example https://github.com/marionettejs/backbone.marionette/pull/3255/commits/e5162ada55b691ceda6239896078507e1bcef3ae
There are `Behavior` importing at the top of the file, but test failed so `Marionette.Behavior` was used instead... Same for `Marionette.Behaviors.behaviorsLookup`...