### PR TITLE
Add license entry to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "homepage": "https://marionettejs.com/",
   "main": "./lib/backbone.marionette.js",
   "version": "3.1.0",
+  "license": "MIT",
   "keywords": [
     "backbone",
     "framework",


### PR DESCRIPTION
### Proposed changes
 - Add `license` definition to bower.json

Link to the issue:

bower.json is lacking the spec-compliant **license** definition (which is already declared in the `license.txt` file). 

As bintray requires this definition in order to deploy webjars, it is not possible to deploy the latest version.