### PR TITLE
Do not inject merged options into View constructor arguments

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -13,6 +13,7 @@ patterns etc.
 * [Setting Options](#setting-options)
   * [The `getOption` Method](#the-getoption-method)
   * [The `mergeOptions` Method](#the-mergeoptions-method)
+  * [The `options` Property](#the-options-property)
 
 ## Class-based Inheritance
 
@@ -254,3 +255,35 @@ In this example, `model` and `something` are directly available on the
 `MyObject` instance, while `another` must be accessed via `getOption`. This is
 handy when you want to add extra keys that will be used heavily throughout the
 defined class.
+
+### The `options` Property
+
+Is possible to define an `options` property in the class definition that will
+be used as default values. The `options` argument passed at class instantiation
+has precedence over the property.
+
+> The `options` argument passed in `initialize` method is equal to the passed at 
+> class instantiation. To get the option inside initialize considering the 
+> `options` property is necessary to use `getOption`  
+
+```javascript
+var Bb = require('backbone');
+var Mn = require('backbone.marionette');
+
+var MyObject = Mn.Object.extend({
+  options: {
+    foo: 'bar',
+    another: 'thing'
+  },
+  
+  initialize: function(options) {
+    console.log(options.foo) // undefined
+    console.log(this.getOption('foo')) // 'bar'
+    console.log(this.getOption('another')) // 'value'            
+  }
+});
+
+var myObject = new MyObject({    
+  another: 'value'
+});
+```

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -258,9 +258,9 @@ defined class.
 
 ### The `options` Property
 
-Is possible to define an `options` property in the class definition that will
-be used as default values. The `options` argument passed at class instantiation
-has precedence over the property.
+The Marionette classes accept an `options` property in the class definition
+which is merged with the `options` argument passed at instantiation. The 
+values from the passed in `options` overrides the property values.
 
 > The `options` argument passed in `initialize` method is equal to the passed at 
 > class instantiation. To get the option inside initialize considering the 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -52,9 +52,7 @@ const CollectionView = Backbone.View.extend({
     this._initChildViewStorage();
     this._initBehaviors();
 
-    const args = Array.prototype.slice.call(arguments);
-    args[0] = this.options;
-    Backbone.View.prototype.constructor.apply(this, args);
+    Backbone.View.prototype.constructor.apply(this, arguments);
 
     // Init empty region
     this.getEmptyRegion();

--- a/src/view.js
+++ b/src/view.js
@@ -40,9 +40,7 @@ const View = Backbone.View.extend({
     this._initBehaviors();
     this._initRegions();
 
-    const args = Array.prototype.slice.call(arguments);
-    args[0] = this.options;
-    Backbone.View.prototype.constructor.apply(this, args);
+    Backbone.View.prototype.constructor.apply(this, arguments);
 
     this.delegateEntityEvents();
 

--- a/test/unit/mixins/view.spec.js
+++ b/test/unit/mixins/view.spec.js
@@ -199,28 +199,6 @@ describe('view mixin', function() {
   });
 
   // http://backbonejs.org/#View-constructor
-  describe('when constructing a view with Backbone viewOptions', function() {
-    it('should attach the viewOptions to the view if options are on the view', function() {
-      this.MyView = Marionette.View.extend({
-        options: {
-          className: '.some-class'
-        }
-      });
-      this.myView = new this.MyView();
-      expect(this.myView.className).to.equal('.some-class');
-    });
-
-    it('should attach the viewOptions to the view if options are on the collectionview', function() {
-      this.MyCollectionView = Marionette.CollectionView.extend({
-        options: {
-          className: '.some-class'
-        }
-      });
-      this.myCollectionView = new this.MyCollectionView();
-      expect(this.myCollectionView.className).to.equal('.some-class');
-    });
-  });
-
   describe('should expose its options in the constructor', function() {
     beforeEach(function() {
       this.options = {foo: 'bar'};


### PR DESCRIPTION
### Proposed changes
 - Do not inject merged options into View constructor arguments

Currently, the Marionette View classes changes the constructor arguments to pass the merged options down to Backbone View constructor and thus to initialize.

The reasoning for this PR is:

1) Is not consistent with Backbone View and other Marionette classes that pass the options/arguments as is down to class hierarchy
2) The arguments manipulation prevents the code to be optimized by the JIT compiler 

If the developer needs to access the merged options in initialize it can use `getOption`, feature available in all Marionette classes.

Properties like `className` and `attributes` that are used by Backbone View can still be declared in the standard way which is more flexible than passing though options.

This change aligns with #3348 as it remove a redundant feature

It is a breaking change