### PR TITLE
Improve Object's internal extendability

### DIFF
--- a/src/mixins/common.js
+++ b/src/mixins/common.js
@@ -11,19 +11,19 @@ export default {
 
   // Imports the "normalizeMethods" to transform hashes of
   // events=>function references/names to a hash of events=>function references
-  normalizeMethods: normalizeMethods,
+  normalizeMethods,
 
-  _setOptions: _setOptions,
+  _setOptions,
 
   // A handy way to merge passed-in options onto the instance
-  mergeOptions: mergeOptions,
+  mergeOptions,
 
   // Enable getting options from this or this.options by name.
-  getOption: getOption,
+  getOption,
 
   // Enable binding view's events from another entity.
-  bindEvents: bindEvents,
+  bindEvents,
 
   // Enable unbinding view's events from another entity.
-  unbindEvents: unbindEvents
+  unbindEvents
 };

--- a/src/object.js
+++ b/src/object.js
@@ -17,9 +17,11 @@ const ClassOptions = [
 // A Base Class that other Classes should descend from.
 // Object borrows many conventions and utilities from Backbone.
 const MarionetteObject = function(options) {
-  this._setOptions(options);
+  if (!this.hasOwnProperty('options')) {
+    this._setOptions(options);
+  }
   this.mergeOptions(options, ClassOptions);
-  this.cid = _.uniqueId(this.cidPrefix);
+  this._setCid();
   this._initRadio();
   this.initialize.apply(this, arguments);
 };
@@ -43,6 +45,11 @@ _.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, RadioMixin, {
   //this is a noop method intended to be overridden by classes that extend from this base
   initialize() {},
 
+  _setCid() {
+    if (this.cid) { return; }
+    this.cid = _.uniqueId(this.cidPrefix);
+  },
+
   destroy(...args) {
     if (this._isDestroyed) { return this; }
 
@@ -55,7 +62,7 @@ _.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, RadioMixin, {
     return this;
   },
 
-  triggerMethod: triggerMethod
+  triggerMethod
 });
 
 export default MarionetteObject;


### PR DESCRIPTION
Internally we extend `Region`, `Behavior`, and `Application` from `Object`.
For each of these cases we call `_setOptions` in the various classes, but then it is also called again by `Object`.  This adds a minor perf improvement by not re-calculating `this.options`.
Similarly while looking into `Region` refactors I found it would be useful to know the `cid` in order to throw an error, but it wasn't available to the constructor.  This would allow us to set it once reliably.
