### PR TITLE
Support custom renderer

### DIFF
--- a/docs/marionette.renderer.md
+++ b/docs/marionette.renderer.md
@@ -1,15 +1,68 @@
-# Marionette.Renderer
+# Marionette Renderer
+
+The renderer that Marionette uses to render data into a template can now be set
+per `Marionette.View` class via the [`Marionette.View.setRenderer` function](#setting-a-renderer).
+This feature supersedes modifying the external [`Marionette.Renderer`](#deprecated-marionette-renderer).
+The default renderer is still the `Marionette.Renderer.render` method so that
+documentation still applies.
+
+## Documentation Index
+
+* [Deprecated Marionette.Renderer](#deprecated-marionette-renderer)
+* [Setting a Renderer](#setting-a-renderer)
+* [Basic Usage](#basic-usage)
+* [Pre-compiled Templates](#pre-compiled-templates)
+* [Custom Template Selection And Rendering](#custom-template-selection-and-rendering)
+* [Using Pre-compiled Templates](#using-pre-compiled-templates)
+
+## Deprecated Marionette.Renderer
+
+Customizing the `Renderer` object has been deprecated in favor of the [`setRenderer` method](#setting-a-renderer).
 
 The `Renderer` object was extracted from the `View` rendering process, in order
 to create a consistent and re-usable method of rendering a template with or
 without data.
 
-## Documentation Index
+## Setting a Renderer
 
-* [Basic Usage](#basic-usage)
-* [Pre-compiled Templates](#pre-compiled-templates)
-* [Custom Template Selection And Rendering](#custom-template-selection-and-rendering)
-* [Using Pre-compiled Templates](#using-pre-compiled-templates)
+You can set the renderer for a View Class by using the class method `setRenderer`.
+The renderer accepts two arguments. The first is the template passed to the view,
+and the second argument is the data to be rendered into the template. The renderer
+should return a string containing the result of applying the data to the template.
+
+```javascript
+Marionette.View.setRenderer(function(template, data) {
+  return _.template(template)(data);
+});
+
+var myView = new Marionette.View({
+  template: 'Hello <%- name %>!',
+  model: new Backbone.Model({ name: 'World' })
+});
+
+myView.render();
+
+myView.el === '<div>Hello World!</div>';
+```
+
+The renderer can also be customized separately on any extended View.
+
+```javascript
+var MyHBSView = Marionette.View.extend();
+
+MyHBSView.setRenderer(function(template, data) {
+  return Handlebars.compile(template)(data);
+});
+
+var myHBSView = new MyHBSView({
+  template: 'Hello {{ name }}!',
+  model: new Backbone.Model({ name: 'World' })
+});
+
+myHBSView.render();
+
+myHBSView.el === '<div>Hello World!</div>';
+```
 
 ## Basic Usage
 
@@ -26,9 +79,8 @@ var html = Mn.Renderer.render(template, data);
 // do something with the HTML here
 ```
 
-If you pass a `template` that coerces to a falsy value -
-[but not false](./marionette.view.md#managing-an-existing-page) - the `render`
-method will  throw an exception stating that there was no template provided.
+If you pass a `template` that coerces to a falsy value the `render`
+method will throw an exception stating that there was no template provided.
 
 ## Pre-compiled Templates
 
@@ -52,11 +104,12 @@ only needs to be a function that returns valid HTML as a string from the
 
 ## Custom Template Selection And Rendering
 
-By default, the renderer will take a jQuery selector object as the first
-parameter, and a JSON data object as the optional second parameter, and View
-object or CompositeView object as the optional third parameter. It then uses
-the `TemplateCache` to load the template by the specified selector, and renders
-the template with the data provided (if any) using underscore templates.
+By default, the renderer will take either a [precompiled template](#pre-compiled-templates)
+or a jQuery selector object as the first parameter, and a JSON data object as the optional
+second parameter, and View object or CompositeView object as the optional third
+parameter. If the first parameter is not precompiled it then uses the `TemplateCache`
+to load the template by the specified selector, and renders the template with the
+data provided (if any) using underscore templates.
 
 If you wish to override the way the template is loaded, see the `TemplateCache`
 object.
@@ -91,37 +144,6 @@ Mn.Renderer.render = function(template, data){
 
 See the [Documentation for `TemplateCache`](./marionette.templatecache.md) for
 more detailed information.
-
-## Using Pre-compiled Templates
-
-You can easily replace the standard template rendering functionality with a
-pre-compiled template, such as those provided by the JST or TPL plugins for
-AMD/RequireJS.
-
-To do this, just override the `render` method to return your executed template
-with the data.
-
-```javascript
-var Mn = require('backbone.marionette');
-
-Mn.Renderer.render = function(template, data) {
-  return template(data);
-};
-```
-
-Then you can specify the pre-compiled template function as your view's
-`template` attribute:
-
-```javascript
-var Mn = require('backbone.marionette');
-var myPrecompiledTemplate = _.template('<div>some template</div>');
-
-Mn.View.extend({
-  template: myPrecompiledTemplate
-});
-```
-
-[Live example](https://jsfiddle.net/marionettejs/kzths849/)
 
 For more information on templates in general, see the
 [Documentation for templates](./template.md).

--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -173,7 +173,7 @@ const CompositeView = CollectionView.extend({
 
 // To prevent duplication but allow the best View organization
 // Certain View methods are mixed directly into the deprecated CompositeView
-const MixinFromView = _.pick(View.prototype, 'serializeModel', 'getTemplate', '_renderTemplate', 'mixinTemplateContext', 'attachElContent');
+const MixinFromView = _.pick(View.prototype, 'serializeModel', 'getTemplate', '_renderTemplate', '_renderHtml', 'mixinTemplateContext', 'attachElContent');
 _.extend(CompositeView.prototype, MixinFromView);
 
 export default CompositeView;

--- a/src/view.js
+++ b/src/view.js
@@ -146,8 +146,13 @@ const View = Backbone.View.extend({
     const data = this.mixinTemplateContext(this.serializeData());
 
     // Render and add to el
-    const html = Renderer.render(template, data, this);
+    const html = this._renderHtml(template, data);
     this.attachElContent(html);
+  },
+
+  // Renders the data into the template
+  _renderHtml(template, data) {
+    return Renderer.render(template, data, this);
   },
 
   // Get the template for this view
@@ -196,6 +201,11 @@ const View = Backbone.View.extend({
       .map('currentView')
       .compact()
       .value();
+  }
+}, {
+  // Sets the renderer for the Marionette.View class
+  setRenderer(renderer) {
+    this.prototype._renderHtml = renderer;
   }
 });
 

--- a/test/unit/view.renderer.js
+++ b/test/unit/view.renderer.js
@@ -1,0 +1,80 @@
+import _ from 'underscore';
+import Backbone from 'backbone';
+import View from '../../src/view';
+
+describe('View.setRenderer', function() {
+  let ViewClass;
+  let ViewSubClass;
+  let model;
+
+  const template = 'fooTemplate';
+  const data = { foo: 'bar' };
+
+  beforeEach(function() {
+    ViewClass = View.extend();
+    ViewSubClass = ViewClass.extend();
+    model = new Backbone.Model(data);
+  });
+
+  describe('when changing a renderer on a View class', function() {
+    let rendererStub;
+
+    beforeEach(function() {
+      rendererStub = this.sinon.stub();
+
+      ViewClass.setRenderer(rendererStub);
+
+      const view = new ViewClass({ template, model });
+
+      view.render();
+    });
+
+    it('should use the custom renderer to render', function() {
+      expect(rendererStub).to.have.been.calledOnce.and.calledWith(template, data);
+    });
+
+    it('should not affect the renderer of the extended View', function() {
+      rendererStub.reset();
+
+      const baseView = new View({ template: _.template('bar'), model });
+      baseView.render();
+
+      expect(rendererStub).to.not.have.been.called;
+    });
+
+    describe('when inheriting from the view class', function() {
+      it('should use the custom renderer', function() {
+        rendererStub.reset();
+
+        const subView = new ViewSubClass({ template, model });
+        subView.render();
+
+        expect(rendererStub).to.have.been.calledOnce.and.calledWith(template, data);
+      });
+    });
+
+    describe('when changing a renderer on an inherited class', function() {
+      let subRendererStub;
+
+      beforeEach(function() {
+        subRendererStub = this.sinon.stub();
+
+        ViewSubClass.setRenderer(subRendererStub);
+
+        rendererStub.reset();
+
+        const view = new ViewSubClass({ template, model });
+
+        view.render();
+      });
+
+      it('should use the custom renderer to render', function() {
+        expect(subRendererStub).to.have.been.calledOnce.and.calledWith(template, data);
+      });
+
+      it('should not use the custom renderer of the inherited class', function() {
+        expect(rendererStub).to.not.have.been.called;
+      });
+    });
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/2474

Hopefully this allows for something like:
```js
import IDomRender from 'marionette-idom';
Marionette.View.setRenderer(IDomRender);
```

Todo:
- [x] Tests
- [x] Docs