### PR TITLE
Prevent additional region destroys from errorring on removeReferences

### DIFF
--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -99,9 +99,6 @@ export default {
 
     region.destroy();
 
-    delete this.regions[name];
-    delete this._regions[name];
-
     this.triggerMethod('remove:region', this, name, region);
   },
 

--- a/src/region.js
+++ b/src/region.js
@@ -375,12 +375,15 @@ const Region = MarionetteObject.extend({
   },
 
   destroy(options) {
+    if (this._isDestroyed) { return this; }
+
     this.reset(options);
 
     if (this._name) {
       this._parentView._removeReferences(this._name);
     }
     delete this._parentView;
+    delete this._name;
 
     return MarionetteObject.prototype.destroy.apply(this, arguments);
   }

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -1168,6 +1168,20 @@ describe('region', function() {
     it('should return the region', function() {
       expect(this.region.destroy).to.have.returned(this.region);
     });
+
+    describe('when the region is already destroyed', function() {
+      it('should not reset the region', function() {
+        this.region.reset.reset();
+        this.region.destroy();
+        expect(this.region.reset).to.not.have.been.called;
+      });
+
+      it('should return the region', function() {
+        this.region.destroy.reset();
+        this.region.destroy();
+        expect(this.region.destroy).to.have.returned(this.region);
+      });
+    });
   });
 
   describe('when destroying a Mn view in a region', function() {

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -399,6 +399,34 @@ describe('layoutView', function() {
     });
   });
 
+  describe('when destroying the childView destroys the parent', function() {
+    let layoutView;
+
+    beforeEach(function() {
+      const LayoutView = Marionette.View.extend({
+        childViewEvents: {
+          'destroy': 'destroy'
+        },
+        template: _.template('<div id="regionOne"></div>'),
+        regions: {
+          regionOne: '#regionOne'
+        }
+      });
+
+      layoutView = new LayoutView();
+
+      const childView = new Marionette.View({
+        template: _.noop
+      });
+
+      layoutView.showChildView('regionOne', childView);
+    });
+
+    it('should not throw any errors', function() {
+      expect(function() { layoutView.destroy(); }).to.not.throw(Error);
+    });
+  });
+
   describe('when re-rendering an already rendered layoutView', function() {
     beforeEach(function() {
       this.ViewBoundRender = this.View.extend({


### PR DESCRIPTION
In the edge case where a parent view destroys itself when a child view destroys, a 2nd `region.destroy` is called during the `this.reset()`.  As such the destroy cannot bail out successfully and will try and re-`_removeReference` even though `parentView` was already deleted.
I believe the easiest solution is to also remove the `_name` references so that the removal is no longer in question.

Related `_removeReference` removes the need for `_removeRegion` to remove its own references as it will happen in the `region.destroy`

Failing example: https://jsfiddle.net/2py5oqr4/