### PR TITLE
Fix region clean up, when view destroy

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -194,6 +194,8 @@ const Region = MarionetteObject.extend({
     // always restore the el to ensure the regions el is present before replacing
     this._restoreEl();
 
+    view.on('before:destroy', this._restoreEl, this);
+
     this.replaceEl(view.el, this.el);
 
     this._isReplaced = true;

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -385,6 +385,23 @@ describe('region', function() {
               expect(this.$parentEl).to.contain.$html('<div id="region"></div>');
             });
           });
+
+          describe('when destroying the view', function() {
+            beforeEach(function() {
+              var view = new Marionette.View({ template: false });
+
+              this.region.show(view);
+              view.destroy();
+            });
+
+            it('should remove the view from the parent', function() {
+              expect(this.$parentEl).to.not.contain.$html(this.view.$el.html());
+            });
+
+            it('should restore the region\'s "el" to the DOM', function() {
+              expect(this.$parentEl).to.contain.$html('<div id="region"></div>');
+            });
+          });
         });
 
       });


### PR DESCRIPTION
Replaces: https://github.com/marionettejs/backbone.marionette/pull/3262

Region with "replaceElement" setting don't restore region element, when view was destroyed by self. Because view element remove from DOM before destroy event fired. Listen before:destroy fix this problem.