### PR TITLE
Set a specific port per travis sauce test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ node_js:
 cache: yarn
 env:
   - TEST_SUITE=coverage
-  - TEST_SUITE=browser
+  - TEST_SUITE=browser SAUCE_PORT=8080
   - TEST_SUITE=lodash USE_LODASH=1
-  - TEST_SUITE=browser USE_LODASH=1
+  - TEST_SUITE=browser USE_LODASH=1 SAUCE_PORT=8081
 after_install:
   - yarn install travis-ci
 script:
   - if [[ $TEST_SUITE = "coverage" ]]; then yarn run coveralls; fi
-  - if [[ $TEST_SUITE = "browser" ]]; then yarn run test-cross-browser; fi
+  - if [[ $TEST_SUITE = "browser" ]]  && [[ $SAUCE_USERNAME ]]; then yarn run test-cross-browser; fi
   - if [[ $TEST_SUITE = "lodash" ]]; then yarn run test; fi
 after_success:
   - if [[ $TRAVIS_BRANCH = "master" ]] && [[ $TRAVIS_PULL_REQUEST = "false" ]]; then node trigger-deploy-mn-com.js; fi

--- a/gulp/test-browser.js
+++ b/gulp/test-browser.js
@@ -16,7 +16,7 @@ const sauceConf = {
   username: process.env.SAUCE_USERNAME,
   key: process.env.SAUCE_ACCESS_KEY,
   testPath: '/test/runner.html',
-  port: '8080',
+  port: process.env.SAUCE_PORT || '8080',
   framework: 'mocha',
   platforms: [
     ['Windows 10', 'MicrosoftEdge', 'latest'],


### PR DESCRIPTION
Attempting a further fix for https://github.com/marionettejs/backbone.marionette/issues/3343

Compliments https://github.com/marionettejs/backbone.marionette/pull/3349

A PR off of the origin _should_ run sauce tests, but not a PR off a fork
