### PR TITLE
Allow showing a template or static string in a region

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -23,6 +23,7 @@ Regions maintain the [View's lifecycle](./viewlifecycle.md#regions-and-the-view-
   * [Using Regions on a view](#using-regions-on-a-view)
 * [Showing a View](#showing-a-view)
   * [Checking whether a region is showing a view](#checking-whether-a-region-is-showing-a-view)
+* [Showing a Template](#showing-a-template)
 * [Emptying a Region](#emptying-a-region)
   * [Preserving Existing Views](#preserving-existing-views)
   * [Detaching Existing Views](#detaching-existing-views)
@@ -260,6 +261,22 @@ mainRegion.hasView() // true
 
 If you show a view in a region with an existing view, Marionette will
 [remove the existing View](#emptying-a-region) before showing the new one.
+
+## Showing a Template
+
+You can show a template or a string directly into a region. Under the hood a
+`Marionette.View` is instantiated and any options you pass to `Region.show` or `View.showChildView`.
+
+```javascript
+var myView = new MyView();
+
+var template = _.template('This is the <%= section %> page');
+var templateContext = templateContext: { section: 'main' };
+
+myView.showChildView('main', template, { templateContext: templateContext });
+
+myView.getRegion('other').show('This text is in another region');
+```
 
 ## Emptying a Region
 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -264,16 +264,20 @@ If you show a view in a region with an existing view, Marionette will
 
 ## Showing a Template
 
-You can show a template or a string directly into a region. Under the hood a
-`Marionette.View` is instantiated and any options you pass to `Region.show` or `View.showChildView`.
+You can show a template or a string directly into a region. Additionally you can pass an object literal containing a template and any other view options. Under the hood a `Marionette.View` is instantiated using the template.
 
 ```javascript
 var myView = new MyView();
 
-var template = _.template('This is the <%= section %> page');
+var template = _.template('This is the <%- section %> page');
 var templateContext = templateContext: { section: 'main' };
 
-myView.showChildView('main', template, { templateContext: templateContext });
+myView.showChildView('main', {
+  template: template,
+  templateContext: templateContext
+});
+
+myView.showChildView('header', _.template('Welcome to the site'));
 
 myView.getRegion('other').show('This text is in another region');
 ```

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -10,7 +10,6 @@ import DelegateEntityEventsMixin from './delegate-entity-events';
 import DomMixin from './dom';
 import TriggersMixin from './triggers';
 import UIMixin from './ui';
-import MarionetteError from '../error';
 
 // MixinOptions
 // - behaviors

--- a/src/region.js
+++ b/src/region.js
@@ -144,7 +144,7 @@ const Region = MarionetteObject.extend({
     return true;
   },
 
-  _getView(view, options) {
+  _getView(view) {
     if (!view) {
       throw new MarionetteError({
         name: 'ViewNotValid',
@@ -163,21 +163,25 @@ const Region = MarionetteObject.extend({
       return view;
     }
 
-    const template = this._getTemplate(view);
-
-    const viewOptions = _.extend({ template }, options);
+    const viewOptions = this._getViewOptions(view);
 
     return new View(viewOptions);
   },
 
   // This allows for a template or a static string to be
   // used as a template
-  _getTemplate(template) {
-    if (_.isFunction(template)) {
-      return template;
+  _getViewOptions(viewOptions) {
+    if (_.isFunction(viewOptions)) {
+      return { template: viewOptions };
     }
 
-    return function() { return template };
+    if (_.isObject(viewOptions)) {
+      return viewOptions;
+    }
+
+    const template = function() { return viewOptions; };
+
+    return { template };
   },
 
   // Override this method to change how the region finds the DOM element that it manages. Return

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -115,6 +115,38 @@ describe('region', function() {
     });
   });
 
+  describe('when showing a template', function() {
+    beforeEach(function() {
+      this.setFixtures('<div id="region"></div>');
+      this.myRegion = new Marionette.Region({
+        el: '#region'
+      });
+
+      this.myRegion.show(_.template('<b>Hello <%= who %>!</b>'), {
+        model: new Backbone.Model({ who: 'World' })
+      });
+    });
+
+    it('should render the template in the region', function() {
+      expect(this.myRegion.$el).to.contain.$html('<b>Hello World!</b>');
+    });
+  });
+
+  describe('when showing an html string', function() {
+    beforeEach(function() {
+      this.setFixtures('<div id="region"></div>');
+      this.myRegion = new Marionette.Region({
+        el: '#region'
+      });
+
+      this.myRegion.show('<b>Hello World!</b>');
+    });
+
+    it('should render the string in the region', function() {
+      expect(this.myRegion.$el).to.contain.$html('<b>Hello World!</b>');
+    });
+  });
+
   describe('when showing an initial view', function() {
     beforeEach(function() {
       this.MyRegion = Backbone.Marionette.Region.extend({

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -122,7 +122,23 @@ describe('region', function() {
         el: '#region'
       });
 
-      this.myRegion.show(_.template('<b>Hello <%= who %>!</b>'), {
+      this.myRegion.show(_.template('<b>Hello World!</b>'));
+    });
+
+    it('should render the template in the region', function() {
+      expect(this.myRegion.$el).to.contain.$html('<b>Hello World!</b>');
+    });
+  });
+
+  describe('when showing a template with viewOptions', function() {
+    beforeEach(function() {
+      this.setFixtures('<div id="region"></div>');
+      this.myRegion = new Marionette.Region({
+        el: '#region'
+      });
+
+      this.myRegion.show({
+        template: _.template('<b>Hello <%- who %>!</b>'),
         model: new Backbone.Model({ who: 'World' })
       });
     });


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2317 and https://github.com/marionettejs/backbone.marionette/issues/2290

I think this feature will be better when we can create regions on the fly from selectors.  For instance imagine this API:

```js
myApp.showView(`
  <div class="header">Hello ${ user.get('name') }</div>
  <div class="main-region main"></div>
  <div class="sidebar-region sidebar"></div>
`);

myApp.getView().showChildView('.main-region', new MainView({ model }));

myApp.getView().showChildView('.sidebar-region', `
  <h2>User Info</h2>
  <div>Select an option to see more info...</div>
`);
```