### PR TITLE
Improve emulate collection perf

### DIFF
--- a/src/child-view-container.js
+++ b/src/child-view-container.js
@@ -12,12 +12,16 @@ const Container = function(views) {
   _.each(views, _.bind(this.add, this));
 };
 
-emulateCollection(Container.prototype, '_views');
+emulateCollection(Container.prototype, '_getViews');
 
 // Container Methods
 // -----------------
 
 _.extend(Container.prototype, {
+
+  _getViews() {
+    return _.values(this._views);
+  },
 
   // Add a view to this container. Stores the view
   // by `cid` and makes it searchable by the model

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -282,7 +282,7 @@ const CollectionView = Backbone.View.extend({
 
       // Get the DOM nodes in the same order as the models and
       // find the model that were children before but aren't in this new order.
-      const elsToReorder = children.reduce(function(viewEls, view) {
+      const elsToReorder = _.reduce(this.children._views, function(viewEls, view) {
         const index = _.indexOf(models, view.model);
 
         if (index === -1) {
@@ -586,7 +586,7 @@ const CollectionView = Backbone.View.extend({
 
     if (_.isObject(view)) {
       // update the indexes of views after this one
-      this.children.each((laterView) => {
+      _.each(this.children._views, (laterView) => {
         if (laterView._index >= view._index) {
           laterView._index += 1;
         }
@@ -698,7 +698,7 @@ const CollectionView = Backbone.View.extend({
     const findPosition = this.sort && (index < this.children.length - 1);
     if (findPosition) {
       // Find the view after this one
-      currentView = this.children.find((view) => {
+      currentView = _.find(this.children._views, (view) => {
         return view._index === index + 1;
       });
     }
@@ -733,7 +733,7 @@ const CollectionView = Backbone.View.extend({
     }
 
     this.triggerMethod('before:destroy:children', this);
-    this.children.each(_.bind(this._removeChildView, this));
+    _.each(this.children._views, _.bind(this._removeChildView, this));
     this.children._updateLength();
     this.triggerMethod('destroy:children', this);
   },

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -431,7 +431,7 @@ const CollectionView = Backbone.View.extend({
 
     this.triggerMethod('before:filter', this);
 
-    const filteredViews = this.children.partition(_.bind(viewFilter, this));
+    const filteredViews = _.partition(this.children._views, _.bind(viewFilter, this));
 
     this._detachChildren(filteredViews[1]);
 
@@ -671,7 +671,7 @@ const CollectionView = Backbone.View.extend({
     }
 
     this.triggerMethod('before:destroy:children', this);
-    this.children.each(_.bind(this._removeChildView, this));
+    _.each(this.children._views, _.bind(this._removeChildView, this));
     this.triggerMethod('destroy:children', this);
   }
 });

--- a/src/utils/emulate-collection.js
+++ b/src/utils/emulate-collection.js
@@ -13,9 +13,9 @@ const methods = ['forEach', 'each', 'map', 'find', 'detect', 'filter',
 const emulateCollection = function(object, listProperty) {
   _.each(methods, function(method) {
     object[method] = function() {
-      const list = _.values(_.result(this, listProperty));
-      const args = [list].concat(_.toArray(arguments));
-      return _[method].apply(_, args);
+      const list = _.result(this, listProperty);
+      const args = Array.prototype.slice.call(arguments);
+      return _[method].apply(_, [list].concat(args));
     };
   });
 };


### PR DESCRIPTION
This improvement will really only affect `NextCollectionView` by moving the `_.values` loop out to the only childview container that needs it.

Additionally this replaces the `_.toArray` with the slice which is barely a perf improvement.. but is more consistent with how we've done this elsewhere.

Then I removed any internal use of the emulation as we can safely avoid it since the child view container is internal and gain even more perf

It's also worth noting that this is probably a slight perf decrease for the current collectionview emulated functions since it's adding the extra function call..  but that should be slight considering the other improvements

This should probably wait on v3.3.1 to be done before merging.