### PR TITLE
Remove behavior or region from a view when they are destroyed

### DIFF
--- a/src/behavior.js
+++ b/src/behavior.js
@@ -59,6 +59,8 @@ const Behavior = MarionetteObject.extend({
   destroy() {
     this.stopListening();
 
+    this.view._removeBehavior(this);
+
     return this;
   },
 

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -89,6 +89,13 @@ export default {
     _invoke(this._behaviors, 'destroy', ...args);
   },
 
+  // Remove a behavior
+  _removeBehavior(behavior) {
+    // Don't worry about the clean up if the view is destroyed
+    if (this._isDestroyed) { return; }
+    this._behaviors = _.without(this._behaviors, behavior);
+  },
+
   _bindBehaviorUIElements() {
     _invoke(this._behaviors, 'bindUIElements');
   },

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -69,6 +69,7 @@ export default {
     this.triggerMethod('before:add:region', this, name, region);
 
     region._parentView = this;
+    region._name = name;
 
     this._regions[name] = region;
 
@@ -102,6 +103,12 @@ export default {
     delete this._regions[name];
 
     this.triggerMethod('remove:region', this, name, region);
+  },
+
+  // Called in a region's destroy
+  _removeReferences(name) {
+    delete this.regions[name];
+    delete this._regions[name];
   },
 
   // Empty all regions in the region manager, but

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -136,10 +136,12 @@ const ViewMixin = {
     // remove children after the remove to prevent extra paints
     this._removeChildren();
 
-    this._destroyBehaviors(args);
-
     this._isDestroyed = true;
     this._isRendered = false;
+
+    // Destory behaviors after _isDestroyed flag
+    this._destroyBehaviors(args);
+
     this.triggerMethod('destroy', this, ...args);
 
     this.stopListening();

--- a/src/region.js
+++ b/src/region.js
@@ -357,6 +357,12 @@ const Region = MarionetteObject.extend({
 
   destroy(options) {
     this.reset(options);
+
+    if (this._name) {
+      this._parentView._removeReferences(this._name);
+    }
+    delete this._parentView;
+
     return MarionetteObject.prototype.destroy.apply(this, arguments);
   }
 });

--- a/test/unit/behaviors.spec.js
+++ b/test/unit/behaviors.spec.js
@@ -1142,7 +1142,7 @@ describe('Behaviors', function() {
     let behavior;
 
     beforeEach(function() {
-      behavior = new Behavior();
+      behavior = new Behavior({}, new View());
       this.sinon.spy(behavior, 'destroy');
     });
 

--- a/test/unit/mixins/behaviors.spec.js
+++ b/test/unit/mixins/behaviors.spec.js
@@ -411,6 +411,44 @@ describe('Behaviors Mixin', function() {
     });
   });
 
+  describe('#_removeBehavior', function() {
+    let behaviorsInstance;
+    let FooBehavior;
+    let BarBehavior;
+
+    beforeEach(function() {
+      behaviorsInstance = new Behaviors();
+      FooBehavior = Behavior.extend({});
+      BarBehavior = Behavior.extend({});
+
+      behaviorsInstance.behaviors = {foo: FooBehavior, bar: BarBehavior};
+      behaviorsInstance._initBehaviors();
+    });
+
+    it('should remove the behavior from the view\'s behaviors', function() {
+      const behaviorInstance = behaviorsInstance._behaviors[0];
+
+      behaviorsInstance._removeBehavior(behaviorInstance);
+
+      expect(behaviorsInstance._behaviors).not.to.include(behaviorInstance);
+      expect(behaviorsInstance._behaviors.length).to.equal(1);
+    });
+
+    describe('when the view is destroyed', function() {
+      it('should not remove the behavior', function() {
+        // behaviorsInstance is not an actual view so simulate destroy
+        behaviorsInstance._isDestroyed = true;
+
+        const behaviorInstance = behaviorsInstance._behaviors[0];
+
+        behaviorsInstance._removeBehavior(behaviorInstance);
+
+        expect(behaviorsInstance._behaviors).to.include(behaviorInstance);
+        expect(behaviorsInstance._behaviors.length).to.equal(2);
+      });
+    });
+  });
+
   describe('#_bindBehaviorUIElements', function() {
     let behaviorsInstance;
     let FooBehavior;


### PR DESCRIPTION
Kind of resolves https://github.com/marionettejs/backbone.marionette/issues/2538

@Haraldson on gitter brought up a scenario in which he'd like to destroy a behavior on a view.

behaviors can be destroyed in which they'll stop reacting to events, but the view's `triggerMethod` ignores the state of the behavior and calls the `onMethod` handler anyhow.  In researching this, it looked like regions should probably be handled the same way.  Ironically `childView`s in `NextCollectionView` will remove themselves on `destroy` as well.

This PR is mostly to get the conversation started.. we can split up the behavior/region stuff if necessary.

The changes to the tests were a result of less-than-ideal tests, not breaking behavior.

@marionettejs/marionette-core thoughts?