### PR TITLE
Simplify internal setOptions util

### DIFF
--- a/src/utils/set-options.js
+++ b/src/utils/set-options.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 
 // Internal utility for setting options consistently across Mn
-const setOptions = function(...args) {
-  this.options = _.extend({}, _.result(this, 'options'), ...args);
+const setOptions = function(options) {
+  this.options = _.extend({}, _.result(this, 'options'), options);
 };
 
 export default setOptions;


### PR DESCRIPTION
This util is only used internally and is only ever called with a single arg.  No need for destructuring or the loop it makes in transpilation.
