### PR TITLE
replaceEl should noop if the els are already the same

### DIFF
--- a/src/mixins/dom.js
+++ b/src/mixins/dom.js
@@ -17,6 +17,10 @@ export default {
   },
 
   replaceEl(newEl, oldEl) {
+    if (newEl === oldEl) {
+      return;
+    }
+
     const parent = oldEl.parentNode;
 
     if (!parent) {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -404,6 +404,23 @@ describe('region', function() {
           });
         });
 
+        describe('when setting the "replaceElement" class option and els are the same', function() {
+          beforeEach(function() {
+            this.$parentEl = this.region.$el.parent();
+            this.regionHtml = this.$parentEl.html();
+            this.region.replaceElement = true;
+            this.region.show(new this.MyView({ el: this.region.el }));
+          });
+
+          it('should have replaced the "el"', function() {
+            expect(this.region.isReplaced()).to.be.true;
+          });
+
+          it('should append the view HTML to the parent "el"', function() {
+            expect(this.$parentEl).to.contain.$html(this.region.currentView.$el.html());
+          });
+        });
+
       });
 
       describe('preventDestroy: false', function() {


### PR DESCRIPTION
To my surprise, `parentEl.replaceChild(childEl, childEl)` is far slower than returning if they’re the same element.

https://jsperf.com/replacechild-of-same-child/1

I don’t love the test exactly, but it follows suit with what is currently there.
