### PR TITLE
Make a childViewEventPrefix feature flag

### DIFF
--- a/docs/marionette.features.md
+++ b/docs/marionette.features.md
@@ -1,10 +1,29 @@
 # Features
 
 Marionette Features are opt-in functionality. That you can enable by setting `Marionette.FEATURES` in your app.
+It is a good practice to set these flags only once prior to instantiating any Marionette class.
+
+```javascript
+Marionette.setEnabled('fooFlag', true);
+
+var myApp = new MyApp({
+  region: '#app-hook'
+});
+
+myApp.start();
+```
 
 ##### Goals:
 + make it possible to add breaking changes in a minor release
 + give community members a chance to provide feedback for new functionality
+
+## `childViewEventPrefix`
+
+This flag is set to `true` by default.
+
+This flag indicates whether [`childViewEventPrefix`](./events.md#a-child-views-event-prefix)
+for all views will return the default value of `'childview'` or if it will return `false`
+disabling [automatic event bubbling](./events.md#event-bubbling).
 
 ## `triggersPreventDefault`
 

--- a/src/config/features.js
+++ b/src/config/features.js
@@ -1,6 +1,7 @@
 // Add Feature flags here
 // e.g. 'class' => false
 const FEATURES = {
+  childViewEventPrefix: true,
   triggersStopPropagation: true,
   triggersPreventDefault: true
 };

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -10,6 +10,7 @@ import DelegateEntityEventsMixin from './delegate-entity-events';
 import DomMixin from './dom';
 import TriggersMixin from './triggers';
 import UIMixin from './ui';
+import { isEnabled } from '../config/features';
 
 // MixinOptions
 // - behaviors
@@ -168,7 +169,9 @@ const ViewMixin = {
 
   // used as the prefix for child view events
   // that are forwarded through the layoutview
-  childViewEventPrefix: 'childview',
+  childViewEventPrefix() {
+    return isEnabled('childViewEventPrefix') ? 'childview' : false;
+  },
 
   // import the `triggerMethod` to trigger events with corresponding
   // methods if the method exists

--- a/test/unit/utils/view.spec.js
+++ b/test/unit/utils/view.spec.js
@@ -415,5 +415,22 @@ describe('view mixin', function() {
         expect(this.layoutEventHandler).not.to.have.been.called;
       });
     });
+
+    describe('when childViewEventPrefix flag is false', function() {
+      let myView;
+
+      beforeEach(function() {
+        Marionette.setEnabled('childViewEventPrefix', false);
+        myView = new Marionette.View();
+      });
+
+      afterEach(function() {
+        Marionette.setEnabled('childViewEventPrefix', true);
+      });
+
+      it('should set childViewEventPrefix to false', function() {
+        expect(_.result(myView, 'childViewEventPrefix')).to.be.false;
+      });
+    });
   });
 });


### PR DESCRIPTION
This flag allow the user to disable automatic event bubbling across the app.

This can be a performance improvement and only helps to increase code organization when the use explicitly has to set the prefix.

I would recommend in v4 that this is `false` by default.

I'm also hoping to work on a blog post that will help explain this further.