### PR TITLE
Add viewComparator: false to NextCollectionView

### DIFF
--- a/docs/marionette.nextcollectionviewadvanced.md
+++ b/docs/marionette.nextcollectionviewadvanced.md
@@ -400,13 +400,14 @@ cv.removeFilter({ preventRender: true });
 The `sort` method will loop through the `NextCollectionView` `children`
 and sort them with the [`viewComparator`](#nextcollectionviews-viewcomparator).
 By default, if a `viewComparator` is not set, the `NextCollectionView` will sort
-the views by the order of the models in the collection.
+the views by the order of the models in the collection. If set to `false` view
+sorting will be disabled.
 This method is also triggered internally when rendering and `before:sort` and
 `sort` events will be triggered before and after sorting.
 
 By default the `NextCollectionView` will maintain a sorted collection's order
-in the DOM. This behavior can be disabled by specifying `{sort: false}` on
-initialize. The `sort` flag cannot be changed after instantiation.
+in the DOM. This behavior can be disabled by specifying `{sortWithCollection: false}`
+on initialize.
 
 ### NextCollectionView's `viewComparator`
 

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -89,7 +89,7 @@ const CollectionView = Backbone.View.extend({
   // Internal method. This checks for any changes in the order of the collection.
   // If the index of any view doesn't match, it will re-sort.
   _onCollectionSort() {
-    if (!this.sortWithCollection) {
+    if (!this.sortWithCollection || this.viewComparator === false) {
       return;
     }
 
@@ -362,6 +362,8 @@ const CollectionView = Backbone.View.extend({
 
   // Sorts views by viewComparator and sets the children to the new order
   _sortChildren() {
+    if (this.viewComparator === false) { return; }
+
     this.triggerMethod('before:sort', this);
 
     let viewComparator = this.getComparator();

--- a/test/unit/next-collection-view/collection-view-sorting.spec.js
+++ b/test/unit/next-collection-view/collection-view-sorting.spec.js
@@ -53,7 +53,51 @@ describe('NextCollectionView - Sorting', function() {
       });
     });
 
-    describe('when viewComparator is falsy', function() {
+    describe('when viewComparator is false', function() {
+      let myCollectionView;
+
+      beforeEach(function() {
+        myCollectionView = new MyCollectionView({
+          viewComparator: false,
+          collection
+        });
+
+        myCollectionView.render();
+      });
+
+
+      it('should not sort the collection', function() {
+        expect(myCollectionView.$el.text()).to.equal(noSortText);
+      });
+
+      it('should not call "before:sort" event', function() {
+        expect(myCollectionView.onBeforeSort).to.not.be.called;
+      });
+
+      it('should not call "sort" event', function() {
+        expect(myCollectionView.onSort).to.not.be.called;
+      });
+
+      describe('when resorting the collection', function() {
+        beforeEach(function() {
+          this.sinon.spy(myCollectionView, 'sort');
+          collection.comparator = 'sort';
+          collection.sort();
+        });
+
+        it('should not call sort', function() {
+          expect(myCollectionView.sort).to.not.be.called;
+        });
+
+        it('should not resort the children on sort', function() {
+          myCollectionView.sort();
+
+          expect(myCollectionView.$el.text()).to.equal(noSortText);
+        });
+      });
+    });
+
+    describe('when viewComparator is falsy but not false', function() {
       let myCollectionView;
 
       beforeEach(function() {


### PR DESCRIPTION
Currently if you need to avoid sorting for any reason, you would have to add a _.noop to the view comparator, but the views would still be looped through.

This short-circuits the sorting if it isn't wanted.