### PR TITLE
Add onDomRemove event

### DIFF
--- a/src/common/monitor-view-events.js
+++ b/src/common/monitor-view-events.js
@@ -39,6 +39,12 @@ function triggerDOMRefresh(view) {
   }
 }
 
+function triggerDOMRemove(view) {
+  if (view._isAttached && view._isRendered) {
+    triggerMethodOn(view, 'dom:remove', view);
+  }
+}
+
 function handleBeforeAttach() {
   triggerMethodChildren(this, 'before:attach', shouldTriggerAttach);
 }
@@ -50,10 +56,15 @@ function handleAttach() {
 
 function handleBeforeDetach() {
   triggerMethodChildren(this, 'before:detach', shouldTriggerDetach);
+  triggerDOMRemove(this);
 }
 
 function handleDetach() {
   triggerMethodChildren(this, 'detach', shouldDetach);
+}
+
+function handleBeforeRender() {
+  triggerDOMRemove(this);
 }
 
 function handleRender() {
@@ -72,6 +83,7 @@ function monitorViewEvents(view) {
     'attach': handleAttach,
     'before:detach': handleBeforeDetach,
     'detach': handleDetach,
+    'before:render': handleBeforeRender,
     'render': handleRender
   });
 }

--- a/test/unit/on-dom-remove.spec.js
+++ b/test/unit/on-dom-remove.spec.js
@@ -1,0 +1,76 @@
+describe('onDomRemove', function() {
+  'use strict';
+
+  beforeEach(function() {
+    this.setFixtures($('<div id="region"></div>'));
+    this.attachedRegion = new Marionette.Region({el: '#region'});
+    this.detachedRegion = new Marionette.Region({el: $('<div></div>')});
+    this.BbView = Backbone.View.extend({
+      onDomRemove: this.sinon.stub()
+    });
+    this.MnView = Marionette.View.extend({
+      template: _.noop,
+      onDomRemove: this.sinon.stub()
+    });
+  });
+
+  describe('when a Backbone view is shown detached from the DOM', function() {
+    beforeEach(function() {
+      this.bbView = new this.BbView();
+      this.detachedRegion.show(this.bbView);
+      this.detachedRegion.empty();
+    });
+
+    it('should never trigger onDomRemove', function() {
+      expect(this.bbView.onDomRemove).not.to.have.been.called;
+    });
+  });
+
+  describe('when a Marionette view is shown detached from the DOM', function() {
+    beforeEach(function() {
+      this.mnView = new this.MnView();
+      this.detachedRegion.show(this.mnView);
+      this.mnView.render();
+      this.detachedRegion.empty();
+    });
+
+    it('should never trigger onDomRemove', function() {
+      expect(this.mnView.onDomRemove).not.to.have.been.called;
+    });
+  });
+
+  describe('when a Backbone view is shown attached to the DOM', function() {
+    beforeEach(function() {
+      this.bbView = new this.MnView();
+      this.attachedRegion.show(this.bbView);
+    });
+
+    describe('when the region is emptied', function() {
+      it('should trigger onDomRemove on the view', function() {
+        this.attachedRegion.empty();
+        expect(this.bbView.onDomRemove).to.have.been.calledOnce.and.calledWith(this.bbView);
+      });
+    });
+  });
+
+  describe('when a Marionette view is shown attached to the DOM', function() {
+    beforeEach(function() {
+      this.mnView = new this.MnView();
+      this.attachedRegion.show(this.mnView);
+    });
+
+    describe('when the region is emptied', function() {
+      it('should trigger onDomRemove on the view', function() {
+        this.attachedRegion.empty();
+        expect(this.mnView.onDomRemove).to.have.been.calledOnce.and.calledWith(this.mnView);
+      });
+    });
+
+    describe('when the view is re-rendered', function() {
+      it('should trigger onDomRemove on the view', function() {
+        this.mnView.render();
+        expect(this.mnView.onDomRemove).to.have.been.calledOnce.and.calledWith(this.mnView);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This event is added to compliment `onDOMRefresh`.

`onAttach` and `onBeforeDetach` are great if you are concerned with the view's `$el` being available in the DOM.  `onDOMRefresh` is a combination of `onAttach` and subsquent renders which is useful if you are concerned with the view's _contents_ being in the DOM, but there is no equivalent `onBeforeDetach` for `onDOMRefresh`.  If you _must_ add something that is concerned with the view's contents being in the DOM the cleanup would look like:
```js
const MyView = Mn.View.extend({
  template: MyTemplate,
  ui: {
    button: '.js-date-button'
  },
  onDomRefresh() {
    this.ui.button.showDatePickerPlugin();
  },
  onBeforeRender() {
     if (this.isRendered()) {
        this.ui.button.destroyDatePickerPlugin();
     }
  },
  onBeforeDetach() {
    this.ui.button.destroyDatePickerPlugin();
  }
});
```

While this event is technically a "before:" I think adding the prefix would complicate things.

Without this event `onDOMRefresh` is deceivingly useful and unsafe without a deeper understanding of the events.

With this event we can say:

|      method     |          use        |
| ------------- | ------------- |
| initialize         | Add children to pre-rendered view  |
| onRender | Add children to view (including re-rendering a prerendered view) |
| onAttach | Add plugins to the view's `el` |
| onBeforeDetach | Destroy plugins on the view's `el` |
| onDomRefresh | Add plugins to the view's content |
| onDomRemove | Destroy plugins on the view's content |
