### PR TITLE
Destroy children by view and not model

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -136,9 +136,7 @@ const CollectionView = Backbone.View.extend({
   // in the collection in order to keep the children in sync with the collection.
   // "models" is an array of models and the corresponding views
   // will be removed and destroyed from the CollectionView
-  _removeChildModels(models, {checkEmpty} = {}) {
-    const shouldCheckEmpty = checkEmpty !== false;
-
+  _removeChildModels(models) {
     // Used to determine where to update the remaining
     // sibling view indices after these views are removed.
     const removedViews = this._getRemovedViews(models);
@@ -152,8 +150,8 @@ const CollectionView = Backbone.View.extend({
     // decrement the index of views after this one
     this._updateIndices(removedViews, false);
 
-    if (shouldCheckEmpty) {
-      this._checkEmpty();
+    if (this.isEmpty()) {
+      this._showEmptyView();
     }
   },
 
@@ -163,7 +161,7 @@ const CollectionView = Backbone.View.extend({
 
     // Returning a view means something was removed.
     return _.reduce(models, (removingViews, model) => {
-      const view = this.children.findByModel(model);
+      const view = model && this.children.findByModel(model);
 
       if (!view || view._isDestroyed) {
         return removingViews;
@@ -364,7 +362,7 @@ const CollectionView = Backbone.View.extend({
   _renderChildren() {
     if (this._isRendered) {
       this._destroyEmptyView();
-      this._destroyChildren({checkEmpty: false});
+      this._destroyChildren();
     }
 
     const models = this._filteredSortedModels();
@@ -662,13 +660,6 @@ const CollectionView = Backbone.View.extend({
     return models.length === 0;
   },
 
-  // If empty, show the empty view
-  _checkEmpty() {
-    if (this.isEmpty()) {
-      this._showEmptyView();
-    }
-  },
-
   // You might need to override this if you've overridden attachHtml
   attachBuffer(collectionView, buffer) {
     this.appendChildren(collectionView.el, buffer);
@@ -732,7 +723,7 @@ const CollectionView = Backbone.View.extend({
 
   // called by ViewMixin destroy
   _removeChildren() {
-    this._destroyChildren({checkEmpty: false});
+    this._destroyChildren();
   },
 
   // Destroy the child views that this collection view is holding on to, if any
@@ -742,8 +733,8 @@ const CollectionView = Backbone.View.extend({
     }
 
     this.triggerMethod('before:destroy:children', this);
-    const childModels = this.children.map('model');
-    this._removeChildModels(childModels, options);
+    this.children.each(_.bind(this._removeChildView, this));
+    this.children._updateLength();
     this.triggerMethod('destroy:children', this);
   },
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -175,18 +175,6 @@ const CollectionView = Backbone.View.extend({
     }, []);
   },
 
-  _findGreatestIndexedView(views) {
-
-    return _.reduce(views, (greatestIndexedView, view) => {
-      // Even if the index is `undefined`, a view will get returned.
-      if (!greatestIndexedView || greatestIndexedView._index < view._index) {
-        return view;
-      }
-
-      return greatestIndexedView;
-    }, undefined);
-  },
-
   _removeChildView(view) {
     this.triggerMethod('before:remove:child', this, view);
 
@@ -584,14 +572,16 @@ const CollectionView = Backbone.View.extend({
       return;
     }
 
-    const view = _.isArray(views) ? this._findGreatestIndexedView(views) : views;
+    const view = _.isArray(views) ? _.max(views, '_index') : views;
 
-    // update the indexes of views after this one
-    this.children.each((laterView) => {
-      if (laterView._index >= view._index) {
-        laterView._index += increment ? 1 : -1;
-      }
-    });
+    if (_.isObject(view)) {
+      // update the indexes of views after this one
+      this.children.each((laterView) => {
+        if (laterView._index >= view._index) {
+          laterView._index += increment ? 1 : -1;
+        }
+      });
+    }
   },
 
   _renderView(view) {

--- a/test/unit/collection-view.reset.spec.js
+++ b/test/unit/collection-view.reset.spec.js
@@ -9,27 +9,29 @@ describe('collection view - reset', function() {
     });
 
     this.onRenderStub = this.sinon.stub();
-    this.destroyChildrenStub = this.sinon.stub();
 
     this.CollectionView = Backbone.Marionette.CollectionView.extend({
       childView: this.View,
-      onRender: this.onRenderStub,
-      _destroyChildren: this.destroyChildrenStub
+      onRender: this.onRenderStub
     });
 
     this.collectionView = new this.CollectionView({
       collection: this.collection
     });
+
+    this.sinon.spy(this.collectionView, '_destroyChildren');
   });
 
   describe('when a collection is reset after the view is loaded', function() {
     beforeEach(function() {
       this.collectionView.render();
+      var childViewAtEnd = new Marionette.View({template: _.constant('END')});
+      this.collectionView.addChildView(childViewAtEnd, this.collection.length);
       this.collection.reset([{foo: 'bar'}, {foo: 'baz'}]);
     });
 
     it('should destroy all open child views', function() {
-      expect(this.destroyChildrenStub).to.have.been.called;
+      expect(this.collectionView._destroyChildren).to.have.been.called;
     });
 
     it('should append the html for each childView', function() {

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -776,7 +776,7 @@ describe('collection view', function() {
       this.sinon.spy(this.collectionView, 'onDestroy');
       this.sinon.spy(this.collectionView, 'onBeforeDestroy');
       this.sinon.spy(this.collectionView, 'trigger');
-      this.sinon.spy(this.collectionView, '_checkEmpty');
+      this.sinon.spy(this.collectionView, 'isEmpty');
 
       this.collectionView.bind('destroy:children', this.destroyHandler);
 
@@ -865,7 +865,7 @@ describe('collection view', function() {
     });
 
     it('should not call checkEmpty', function() {
-      expect(this.collectionView._checkEmpty).to.have.not.been.called;
+      expect(this.collectionView.isEmpty).to.have.not.been.called;
     });
 
     it('should return the CollectionView', function() {
@@ -924,40 +924,12 @@ describe('collection view', function() {
       this.childView1 = this.collectionView.children.findByIndex(1);
       this.sinon.spy(this.childView1, 'remove');
 
-      this.childrenViews = this.collectionView.children.map(_.identity);
-
-      this.sinon.spy(this.collectionView, '_destroyChildren');
-      this.sinon.spy(this.collectionView, '_checkEmpty');
       this.collectionView._destroyChildren();
     });
 
     it('should call the "remove" method on each child', function() {
       expect(this.childView0.remove).to.have.been.called;
       expect(this.childView1.remove).to.have.been.called;
-    });
-
-    it('should call checkEmpty', function() {
-      expect(this.collectionView._checkEmpty).to.have.been.calledOnce;
-    });
-
-    describe('with the checkEmpty flag set as false', function() {
-      it('should not call _checkEmpty', function() {
-        this.collectionView._destroyChildren({checkEmpty: false});
-        expect(this.collectionView._checkEmpty).to.have.been.calledOnce;
-      });
-    });
-
-    describe('with the checkEmpty flag set as true', function() {
-      it('should call _checkEmpty', function() {
-        this.collectionView.collection.add({id: 3});
-        this.collectionView._destroyChildren({checkEmpty: true});
-        expect(this.collectionView._checkEmpty).to.have.been.calledTwice;
-      });
-
-      it('should not call _checkEmpty when collection is empty', function() {
-        this.collectionView._destroyChildren({checkEmpty: true});
-        expect(this.collectionView._checkEmpty).to.have.been.calledOnce;
-      });
     });
   });
 


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/3278

When destroy all children, some view may not have a model.
This also removes the need for the `checkEmpty` flag and subsequent tests around that flag.