### PR TITLE
Add initialize event to behaviors

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -332,9 +332,11 @@ The View + Behavior initialize process is as follows:
 2. Behavior is constructed
 3. Behavior is initialized with view property set
 4. View is initialized
+5. View triggers an `initialize` event on the behavior.
 
 This means that the behavior can access the view during its own `initialize` method.
 The view `initialize` is called later with the information eventually injected by the behavior.
+The `initialize` event is triggered on the behavior indicating that the view is fully initialized.
 
 [Live example](https://jsfiddle.net/marionettejs/qb9go1y3/)
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -64,6 +64,8 @@ const CollectionView = Backbone.View.extend({
     Backbone.View.prototype.constructor.apply(this, args);
 
     this.delegateEntityEvents();
+
+    this._triggerEventOnBehaviors('initialize', this);
   },
 
   // Instead of inserting elements one by one into the page, it's much more performant to insert

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -60,6 +60,8 @@ const CollectionView = Backbone.View.extend({
     this._initEmptyRegion();
 
     this.delegateEntityEvents();
+
+    this._triggerEventOnBehaviors('initialize', this);
   },
 
   // Internal method to set up the `children` object for storing all of the child views

--- a/src/view.js
+++ b/src/view.js
@@ -46,6 +46,8 @@ const View = Backbone.View.extend({
     Backbone.View.prototype.constructor.apply(this, args);
 
     this.delegateEntityEvents();
+
+    this._triggerEventOnBehaviors('initialize', this);
   },
 
   // Serialize the view's model *or* collection, if

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -203,13 +203,6 @@ describe('Behaviors', function() {
     });
 
     it('should call initialize when a behavior is created', function() {
-      /* eslint-disable no-unused-vars */
-      const fooView = new FooView();
-
-      expect(initializeStub).to.have.been.calledOnce;
-    });
-
-    it('should call initialize when a behavior is created', function() {
       const fooView = new FooView();
 
       expect(initializeStub).to.have.been.calledOnce.and.calledWith(behaviorOptions, fooView);

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -28,6 +28,18 @@ describe('collection view', function() {
   // Collection View Specs
   // ---------------------
 
+  describe('when instantiating a CollectionView', function() {
+    it('should trigger `initialize` on the behaviors', function() {
+      this.sinon.stub(this.CollectionView.prototype, '_triggerEventOnBehaviors');
+
+      const myCollectionView = new this.CollectionView();
+
+      // _triggerEventOnBehaviors comes from Behaviors mixin
+      expect(myCollectionView._triggerEventOnBehaviors)
+        .to.be.calledOnce.and.calledWith('initialize', myCollectionView);
+    });
+  });
+
   describe('when a collection view is DOM', function() {
     beforeEach(function() {
       this.$fixtureEl = $('<div id="fixture-collectionview"><span id="el1">1</span></div>');

--- a/test/unit/next-collection-view/collection-view.spec.js
+++ b/test/unit/next-collection-view/collection-view.spec.js
@@ -101,6 +101,16 @@ describe('NextCollectionView', function() {
 
       expect(myCollectionView.initialize).to.be.calledBefore(myCollectionView.delegateEntityEvents);
     });
+
+    it('should trigger `initialize` on the behaviors', function() {
+      this.sinon.stub(MyCollectionView.prototype, '_triggerEventOnBehaviors');
+
+      const myCollectionView = new MyCollectionView();
+
+      // _triggerEventOnBehaviors comes from Behaviors mixin
+      expect(myCollectionView._triggerEventOnBehaviors)
+        .to.be.calledOnce.and.calledWith('initialize', myCollectionView);
+    });
   });
 
   describe('#childView', function() {

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -383,6 +383,18 @@ describe('item view', function() {
     });
   });
 
+  describe('when instantiating a View', function() {
+    it('should trigger `initialize` on the behaviors', function() {
+      this.sinon.stub(Marionette.View.prototype, '_triggerEventOnBehaviors');
+
+      const myView = new Marionette.View();
+
+      // _triggerEventOnBehaviors comes from Behaviors mixin
+      expect(myView._triggerEventOnBehaviors)
+        .to.be.calledOnce.and.calledWith('initialize', myView);
+    });
+  });
+
   describe('when serializing view data', function() {
     beforeEach(function() {
       this.modelData = {foo: 'bar'};


### PR DESCRIPTION
Resolves: https://github.com/marionettejs/backbone.marionette/issues/1579

The use-case here is that often times you want to initialize a behavior with things relative to the initialized view, but the behavior itself is initialized prior to the view's initialization so that it's events can be delegated.

This new event allows for developers to access view properties once the view is ready

```js
var MyBehavior = Marionette.Behavior.extend({
  onInitializeView: function(view) {
    view.$el.addClass('my-behavior');
  }
});
```

Todo:
- [x] Tests
- [x] Docs
- [x] Apply this to https://github.com/marionettejs/backbone.marionette/pull/3244 upon merge of one or the other