### PR TITLE
Refactor region to simplify implementation of animated regions

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -443,8 +443,6 @@ var EmptyMsgRegion = Mn.Region.extend({
 ```
 [Live example](https://jsfiddle.net/marionettejs/c1nacq0c/1/)
 
-> `hasView` will not work reliably inside `onEmpty` because will always evaluate to false
-
 ## Set How View's `el` Is Attached
 
 Override the region's `attachHtml` method to change how the view is attached

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -30,7 +30,9 @@ Regions maintain the [View's lifecycle](./viewlifecycle.md#regions-and-the-view-
   * [Preserving Existing Views](#preserving-existing-views)
   * [Detaching Existing Views](#detaching-existing-views)
 * [`reset` A Region](#reset-a-region)
+* [Check If View Is Being Swapped By Another](#check-if-view-is-being-swapped-by-another)
 * [Set How View's `el` Is Attached](#set-how-views-el-is-attached)
+* [Configure How To Remove View](#configure-how-to-remove-view)
 
 ## Defining the Application Region
 
@@ -421,6 +423,28 @@ myRegion.reset();
 
 This can be useful in unit testing your views.
 
+## Check If View Is Being Swapped By Another
+
+The `isSwappingView` method returns if a view is being swapped by another one. It's useful
+inside region lifecycle events / methods.
+
+The example will show an message when the region is empty  
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var EmptyMsgRegion = Mn.Region.extend({
+  onEmpty() {
+    if (!this.isSwappingView()) {
+      this.$el.append('Empty Region');
+    }    
+  }  
+});
+```
+[Live example](https://jsfiddle.net/marionettejs/c1nacq0c/1/)
+
+> `hasView` will not work reliably inside `onEmpty` because will always evaluate to false
+
 ## Set How View's `el` Is Attached
 
 Override the region's `attachHtml` method to change how the view is attached
@@ -463,3 +487,60 @@ var MyView = Mn.View.extend({
   }
 });
 ```
+
+## Configure How To Remove View
+
+Override the region's `removeView` method to change how and when the view is destroyed / removed
+from the DOM. This method receives one parameter - the view to remove.
+
+The default implementation of `removeView` is:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+Mn.Region.prototype.removeView = function(view){
+  this.destroyView(view);
+}
+```
+
+> `destroyView` method destroys the view taking into consideration if is
+> a Marionette.View descendant or vanilla Backbone view. It can be replaced
+> by a `view.destroy()` call if is ensured that view descends from Marionette.View   
+
+This example will animate with a fade effect showing and hiding the view:
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var AnimatedRegion = Mn.Region.extend({
+  attachHtml(view) {    
+    view.$el
+      .css({display: 'none'})
+      .appendTo(this.$el);      
+    if (!this.isSwappingView()) view.$el.fadeIn('slow');
+  },
+  
+  removeView(view) {
+    view.$el.fadeOut('slow', () => {
+      this.destroyView(view); // or view.destroy() for Marionette.View
+      this.currentView.$el.fadeIn('slow');
+    })    
+  }  
+});
+
+var MyView = Mn.View.extend({
+  regions: {
+    animatedRegion: {
+      regionClass: AnimatedRegion,
+      el: '#animated-region'
+    }
+  }
+});
+```
+
+[Live example](https://jsfiddle.net/marionettejs/c1nacq0c/2/)
+
+Using a similar approach is possible to create a region animated with CSS:
+
+[Live example](https://jsfiddle.net/marionettejs/9ys4d57x/1/)
+ 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -521,11 +521,12 @@ var AnimatedRegion = Mn.Region.extend({
   },
   
   removeView(view) {
-    view.$el.fadeOut('slow', () => {
-      this.destroyView(view); // or view.destroy() for Marionette.View
-      this.currentView.$el.fadeIn('slow');
+    var self = this;
+    view.$el.fadeOut('slow', function() {
+      self.destroyView(view);
+      if (self.currentView) self.currentView.$el.fadeIn('slow');
     })    
-  }  
+  }   
 });
 
 var MyView = Mn.View.extend({
@@ -538,9 +539,9 @@ var MyView = Mn.View.extend({
 });
 ```
 
-[Live example](https://jsfiddle.net/marionettejs/c1nacq0c/2/)
+[Live example](https://jsfiddle.net/marionettejs/c1nacq0c/3/)
 
 Using a similar approach is possible to create a region animated with CSS:
 
-[Live example](https://jsfiddle.net/marionettejs/9ys4d57x/1/)
+[Live example](https://jsfiddle.net/marionettejs/9ys4d57x/2/)
  

--- a/src/region.js
+++ b/src/region.js
@@ -308,7 +308,7 @@ const Region = MarionetteObject.extend({
   },
 
   removeView(view) {
-    this.destroyView(view)
+    this.destroyView(view);
   },
 
   detachView() {

--- a/src/region.js
+++ b/src/region.js
@@ -269,7 +269,11 @@ const Region = MarionetteObject.extend({
     delete this.currentView;
 
     if (!view._isDestroyed) {
-      this._removeView(view, shouldDestroy);
+      if (shouldDestroy) {
+        this._removeView(view);
+      } else {
+        this._detachView(view);
+      }
       this._stopChildViewEvents(view);
     }
 
@@ -284,12 +288,7 @@ const Region = MarionetteObject.extend({
     this._parentView.stopListening(view);
   },
 
-  _removeView(view, shouldDestroy) {
-    if (!shouldDestroy) {
-      this._detachView(view);
-      return;
-    }
-
+  _removeView(view) {
     if (view.destroy) {
       view.destroy();
     } else {

--- a/src/region.js
+++ b/src/region.js
@@ -300,11 +300,16 @@ const Region = MarionetteObject.extend({
   },
 
   destroyView(view) {
+    if (view._isDestroyed) {
+      return this;
+    }
+
     if (view.destroy) {
       view.destroy();
     } else {
       destroyBackboneView(view);
     }
+    return this;
   },
 
   removeView(view) {

--- a/src/region.js
+++ b/src/region.js
@@ -270,7 +270,7 @@ const Region = MarionetteObject.extend({
 
     if (!view._isDestroyed) {
       if (shouldDestroy) {
-        this._removeView(view);
+        this.removeView(view);
       } else {
         this._detachView(view);
       }
@@ -288,7 +288,7 @@ const Region = MarionetteObject.extend({
     this._parentView.stopListening(view);
   },
 
-  _removeView(view) {
+  removeView(view) {
     if (view.destroy) {
       view.destroy();
     } else {

--- a/src/region.js
+++ b/src/region.js
@@ -288,12 +288,16 @@ const Region = MarionetteObject.extend({
     this._parentView.stopListening(view);
   },
 
-  removeView(view) {
+  destroyView(view) {
     if (view.destroy) {
       view.destroy();
     } else {
       destroyBackboneView(view);
     }
+  },
+
+  removeView(view) {
+    this.destroyView(view)
   },
 
   detachView() {

--- a/src/region.js
+++ b/src/region.js
@@ -23,7 +23,7 @@ const Region = MarionetteObject.extend({
   cidPrefix: 'mnr',
   replaceElement: false,
   _isReplaced: false,
-  swappingView: false,
+  _isSwappingView: false,
 
   constructor(options) {
     this._setOptions(options);
@@ -59,7 +59,7 @@ const Region = MarionetteObject.extend({
 
     if (view === this.currentView) { return this; }
 
-    this.swappingView = !!this.currentView;
+    this._isSwappingView = !!this.currentView;
 
     this.triggerMethod('before:show', this, view, options);
 
@@ -78,7 +78,7 @@ const Region = MarionetteObject.extend({
 
     this.triggerMethod('show', this, view, options);
 
-    this.swappingView = false;
+    this._isSwappingView = false;
 
     return this;
   },
@@ -235,6 +235,11 @@ const Region = MarionetteObject.extend({
   // Check to see if the region's el was replaced.
   isReplaced() {
     return !!this._isReplaced;
+  },
+
+  // Check to see if a view is being swapped by another
+  isSwappingView() {
+    return !!this._isSwappingView;
   },
 
   // Override this method to change how the new view is appended to the `$el` that the

--- a/src/region.js
+++ b/src/region.js
@@ -23,6 +23,7 @@ const Region = MarionetteObject.extend({
   cidPrefix: 'mnr',
   replaceElement: false,
   _isReplaced: false,
+  swappingView: false,
 
   constructor(options) {
     this._setOptions(options);
@@ -58,6 +59,8 @@ const Region = MarionetteObject.extend({
 
     if (view === this.currentView) { return this; }
 
+    this.swappingView = !!this.currentView;
+
     this.triggerMethod('before:show', this, view, options);
 
     // Assume an attached view is already in the region for pre-existing DOM
@@ -74,6 +77,9 @@ const Region = MarionetteObject.extend({
     this.currentView = view;
 
     this.triggerMethod('show', this, view, options);
+
+    this.swappingView = false;
+
     return this;
   },
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -56,6 +56,10 @@ describe('region', function() {
         (Backbone.Marionette.Region.extend({el: $('the-ghost-of-lechuck')[0]}))();
       }).to.throw;
     });
+
+    it('should not been swapping view', function() {
+      expect(this.customRegion.isSwappingView()).to.be.false;
+    });
   });
 
   describe('when creating a new region and the "el" does not exist in DOM', function() {
@@ -165,10 +169,13 @@ describe('region', function() {
 
   describe('when showing an initial view', function() {
     beforeEach(function() {
+      var self = this;
       this.MyRegion = Backbone.Marionette.Region.extend({
         el: '#region',
         onBeforeShow: this.sinon.stub(),
-        onShow: this.sinon.stub(),
+        onShow: this.sinon.spy(function() {
+          self.isSwappingOnShow = this.isSwappingView();
+        }),
         onBeforeEmpty: this.sinon.stub(),
         onEmpty: this.sinon.stub(),
       });
@@ -230,6 +237,10 @@ describe('region', function() {
       expect(this.region.onBeforeShow).to.have.been.calledWith(this.region, this.view, this.showOptions);
     });
 
+    it('should not been swapping view', function() {
+      expect(this.isSwappingOnShow).to.be.false;
+    });
+
     describe('region and view event ordering', function() {
       it('triggers before:show before before:render', function() {
         expect(this.region.onBeforeShow).to.have.been.calledBefore(this.view.onBeforeRender);
@@ -267,6 +278,10 @@ describe('region', function() {
 
       it('should still have a view', function() {
         expect(this.region.hasView()).to.equal(true);
+      });
+
+      it('should been swapping view', function() {
+        expect(this.isSwappingOnShow).to.be.true;
       });
     });
 
@@ -595,7 +610,7 @@ describe('region', function() {
 
       it('should not call removeView', function() {
         expect(this.region.removeView).not.to.have.been.called;
-      })
+      });
     });
   });
 
@@ -850,10 +865,13 @@ describe('region', function() {
 
   describe('when destroying the current view', function() {
     beforeEach(function() {
+      var self = this;
       this.MyRegion = Backbone.Marionette.Region.extend({
         el: '#region',
         onBeforeEmpty: this.sinon.stub(),
-        onEmpty: this.sinon.stub()
+        onEmpty: this.sinon.spy(function() {
+          self.isSwappingOnEmpty = this.isSwappingView();
+        })
       });
 
       this.MyView = Backbone.View.extend({
@@ -914,6 +932,10 @@ describe('region', function() {
 
     it('should not have a view', function() {
       expect(this.region.hasView()).to.equal(false);
+    });
+
+    it('should not been swapping view', function() {
+      expect(this.isSwappingOnEmpty).to.be.false;
     });
   });
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -779,6 +779,17 @@ describe('region', function() {
       }).not.to.throw(new Error('View (cid: "' + this.view.cid +
           '") has already been destroyed and cannot be used.'));
     });
+
+    describe('and destroyView is called', function() {
+      beforeEach(function() {
+        this.region.destroyView(this.view);
+      });
+
+      it('should not call view.destroy', function() {
+        expect(this.view.destroy).to.have.not.been.called;
+      })
+    })
+
   });
 
   describe('when a view is already destroyed and showing another', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -296,6 +296,7 @@ describe('region', function() {
         this.sinon.spy(this.view1, 'destroy');
         this.sinon.spy(this.view1, 'off');
         this.sinon.spy(this.view2, 'destroy');
+        this.sinon.spy(this.region, 'removeView');
 
         this.region.show(this.view1);
       });
@@ -331,6 +332,10 @@ describe('region', function() {
         // https://github.com/marionettejs/backbone.marionette/issues/2159#issue-52745401
         it('should still have view1\'s, event bindings', function() {
           expect(jQuery._data(this.view.el, 'events').click).to.be.defined;
+        });
+
+        it('should not call removeView', function() {
+          expect(this.region.removeView).not.to.have.been.called;
         });
 
         describe('when setting the "replaceElement" class option', function() {
@@ -434,6 +439,10 @@ describe('region', function() {
 
         it('view1 should not reference region', function() {
           expect(this.view1._parent).to.be.undefined;
+        });
+
+        it('should call removeView', function() {
+          expect(this.region.removeView).to.have.been.called;
         });
       });
 
@@ -550,6 +559,8 @@ describe('region', function() {
         this.regionEmptyStub = this.sinon.stub();
         this.region.on('empty', this.regionEmptyStub);
 
+        this.sinon.spy(this.region, 'removeView');
+
         this.detachedView = this.region.detachView();
         this.noDetachedView = this.region.detachView();
       });
@@ -581,6 +592,10 @@ describe('region', function() {
       it('should not have a parent', function() {
         expect(this.detachedView).to.not.have.property('_parent');
       });
+
+      it('should not call removeView', function() {
+        expect(this.region.removeView).not.to.have.been.called;
+      })
     });
   });
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -57,7 +57,7 @@ describe('region', function() {
       }).to.throw;
     });
 
-    it('should not been swapping view', function() {
+    it('should not be swapping view', function() {
       expect(this.customRegion.isSwappingView()).to.be.false;
     });
   });
@@ -237,7 +237,7 @@ describe('region', function() {
       expect(this.region.onBeforeShow).to.have.been.calledWith(this.region, this.view, this.showOptions);
     });
 
-    it('should not been swapping view', function() {
+    it('should not be swapping view', function() {
       expect(this.isSwappingOnShow).to.be.false;
     });
 
@@ -280,7 +280,7 @@ describe('region', function() {
         expect(this.region.hasView()).to.equal(true);
       });
 
-      it('should been swapping view', function() {
+      it('should be swapping view', function() {
         expect(this.isSwappingOnShow).to.be.true;
       });
     });
@@ -934,7 +934,7 @@ describe('region', function() {
       expect(this.region.hasView()).to.equal(false);
     });
 
-    it('should not been swapping view', function() {
+    it('should not be swapping view', function() {
       expect(this.isSwappingOnEmpty).to.be.false;
     });
   });


### PR DESCRIPTION
### Proposed changes
 - Rename _removeView to removeView
 - Add destroyView method and use it in removeView
 - Move shouldDestroy check and detachView code out of removeView
 - Add swappingView flag, to allow to check if there is already a currentView that is being swapped by another

Link to the issue:
#3312 

This change allows to implement animated region as follows:

```
class AnimatedRegion extends Marionette.Region {

  attachHtml(view) {    
    view.$el
      .css({display: 'none'})
      .appendTo(this.$el);      
    if (!this.swappingView) view.$el.fadeIn('slow')
  }
  
  removeView(view) {
    view.$el.fadeOut('slow', () => {
        this.destroyView(view) // or view.remove if sure that view is a Mn.View
        this.currentView.$el.fadeIn('slow')
    })    
  }  
}
```

CSS animation could be implemented with similar code as demonstrated by http://codepen.io/blikblum/pen/PppGmG

`destroyView` is optional since is possible to just call view.destroy for Mn.View or call the overridden method using ES6 super to take care of BB.View. But this would not fit the current API that AFAIK does not recommend / require calling super methods

