### PR TITLE
Add templateAsEl option to View

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -20,10 +20,13 @@ const ClassOptions = [
   'regionClass',
   'regions',
   'template',
+  'templateAsEl',
   'templateContext',
   'triggers',
   'ui'
 ];
+
+const TEMPLATE_AS_EL = 'TEMPLATE_AS_EL';
 
 // The standard view. Includes view events, automatic rendering
 // of Underscore templates, nested views, and more.
@@ -35,6 +38,10 @@ const View = Backbone.View.extend({
     this._setOptions(options);
 
     this.mergeOptions(options, ClassOptions);
+
+    if (this.templateAsEl) {
+      this.el = TEMPLATE_AS_EL;
+    }
 
     monitorViewEvents(this);
 
@@ -86,7 +93,9 @@ const View = Backbone.View.extend({
   // Overriding Backbone.View's `setElement` to handle
   // if an el was previously defined. If so, the view might be
   // rendered or attached on setElement.
-  setElement() {
+  setElement(el) {
+    if (el === TEMPLATE_AS_EL) { return this; }
+
     const hasEl = !!this.el;
 
     Backbone.View.prototype.setElement.apply(this, arguments);
@@ -145,6 +154,12 @@ const View = Backbone.View.extend({
 
     // Render and add to el
     const html = Renderer.render(template, data, this);
+
+    if (this.templateAsEl) {
+      this.setElement(html);
+      return;
+    }
+
     this.attachElContent(html);
   },
 


### PR DESCRIPTION
Resolves #2357 

Adds `templateAsEl` option to View

This allows the user to bypass the View’s `el`, `tagName`, `className`, `attributes` and use the template as the `el`.

Note that re-rendering will re-delegate events which is much more expensive than using the view’s `el`.

https://jsfiddle.net/9z76s1p1/2/

I'm not sure how much I really like this feature.  It seems like it will have unwelcomed pref issues for little value.  

What could be further addressed is delegating events on the document at which point https://github.com/marionettejs/backbone.marionette/issues/2967 will only get worse if not handled correctly.  I've seen mixed opinions on globally delegated events and performance.

In any case, here it is to play with.  If there is interested in seeing this to completion it'll need specs and docs.  I'd also love to see perf tests to fully understand the hit calling delegateEvents for each render will have.