### PR TITLE
Typo, GrantParentView => GrandParentView

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -467,7 +467,7 @@ var ParentView = Marionette.CollectionView.extend({
   }
 });
 
-var GrantParentView = Marionette.View.extend({
+var GrandParentView = Marionette.View.extend({
   regions: {
     list: '.list'
   },


### PR DESCRIPTION
### Proposed changes
 - Correct to: `var GrandParentView ...`
