### PR TITLE
Feature/trigger method event args

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -181,7 +181,7 @@ var MyView = Mn.View.extend({
     console.log('Show the modal');
   },
 
-  onDataEntered: function() {
+  onDataEntered: function(view, event) {
     console.log('Data was entered');
   }
 });

--- a/docs/marionette.features.md
+++ b/docs/marionette.features.md
@@ -5,3 +5,10 @@ Marionette Features are opt-in functionality. That you can enable by setting `Ma
 ##### Goals:
 + make it possible to add breaking changes in a minor release
 + give community members a chance to provide feedback for new functionality
+
+## `triggersStopPropagating`
+
+This flag is set to `true` by default.
+
+It indicates the whether or not [`View.triggers` will call `event.stopPropagating()`](./marionette.view.md#view-triggers-event-object) if not explicitly defined by the trigger.
+In v2 and v3 the default has been true, but for v4 [`false` is being considered](https://github.com/marionettejs/backbone.marionette/issues/2926).

--- a/docs/marionette.features.md
+++ b/docs/marionette.features.md
@@ -6,6 +6,13 @@ Marionette Features are opt-in functionality. That you can enable by setting `Ma
 + make it possible to add breaking changes in a minor release
 + give community members a chance to provide feedback for new functionality
 
+## `triggersPreventDefault`
+
+This flag is set to `true` by default.
+
+It indicates the whether or not [`View.triggers` will call `event.preventDefault()`](./marionette.view.md#view-triggers-event-object) if not explicitly defined by the trigger.
+In v2 and v3 the default has been true, but for v4 [`false` is being considered](https://github.com/marionettejs/backbone.marionette/issues/2926).
+
 ## `triggersStopPropagating`
 
 This flag is set to `true` by default.

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -580,7 +580,7 @@ var MyView = Mn.View.extend({
     'click a': 'link:clicked'
   },
 
-  onLinkClicked: function() {
+  onLinkClicked: function(view, event) {
     console.log('Show the modal');
   }
 });
@@ -599,6 +599,11 @@ events and listening to child events, see the
 [event bubbling documentation](./events.md#child-view-events).
 
 #### View `triggers` Event Object
+
+Event handlers will receive the triggering view as the first argument and the
+DOM Event object as the second. It is _strongly recommended_ that View's handle
+their own DOM event objects. It should be considered a best practice to not
+utilize the DOM event in external listeners.
 
 By default all trigger events are stopped with `preventDefault` and
 `stopPropagation` methods, but you can manually configure the triggers using

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -622,7 +622,7 @@ var MyView = Mn.View.extend({
 });
 ```
 
-The default behavior for calling `stopPropagation()` can be changed with the feature flag [`triggersStopPropagation`](./marionette.features.md).
+The default behavior for calling `preventDefault` can be changed with the feature flag [`triggersPreventDefault`](./marionette.features.md#triggerspreventdefault), and `stopPropagation` can be changed with the feature flag [`triggersStopPropagation`](./marionette.features.md#triggersstoppropagation).
 
 ## Model and Collection events
 

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -34,6 +34,7 @@ multiple views through the `regions` attribute.
     * [Event and Trigger Mapping](#event-and-trigger-mapping)
     * [View `events`](#view-events)
     * [View `triggers`](#view-triggers)
+    * [View `triggers` Event Object](#view-triggers-event-object)
 * [Model and Collection Events](#model-and-collection-events)
   * [Model Events](#model-events)
     * [Function Callback](#function-callback)
@@ -596,6 +597,27 @@ The major benefit of the `triggers` attribute over `events` is that triggered
 events can bubble up to any parent views. For a full explanation of bubbling
 events and listening to child events, see the
 [event bubbling documentation](./events.md#child-view-events).
+
+#### View `triggers` Event Object
+
+By default all trigger events are stopped with `preventDefault` and
+`stopPropagation` methods, but you can manually configure the triggers using
+a hash instead of event name. The example below triggers an event and prevents
+default browser behaviour using `preventDefault` method.
+
+```js
+var MyView = Mn.View.extend({
+  triggers: {
+    'click a': {
+      event: 'link:clicked',
+      preventDefault: true, // this param is optional and will default to true
+      stopPropagation: false
+    }
+  }
+});
+```
+
+The default behavior for calling `stopPropagation()` can be changed with the feature flag [`triggersStopPropagation`](./marionette.features.md).
 
 ## Model and Collection events
 

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -1,7 +1,8 @@
 // Add Feature flags here
 // e.g. 'class' => false
 const FEATURES = {
-  triggersStopPropagation: true
+  triggersStopPropagation: true,
+  triggersPreventDefault: true
 };
 
 function isEnabled(name) {

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -1,6 +1,7 @@
 // Add Feature flags here
 // e.g. 'class' => false
 const FEATURES = {
+  triggersStopPropagation: true
 };
 
 function isEnabled(name) {

--- a/src/mixins/triggers.js
+++ b/src/mixins/triggers.js
@@ -27,7 +27,7 @@ function buildViewTrigger(view, triggerDef) {
       event.stopPropagation();
     }
 
-    view.triggerMethod(eventName, view);
+    view.triggerMethod(eventName, view, event);
   };
 }
 

--- a/src/mixins/triggers.js
+++ b/src/mixins/triggers.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import getUniqueEventName from '../utils/get-unique-event-name';
+import { isEnabled } from '../config/features';
 
 // Internal method to create an event handler for a given `triggerDef` like
 // 'click:foo'
@@ -10,15 +11,20 @@ function buildViewTrigger(view, triggerDef) {
 
   const eventName = triggerDef.event;
   const shouldPreventDefault = triggerDef.preventDefault !== false;
-  const shouldStopPropagation = triggerDef.stopPropagation !== false;
 
-  return function(e) {
+  let shouldStopPropagation = !!triggerDef.stopPropagation;
+
+  if (isEnabled('triggersStopPropagation')) {
+    shouldStopPropagation = triggerDef.stopPropagation !== false;
+  }
+
+  return function(event) {
     if (shouldPreventDefault) {
-      e.preventDefault();
+      event.preventDefault();
     }
 
     if (shouldStopPropagation) {
-      e.stopPropagation();
+      event.stopPropagation();
     }
 
     view.triggerMethod(eventName, view);

--- a/src/mixins/triggers.js
+++ b/src/mixins/triggers.js
@@ -10,7 +10,12 @@ function buildViewTrigger(view, triggerDef) {
   }
 
   const eventName = triggerDef.event;
-  const shouldPreventDefault = triggerDef.preventDefault !== false;
+
+  let shouldPreventDefault = !!triggerDef.preventDefault;
+
+  if (isEnabled('triggersPreventDefault')) {
+    shouldPreventDefault = triggerDef.preventDefault !== false;
+  }
 
   let shouldStopPropagation = !!triggerDef.stopPropagation;
 

--- a/test/unit/view.triggers.spec.js
+++ b/test/unit/view.triggers.spec.js
@@ -124,6 +124,57 @@ describe('view triggers', function() {
     });
   });
 
+  describe('when triggersPreventDefault flag is set to false', function() {
+    beforeEach(function() {
+      Marionette.setEnabled('triggersPreventDefault', false);
+    });
+
+    afterEach(function() {
+      Marionette.setEnabled('triggersPreventDefault', true);
+    });
+
+    describe('triggers should not prevent events by default', function() {
+      beforeEach(function() {
+        this.View = Marionette.View.extend({triggers: this.triggersHash});
+        this.view = new this.View();
+        this.view.on('fooHandler', this.fooHandlerStub);
+
+        this.view.$el.trigger(this.fooEvent);
+      });
+
+      it('should stop propagation by default', function() {
+        expect(this.fooEvent.isPropagationStopped()).to.be.true;
+      });
+
+      it('should not prevent default by default', function() {
+        expect(this.fooEvent.isDefaultPrevented()).to.be.false;
+      });
+    });
+
+    describe('when triggers items are manually configured', function() {
+      beforeEach(function() {
+        this.View = Marionette.View.extend({
+          triggers: {
+            'foo': {
+              event: 'fooHandler',
+              preventDefault: true,
+              stopPropagation: true
+            }
+          }
+        });
+        this.view = new this.View();
+        this.view.on('fooHandler', this.fooHandlerStub);
+
+        this.view.$el.trigger(this.fooEvent);
+      });
+
+      it('should prevent and stop the first view event', function() {
+        expect(this.fooEvent.isDefaultPrevented()).to.be.true;
+        expect(this.fooEvent.isPropagationStopped()).to.be.true;
+      });
+    });
+  });
+
   describe('when triggersStopPropagation flag is set to false', function() {
     beforeEach(function() {
       Marionette.setEnabled('triggersStopPropagation', false);

--- a/test/unit/view.triggers.spec.js
+++ b/test/unit/view.triggers.spec.js
@@ -119,4 +119,51 @@ describe('view triggers', function() {
       expect(this.fooEvent.isPropagationStopped()).to.be.false;
     });
   });
+
+  describe('when triggersStopPropagation flag is set to false', function() {
+    beforeEach(function() {
+      Marionette.setEnabled('triggersStopPropagation', false);
+    });
+
+    describe('triggers should not stop propagation and events by default', function() {
+      beforeEach(function() {
+        this.View = Marionette.View.extend({triggers: this.triggersHash});
+        this.view = new this.View();
+        this.view.on('fooHandler', this.fooHandlerStub);
+
+        this.view.$el.trigger(this.fooEvent);
+      });
+
+      it('should stop propagation by default', function() {
+        expect(this.fooEvent.isPropagationStopped()).to.be.false;
+      });
+
+      it('should prevent default by default', function() {
+        expect(this.fooEvent.isDefaultPrevented()).to.be.true;
+      });
+    });
+
+    describe('when triggers items are manually configured', function() {
+      beforeEach(function() {
+        this.View = Marionette.View.extend({
+          triggers: {
+            'foo': {
+              event: 'fooHandler',
+              preventDefault: true,
+              stopPropagation: true
+            }
+          }
+        });
+        this.view = new this.View();
+        this.view.on('fooHandler', this.fooHandlerStub);
+
+        this.view.$el.trigger(this.fooEvent);
+      });
+
+      it('should prevent and stop the first view event', function() {
+        expect(this.fooEvent.isDefaultPrevented()).to.be.true;
+        expect(this.fooEvent.isPropagationStopped()).to.be.true;
+      });
+    });
+  });
 });

--- a/test/unit/view.triggers.spec.js
+++ b/test/unit/view.triggers.spec.js
@@ -34,6 +34,10 @@ describe('view triggers', function() {
     it('should include the view in the event', function() {
       expect(this.fooHandlerStub.lastCall.args[0]).to.contain(this.view);
     });
+
+    it('should include the event object in the event', function() {
+      expect(this.fooHandlerStub.lastCall.args[1]).to.be.an.instanceOf($.Event);
+    });
   });
 
   describe('when triggers and standard events are both configured', function() {
@@ -125,7 +129,11 @@ describe('view triggers', function() {
       Marionette.setEnabled('triggersStopPropagation', false);
     });
 
-    describe('triggers should not stop propagation and events by default', function() {
+    afterEach(function() {
+      Marionette.setEnabled('triggersStopPropagation', true);
+    });
+
+    describe('triggers should not stop propagation by default', function() {
       beforeEach(function() {
         this.View = Marionette.View.extend({triggers: this.triggersHash});
         this.view = new this.View();


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2926 and https://github.com/marionettejs/backbone.marionette/issues/2975

This was two birds with one stone as they're related, but if one is contentious I can pull it.  I doubt the feature flag would cause any concern, but in the past people haven't wanted to add the originating DOM event to the triggers argument.  Previously in `v2` triggers returnd a pretty odd object containing the `view`, `model`, and `collection` and adding `event` to that seemed rather bad, but now appending it as the 2nd argument seems very reasonable to me.

Again we want to suggest using it only for the `onEvent` methods within the view, but if someone wanted to get around this, using events and triggering an event was drop dead simple anyways.. so not including it isn't enforcing anything.  But if `triggers` does contain the event, at work I can tell other coders to _always_ use `triggers` now instead of "always use `triggers` except when you need the DOM event, then you have to use `events`"

- [ ] TODO: If this is merged the live examples should be updated to reflect the small changes