### PR TITLE
bug fix #3314

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -438,7 +438,7 @@ const CollectionView = Backbone.View.extend({
     } else if (comparator.length === 1) {
       return _.sortBy(models, _.bind(comparator, this));
     } else {
-      return models.sort(_.bind(comparator, this));
+      return _.clone(models).sort(_.bind(comparator, this));
     }
   },
 

--- a/test/unit/sorted-views.spec.js
+++ b/test/unit/sorted-views.spec.js
@@ -205,6 +205,7 @@ describe('collection/composite view sorting', function() {
   describe('when working with collections with a custom view comparator', function() {
     beforeEach(function() {
       this.collection.comparator = 'foo';
+      this.startCollectionOrder = this.collection.map('foo').join();
 
       this.collectionView = new this.CollectionView({
         childView: this.ChildView,
@@ -215,7 +216,9 @@ describe('collection/composite view sorting', function() {
       this.compositeView = new this.CompositeView({
         childView: this.ChildView,
         collection: this.collection,
-        viewComparator: function(model) { return model.get('bar'); }
+        viewComparator: function(modelA, modelB) {
+          return modelA.get('bar') > modelB.get('bar') ? 1 : -1;
+        }
       });
 
       this.sinon.spy(this.collectionView, 'resortView');
@@ -223,6 +226,11 @@ describe('collection/composite view sorting', function() {
 
       this.collectionView.render();
       this.compositeView.render();
+      this.endCollectionOrder = this.collection.map('foo').join();
+    });
+
+    it('should not change collection order', function() {
+      expect(this.startCollectionOrder).to.equal(this.endCollectionOrder);
     });
 
     describe('when adding a model', function() {


### PR DESCRIPTION
### Proposed changes
 
As this example:
https://jsfiddle.net/37huLw61/
the bug was caused by Array.prototype.sort (mutate data).

```javascript
  _sortModelsBy(models, comparator) {
    if (typeof comparator === 'string') {
      return _.sortBy(models, (model) => {
        return model.get(comparator);
      });
    } else if (comparator.length === 1) {
      return _.sortBy(models, _.bind(comparator, this));
    } else {
      // FIX: clone the array before sorting it 
      return _.clone(models).sort(_.bind(comparator, this));
    }
  },
```

Link to the issue: #3314