### PR TITLE
Fix region clean up, when view destroy

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -72,6 +72,10 @@ const Region = MarionetteObject.extend({
 
     this._attachView(view, options);
 
+    if (this._isReplaced) {
+      view.on('before:destroy', this._empty, this);
+    }
+
     this.triggerMethod('show', this, view, options);
     return this;
   },
@@ -225,6 +229,10 @@ const Region = MarionetteObject.extend({
   },
 
   _empty(view, shouldDestroy) {
+    if (this._isReplaced) {
+      view.off('before:destroy', this._empty, this);
+    }
+
     view.off('destroy', this._empty, this);
     this.triggerMethod('before:empty', this, view);
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -337,6 +337,22 @@ describe('region', function() {
               expect(this.$parentEl).to.contain.$html('<div id="region"></div>');
             });
           });
+
+          describe('and restore, when view was self destroyed', function() {
+            beforeEach(function() {
+              this.view.trigger('before:destroy', this.view);
+              this.view._removeElement();
+              this.view.trigger('destroy', this.view);
+            });
+
+            it('should remove the view from the parent', function() {
+              expect(this.$parentEl).to.not.contain.$html(this.view.$el.html());
+            });
+
+            it('should restore the region\'s "el" to the DOM', function() {
+              expect(this.$parentEl).to.contain.$html('<div id="region"></div>');
+            });
+          });
         });
 
       });


### PR DESCRIPTION
Region with "replaceElement" setting don't restore region element, when view was destroyed by self. Because view element remove from DOM before `destroy` event fired. Listen `before:destroy` fix this problem.

