### PR TITLE
Move view actions that support backbone views a common module

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -3,7 +3,7 @@
 
 import _ from 'underscore';
 import Backbone from 'backbone';
-import destroyBackboneView from './utils/destroy-backbone-view';
+import { renderView, destroyView } from './common/view';
 import isNodeAttached from './common/is-node-attached';
 import monitorViewEvents from './common/monitor-view-events';
 import { triggerMethodOn } from './common/trigger-method';
@@ -181,11 +181,7 @@ const CollectionView = Backbone.View.extend({
     this.triggerMethod('before:remove:child', this, view);
 
     this.children._remove(view);
-    if (view.destroy) {
-      view.destroy();
-    } else {
-      destroyBackboneView(view);
-    }
+    destroyView(view);
 
     this.stopListening(view);
     this.triggerMethod('remove:child', this, view);
@@ -558,7 +554,7 @@ const CollectionView = Backbone.View.extend({
       this.children.add(view);
     }
 
-    this._renderView(view);
+    renderView(view);
 
     this._attachView(view, index);
 
@@ -591,23 +587,6 @@ const CollectionView = Backbone.View.extend({
           laterView._index += 1;
         }
       });
-    }
-  },
-
-  _renderView(view) {
-    if (view._isRendered) {
-      return;
-    }
-
-    if (!view.supportsRenderLifecycle) {
-      triggerMethodOn(view, 'before:render', view);
-    }
-
-    view.render();
-
-    if (!view.supportsRenderLifecycle) {
-      view._isRendered = true;
-      triggerMethodOn(view, 'render', view);
     }
   },
 

--- a/src/common/view.js
+++ b/src/common/view.js
@@ -1,6 +1,28 @@
 import { triggerMethodOn } from '../common/trigger-method';
 
-export default function destroyBackboneView(view) {
+export function renderView(view) {
+  if (view._isRendered) {
+    return;
+  }
+
+  if (!view.supportsRenderLifecycle) {
+    triggerMethodOn(view, 'before:render', view);
+  }
+
+  view.render();
+
+  if (!view.supportsRenderLifecycle) {
+    view._isRendered = true;
+    triggerMethodOn(view, 'render', view);
+  }
+}
+
+export function destroyView(view) {
+  if (view.destroy) {
+    view.destroy();
+    return;
+  }
+
   if (!view.supportsDestroyLifecycle) {
     triggerMethodOn(view, 'before:destroy', view);
   }

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -3,7 +3,7 @@
 
 import _ from 'underscore';
 import Backbone from 'backbone';
-import destroyBackboneView from './utils/destroy-backbone-view';
+import { renderView, destroyView } from './common/view';
 import isNodeAttached from './common/is-node-attached';
 import monitorViewEvents from './common/monitor-view-events';
 import { triggerMethodOn } from './common/trigger-method';
@@ -561,28 +561,11 @@ const CollectionView = Backbone.View.extend({
     const elBuffer = this.createBuffer();
 
     _.each(views, view => {
-      this._renderChildView(view);
+      renderView(view);
       this.appendChildren(elBuffer, view.el);
     });
 
     return elBuffer;
-  },
-
-  _renderChildView(view) {
-    if (view._isRendered) {
-      return;
-    }
-
-    if (!view.supportsRenderLifecycle) {
-      triggerMethodOn(view, 'before:render', view);
-    }
-
-    view.render();
-
-    if (!view.supportsRenderLifecycle) {
-      view._isRendered = true;
-      triggerMethodOn(view, 'render', view);
-    }
   },
 
   // Override this method to do something other than `.append`.
@@ -651,11 +634,7 @@ const CollectionView = Backbone.View.extend({
       return;
     }
 
-    if (view.destroy) {
-      view.destroy();
-    } else {
-      destroyBackboneView(view);
-    }
+    destroyView(view);
   },
 
   // called by ViewMixin destroy

--- a/src/region.js
+++ b/src/region.js
@@ -4,7 +4,7 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
 import deprecate from './utils/deprecate';
-import destroyBackboneView from './utils/destroy-backbone-view';
+import { renderView, destroyView } from './common/view';
 import monitorViewEvents from './common/monitor-view-events';
 import isNodeAttached from './common/is-node-attached';
 import { triggerMethodOn } from './common/trigger-method';
@@ -70,7 +70,7 @@ const Region = MarionetteObject.extend({
 
     this._setupChildView(view);
 
-    this._renderView(view);
+    renderView(view);
 
     this._attachView(view, options);
 
@@ -100,23 +100,6 @@ const Region = MarionetteObject.extend({
     if (!parentView) { return; }
 
     parentView._proxyChildViewEvents(view);
-  },
-
-  _renderView(view) {
-    if (view._isRendered) {
-      return;
-    }
-
-    if (!view.supportsRenderLifecycle) {
-      triggerMethodOn(view, 'before:render', view);
-    }
-
-    view.render();
-
-    if (!view.supportsRenderLifecycle) {
-      view._isRendered = true;
-      triggerMethodOn(view, 'render', view);
-    }
   },
 
   _attachView(view, options = {}) {
@@ -304,11 +287,7 @@ const Region = MarionetteObject.extend({
       return view;
     }
 
-    if (view.destroy) {
-      view.destroy();
-    } else {
-      destroyBackboneView(view);
-    }
+    destroyView(view);
     return view;
   },
 

--- a/test/unit/collection-view.spec.js
+++ b/test/unit/collection-view.spec.js
@@ -384,12 +384,6 @@ describe('collection view', function() {
     it('should call "render" on the childView', function() {
       expect(this.childView.render).to.have.been.calledOnce;
     });
-
-    it('should not render childView twice', function() {
-      this.collectionView._renderView(this.childView);
-
-      expect(this.childView.render).to.not.have.been.calledTwice;
-    });
   });
 
   describe('when sorting a collection', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -111,9 +111,9 @@ describe('region', function() {
         });
 
         it('should not render the view', function() {
-          this.sinon.spy(this.region, '_renderView');
+          this.sinon.spy(this.myView, 'render');
           this.region.show(this.myView);
-          expect(this.region._renderView).not.to.have.been.called;
+          expect(this.myView.render).not.to.have.been.called;
         });
       });
     });
@@ -749,7 +749,6 @@ describe('region', function() {
 
       this.sinon.spy(this.view, 'destroy');
       this.sinon.spy(this.region, 'attachHtml');
-      this.sinon.spy(this.region, '_renderView');
       this.sinon.spy(this.view, 'render');
       this.region.show(this.view);
     });
@@ -762,8 +761,8 @@ describe('region', function() {
       expect(this.region.attachHtml).not.to.have.been.calledWith(this.view);
     });
 
-    it('should not call "_renderView"', function() {
-      expect(this.region._renderView).not.to.have.been.called;
+    it('should not call "render" on the view', function() {
+      expect(this.view.render).not.to.have.been.called;
     });
   });
 
@@ -1022,34 +1021,6 @@ describe('region', function() {
     });
   });
 
-  describe('when initializing a region with an existing view', function() {
-    beforeEach(function() {
-      this.View = Backbone.View.extend({
-        onShow: function() {}
-      });
-
-      this.view = new this.View();
-
-      this.sinon.spy(this.view, 'render');
-      this.sinon.spy(this.view, 'onShow');
-
-      this.region = new Backbone.Marionette.Region({
-        el: '#foo',
-        currentView: this.view
-      });
-
-      this.sinon.spy(this.region, '_renderView');
-    });
-
-    it('should not render the view', function() {
-      expect(this.region._renderView).not.to.have.been.called;
-    });
-
-    it('should not `show` the view', function() {
-      expect(this.view.onShow).not.to.have.been.called;
-    });
-  });
-
   describe('when creating a region instance with an initialize method', function() {
     beforeEach(function() {
       this.expectedOptions = {foo: 'bar'};
@@ -1287,27 +1258,6 @@ describe('region', function() {
           .and.to.have.been.calledOn(this.view)
           .and.to.have.been.calledWith(this.view);
       });
-    });
-  });
-
-  describe('when calling "_renderView"', function() {
-    beforeEach(function() {
-      this.region = new Backbone.Marionette.Region({
-        el: '#region'
-      });
-
-      this.View = Backbone.Marionette.View.extend({
-        template: _.template('')
-      });
-
-      this.view = new this.View();
-      this.sinon.spy(this.view, 'render');
-
-      this.region._renderView(this.view);
-    });
-
-    it('should call "render" on the view', function() {
-      expect(this.view.render).to.have.been.calledOnce;
     });
   });
 


### PR DESCRIPTION
We followed the same pattern everywhere this utility was used.
Save a few lines and move it all into the util.
