### PR TITLE
Fix code sample for modelEvents in View documentation

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -614,7 +614,7 @@ var MyView = Mn.View.extend({
     'change:attribute': 'actOnChange'
   },
 
-  actOnChange: function(value, model) {
+  actOnChange: function(model, value) {
     console.log('New value: ' + value);
   }
 });


### PR DESCRIPTION
There is an error In the modelEvents code sample, the callback function arguments are in the wrong order.

The model is passed first and then the value.