### PR TITLE
getRegion will render an unrendered view

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -263,6 +263,7 @@ methods to help utilize regions.
 - `getRegion(name)` - Request a region from a view by name.
  - Note: If the view hasn't been rendered at this point, it will be.
 - `getRegions()` - Returns an object literal of all regions on the view organized by name.
+ - Note: If the view hasn't been rendered at this point, it will be.
 - `hasRegion(name)` - Check if a view has a region.
 - `emptyRegions()` - Empty all of the regions on a view.
 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -261,6 +261,7 @@ In addition to adding and removing regions there are a few
 methods to help utilize regions.
 
 - `getRegion(name)` - Request a region from a view by name.
+ - Note: If the view hasn't been rendered at this point, it will be.
 - `getRegions()` - Returns an object literal of all regions on the view organized by name.
 - `hasRegion(name)` - Check if a view has a region.
 - `emptyRegions()` - Empty all of the regions on a view.

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -205,6 +205,8 @@ var MyView = Mn.View.extend({
 });
 ```
 
+Note: If `view.showChildView(region, subView)` is invoked before the `view` has been rendered, it will automatically render the `view` so the region's `el` exists in the DOM.
+
 [Live example](https://jsfiddle.net/marionettejs/98u073m0/)
 
 #### Accessing a Child View

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -123,6 +123,9 @@ export default {
   // Accepts the region name
   // getRegion('main')
   getRegion(name) {
+    if (!this.isRendered()) {
+      this.render();
+    }
     return this._regions[name];
   },
 

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -123,7 +123,7 @@ export default {
   // Accepts the region name
   // getRegion('main')
   getRegion(name) {
-    if (!this.isRendered()) {
+    if (!this._isRendered) {
       this.render();
     }
     return this._regions[name];

--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -86,7 +86,7 @@ export default {
 
   // Remove all regions from the View
   removeRegions() {
-    const regions = this.getRegions();
+    const regions = this._getRegions();
 
     _.each(this._regions, _.bind(this._removeRegion, this));
 
@@ -130,8 +130,15 @@ export default {
   },
 
   // Get all regions
-  getRegions() {
+  _getRegions() {
     return _.clone(this._regions);
+  },
+
+  getRegions() {
+    if (!this._isRendered) {
+      this.render();
+    }
+    return this._getRegions();
   },
 
   showChildView(name, view, ...args) {

--- a/src/view.js
+++ b/src/view.js
@@ -190,7 +190,7 @@ const View = Backbone.View.extend({
   },
 
   _getImmediateChildren() {
-    return _.chain(this.getRegions())
+    return _.chain(this._getRegions())
       .map('currentView')
       .compact()
       .value();

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -597,10 +597,8 @@ describe('region', function() {
           subRegion: '.sub-region'
         },
 
-        render: function() {
-          $(this.el).html('<div class="sub-region"></div><div>some content</div>');
-          this._isRendered = true;
-          this.triggerMethod('render');
+        template: function() {
+          return '<div class="sub-region"></div><div>some content</div>';
         },
 
         onRender: function() {
@@ -1035,9 +1033,6 @@ describe('region', function() {
   describe('when getting a region', function() {
     beforeEach(function() {
       this.itemView = new Backbone.Marionette.View();
-      this.itemView.template = function() {
-        return 'content';
-      };
       this.itemView.render = sinon.stub();
       this.itemView.addRegions({
         MyRegion: '#region',
@@ -1053,7 +1048,7 @@ describe('region', function() {
 
     it('should call render if getRegion is called without being rendered', function() {
       this.itemView.getRegion('whoCares');
-      expect(this.itemView.render.called).to.be.true;
+      expect(this.itemView.render).to.be.calledOnce;
     });
   });
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -1038,6 +1038,7 @@ describe('region', function() {
       this.itemView.template = function() {
         return 'content';
       };
+      this.itemView.render = sinon.stub();
       this.itemView.addRegions({
         MyRegion: '#region',
         anotherRegion: '#region2'
@@ -1048,6 +1049,11 @@ describe('region', function() {
 
     it('should return the region', function() {
       expect(this.itemView.getRegion('MyRegion')).to.equal(this.region);
+    });
+
+    it('should call render if getRegion is called without being rendered', function() {
+      this.itemView.getRegion('whoCares');
+      expect(this.itemView.render.called).to.be.true;
     });
   });
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -1033,7 +1033,7 @@ describe('region', function() {
   describe('when getting a region', function() {
     beforeEach(function() {
       this.itemView = new Backbone.Marionette.View();
-      this.itemView.render = sinon.stub();
+      this.itemView.render = this.sinon.stub();
       this.itemView.addRegions({
         MyRegion: '#region',
         anotherRegion: '#region2'

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -599,6 +599,7 @@ describe('region', function() {
 
         render: function() {
           $(this.el).html('<div class="sub-region"></div><div>some content</div>');
+          this._isRendered = true;
           this.triggerMethod('render');
         },
 
@@ -1008,6 +1009,9 @@ describe('region', function() {
       this.setFixtures('<div id="region"></div><div id="region2"></div>');
 
       this.itemView = new Backbone.Marionette.View();
+      this.itemView.template = function() {
+        return 'content';
+      };
       this.itemView.addRegions({
         MyRegion: '#region',
         anotherRegion: '#region2'
@@ -1031,6 +1035,9 @@ describe('region', function() {
   describe('when getting a region', function() {
     beforeEach(function() {
       this.itemView = new Backbone.Marionette.View();
+      this.itemView.template = function() {
+        return 'content';
+      };
       this.itemView.addRegions({
         MyRegion: '#region',
         anotherRegion: '#region2'

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -609,13 +609,19 @@ describe('layoutView', function() {
   describe('when a layout has regions', function() {
     beforeEach(function() {
       this.layout = new this.View();
-      this.layout.render();
-      this.regions = this.layout.getRegions();
     });
 
     it('should be able to retrieve all regions', function() {
+      this.layout.render();
+      this.regions = this.layout.getRegions();
       expect(this.regions.regionOne).to.equal(this.layout.getRegion('regionOne'));
       expect(this.regions.regionTwo).to.equal(this.layout.getRegion('regionTwo'));
+    });
+
+    it('should render the view if it hasn\'t been yet', function() {
+      this.sinon.spy(this.layout, 'render');
+      this.layout.getRegions();
+      expect(this.layout.render).to.be.calledOnce;
     });
 
     describe('when the regions are specified via regions hash and the view has no template', function() {
@@ -628,6 +634,8 @@ describe('layoutView', function() {
             '</div>' +
           '</div>';
         this.setFixtures(fixture);
+        this.layout.render();
+        this.regions = this.layout.getRegions();
         this.View = Backbone.Marionette.View.extend({
           el: '.region-hash-no-template-spec .some-layout-view',
           template: false,

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -412,9 +412,9 @@ describe('layoutView', function() {
       this.layoutView = new this.ViewBoundRender({
         model: new Backbone.Model()
       });
-      this.sinon.spy(this.layoutView.getRegion('regionOne'), 'empty');
       this.layoutView.render();
 
+      this.sinon.spy(this.layoutView.getRegion('regionOne'), 'empty');
       this.view = new Backbone.View();
       this.view.destroy = function() {};
       this.layoutView.getRegion('regionOne').show(this.view);


### PR DESCRIPTION
### Proposed changes
 - getRegion will render the view if it hasn't been rendered yet
 - Updated tests
 - Added test

It feels a little wrong for `getRegion` to be responsible for this.  I tried moving the logic down to the `Region._ensureElement`, but that also didn't work well.

Is there a more pure spot to put this?

Link to the issue:
#3294 