### PR TITLE
Make monitorViewEvents opt-out

### DIFF
--- a/docs/viewlifecycle.md
+++ b/docs/viewlifecycle.md
@@ -31,6 +31,7 @@ their children.
 * [`Region`s and the View Lifecycle](#regions-and-the-view-lifecycle)
   * [Show View Events](#show-view-events)
   * [Empty Region Events](#empty-region-events)
+* [Advanced Event Settings](#advanced-event-settings)
 
 ## `View` Lifecycle
 Marionette views define a number of events during the creation and destruction
@@ -896,3 +897,21 @@ destroyed.
 
 Fired after the entire destruction process is complete. At this point, the view
 has been removed from the DOM completely.
+
+
+## Advanced Event Settings
+Marionette is able to trigger `attach`/`detach` events down the view tree along with
+triggering the `dom:refresh`/`dom:remove` events because of the view event monitor.
+This monitor starts when a view is created or shown in a region (to handle non-Marionette views).
+
+In some cases it may be a useful performance improvement to disable this functionality.
+Doing so is as easy as setting `monitorViewEvents: false` on the view class.
+
+```javascript
+const NonMonitoredView = Mn.View.extend({
+  monitorViewEvents: false
+});
+```
+
+**Important Note**: Disabling the view monitor will break the monitor generated
+events for this view _and all child views_ of this view. Disabling should be done carefully.

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -76,7 +76,7 @@ const CollectionView = Backbone.View.extend({
   },
 
   _endBuffering() {
-    const shouldTriggerAttach = !!this._isAttached;
+    const shouldTriggerAttach = this._isAttached && this.monitorViewEvents !== false;
     const triggerOnChildren = shouldTriggerAttach ? this._getImmediateChildren() : [];
 
     this._isBuffering = false;
@@ -182,6 +182,7 @@ const CollectionView = Backbone.View.extend({
     this.triggerMethod('before:remove:child', this, view);
 
     this.children._remove(view);
+    view._shouldDisableEvents = this.monitorViewEvents === false;
     destroyView(view);
 
     this.stopListening(view);
@@ -600,7 +601,7 @@ const CollectionView = Backbone.View.extend({
   _attachView(view, index) {
     // Only trigger attach if already attached and not buffering,
     // otherwise _endBuffering() or Region#show() handles this.
-    const shouldTriggerAttach = !view._isAttached && !this._isBuffering && this._isAttached;
+    const shouldTriggerAttach = !view._isAttached && !this._isBuffering && this._isAttached && this.monitorViewEvents !== false;
 
     if (shouldTriggerAttach) {
       triggerMethodOn(view, 'before:attach', view);

--- a/src/common/monitor-view-events.js
+++ b/src/common/monitor-view-events.js
@@ -74,7 +74,7 @@ function handleRender() {
 // Monitor a view's state, propagating attach/detach events to children and firing dom:refresh
 // whenever a rendered view is attached or an attached view is rendered.
 function monitorViewEvents(view) {
-  if (view._areViewEventsMonitored) { return; }
+  if (view._areViewEventsMonitored || view.monitorViewEvents === false) { return; }
 
   view._areViewEventsMonitored = true;
 

--- a/src/common/view.js
+++ b/src/common/view.js
@@ -27,7 +27,7 @@ export function destroyView(view) {
     triggerMethodOn(view, 'before:destroy', view);
   }
 
-  const shouldTriggerDetach = !!view._isAttached;
+  const shouldTriggerDetach = view._isAttached && !view._shouldDisableEvents;
 
   if (shouldTriggerDetach) {
     triggerMethodOn(view, 'before:detach', view);

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -118,7 +118,7 @@ const ViewMixin = {
   // Handle destroying the view and its children.
   destroy(...args) {
     if (this._isDestroyed) { return this; }
-    const shouldTriggerDetach = !!this._isAttached;
+    const shouldTriggerDetach = this._isAttached && !this._shouldDisableEvents;
 
     this.triggerMethod('before:destroy', this, ...args);
     if (shouldTriggerDetach) {

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -505,7 +505,7 @@ const CollectionView = Backbone.View.extend({
   },
 
   _detachChildView(view) {
-    const shouldTriggerDetach = !!view._isAttached;
+    const shouldTriggerDetach = view._isAttached && this.monitorViewEvents !== false;
     if (shouldTriggerDetach) {
       triggerMethodOn(view, 'before:detach', view);
     }
@@ -541,7 +541,7 @@ const CollectionView = Backbone.View.extend({
   },
 
   _attachChildren(els, views) {
-    const shouldTriggerAttach = !!this._isAttached;
+    const shouldTriggerAttach = this._isAttached && this.monitorViewEvents !== false;
 
     views = shouldTriggerAttach ? views : [];
 
@@ -637,6 +637,7 @@ const CollectionView = Backbone.View.extend({
       return;
     }
 
+    view._shouldDisableEvents = this.monitorViewEvents === false;
     destroyView(view);
   },
 

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -654,6 +654,9 @@ const CollectionView = Backbone.View.extend({
     }
 
     this.triggerMethod('before:destroy:children', this);
+    if (this.monitorViewEvents === false) {
+      this.Dom.detachContents();
+    }
     _.each(this.children._views, _.bind(this._removeChildView, this));
     this.triggerMethod('destroy:children', this);
   }

--- a/src/region.js
+++ b/src/region.js
@@ -104,8 +104,13 @@ const Region = MarionetteObject.extend({
     parentView._proxyChildViewEvents(view);
   },
 
+  // If the regions parent view is not monitoring its attach/detach events
+  _shouldDisableMonitoring() {
+    return this._parentView && this._parentView.monitorViewEvents === false;
+  },
+
   _attachView(view, options = {}) {
-    const shouldTriggerAttach = !view._isAttached && isNodeAttached(this.el);
+    const shouldTriggerAttach = !view._isAttached && isNodeAttached(this.el) && !this._shouldDisableMonitoring();
     const shouldReplaceEl = typeof options.replaceElement === 'undefined' ? !!_.result(this, 'replaceElement') : !!options.replaceElement;
 
     if (shouldTriggerAttach) {
@@ -296,6 +301,7 @@ const Region = MarionetteObject.extend({
       return view;
     }
 
+    view._shouldDisableEvents = this._shouldDisableMonitoring();
     destroyView(view);
     return view;
   },
@@ -319,7 +325,7 @@ const Region = MarionetteObject.extend({
   },
 
   _detachView(view) {
-    const shouldTriggerDetach = !!view._isAttached;
+    const shouldTriggerDetach = view._isAttached && !this._shouldDisableMonitoring();;
     const shouldRestoreEl = this._isReplaced;
     if (shouldTriggerDetach) {
       triggerMethodOn(view, 'before:detach', view);

--- a/test/unit/common/monitor-view-events.js
+++ b/test/unit/common/monitor-view-events.js
@@ -1,0 +1,40 @@
+import View from '../../../src/view';
+import monitorViewEvents from '../../../src/common/monitor-view-events';
+
+describe('monitorViewEvents', function() {
+  describe('when the monitor is disabled', function() {
+    let view;
+
+    beforeEach(function() {
+      const NonMonitoredView = View.extend({
+        monitorViewEvents: false
+      });
+
+      view = new NonMonitoredView();
+
+      this.sinon.spy(view, 'on');
+    });
+
+    it('should not attach events', function() {
+      monitorViewEvents(view);
+      expect(view.on).to.not.have.been.called;
+    });
+  });
+
+  describe('when the view is already monitored', function() {
+    let view;
+
+    beforeEach(function() {
+      view = new View();
+
+      monitorViewEvents(view);
+
+      this.sinon.spy(view, 'on');
+    });
+
+    it('should not attach events', function() {
+      monitorViewEvents(view);
+      expect(view.on).to.not.have.been.called;
+    });
+  });
+});

--- a/test/unit/next-collection-view/collection-view-children.spec.js
+++ b/test/unit/next-collection-view/collection-view-children.spec.js
@@ -419,6 +419,51 @@ describe('next CollectionView Children', function() {
           });
         });
       });
+
+      describe('when the collectionView is not monitoring events', function() {
+        beforeEach(function() {
+          const myRegion = new Region({ el: '#fixtures' });
+          myRegion.show(myCollectionView);
+          myCollectionView.monitorViewEvents = false;
+          myCollectionView.addChildView(childView);
+        });
+
+        it('should not trigger "before:attach" event on the childView', function() {
+          expect(childView.onBeforeAttach).to.not.be.called;
+        });
+
+        it('should not trigger "attach" event on the childView', function() {
+          expect(childView.onAttach).to.not.be.called;
+        });
+
+        describe('when removing the childview', function() {
+          beforeEach(function() {
+            myCollectionView.removeChildView(childView);
+          });
+
+          it('should not trigger "before:detach" event on the childView', function() {
+            expect(childView.onBeforeDetach).to.not.be.called;
+          });
+
+          it('should not trigger "detach" event on the childView', function() {
+            expect(childView.onDetach).to.not.be.called;
+          });
+        });
+
+        describe('when detaching the childview', function() {
+          beforeEach(function() {
+            myCollectionView.detachChildView(childView);
+          });
+
+          it('should not trigger "before:detach" event on the childView', function() {
+            expect(childView.onBeforeDetach).to.not.be.called;
+          });
+
+          it('should not trigger "detach" event on the childView', function() {
+            expect(childView.onDetach).to.not.be.called;
+          });
+        });
+      });
     });
 
     describe('when the collectionView is not attached', function() {

--- a/test/unit/next-collection-view/collection-view-children.spec.js
+++ b/test/unit/next-collection-view/collection-view-children.spec.js
@@ -515,23 +515,36 @@ describe('next CollectionView Children', function() {
       myCollectionView.onDestroyChildren = this.sinon.stub();
 
       myCollectionView.render();
-      myCollectionView.destroy();
     });
 
     it('should destroy each view', function() {
+      myCollectionView.destroy();
       myCollectionView.children.each(view => {
         expect(view.isDestroyed()).to.be.true;
       });
     });
 
     it('should trigger "before:destroy:children"', function() {
+      myCollectionView.destroy();
       expect(myCollectionView.onBeforeDestroyChildren)
         .to.be.calledOnce.and.calledWith(myCollectionView);
     });
 
     it('should trigger "destroy:children"', function() {
+      myCollectionView.destroy();
       expect(myCollectionView.onDestroyChildren)
         .to.be.calledOnce.and.calledWith(myCollectionView);
+    });
+
+    describe('when view events are not monitored', function() {
+      it('should detach the contents from the dom prior to destroying', function() {
+        this.sinon.spy(myCollectionView.Dom, 'detachContents');
+        myCollectionView.monitorViewEvents = false;
+        myCollectionView.destroy();
+        expect(myCollectionView.Dom.detachContents).to.have.been.calledOnce
+          .and.calledAfter(myCollectionView.onBeforeDestroyChildren)
+          .and.calledBefore(myCollectionView.onDestroyChildren);
+      });
     });
   });
 

--- a/test/unit/on-attach.spec.js
+++ b/test/unit/on-attach.spec.js
@@ -70,6 +70,64 @@ describe('onAttach', function() {
     region = new Marionette.Region({el: regionEl});
   });
 
+  describe('when showing a view into a region of a view without events monitored', function() {
+    let layoutView;
+    let view;
+
+    beforeEach(function() {
+      const LayoutView = Marionette.View.extend({
+        monitorViewEvents: false,
+        el: '#region',
+        template: _.template('<div id="child"></div>'),
+        regions: {
+          child: '#child'
+        }
+      });
+
+      layoutView = new LayoutView();
+      layoutView.render();
+
+      view = new ChildView();
+      layoutView.showChildView('child', view);
+    });
+
+    it('should not trigger onBeforeAttach on the view', function() {
+      expect(view.onBeforeAttach).to.not.be.called;
+    });
+
+    it('should not trigger onAttach on the view', function() {
+      expect(view.onAttach).to.not.be.called;
+    });
+
+    describe('when destroying the view', function() {
+      beforeEach(function() {
+        layoutView.getRegion('child').destroyView(view);
+      });
+
+      it('should not trigger onBeforeDetach on the view', function() {
+        expect(view.onBeforeDetach).to.not.be.called;
+      });
+
+      it('should not trigger onDetach on the view', function() {
+        expect(view.onDetach).to.not.be.called;
+      });
+    });
+
+    describe('when detaching the view', function() {
+      beforeEach(function() {
+        layoutView.getRegion('child').detachView();
+      });
+
+      it('should not trigger onBeforeDetach on the view', function() {
+        expect(view.onBeforeDetach).to.not.be.called;
+      });
+
+      it('should not trigger onDetach on the view', function() {
+        expect(view.onDetach).to.not.be.called;
+      });
+    });
+  });
+
   describe('when showing a view into a region not attached to the document', function() {
     let detachedRegion;
     let view;


### PR DESCRIPTION
The monitorViewEvents object make `attach`/`detach` events and the `dom:refresh` / `dom:remove` events possible.

Disabling this for a view will make these events unreliable for a view and all of this view's descendants.

That said, for edge-cases where performance is paramount, disabling the monitor can help speed up rendering.

Between this, https://github.com/marionettejs/backbone.marionette/pull/3387 and some other reasonable modifications I'm able to get the js-framework-benchmark down to being amongst the competition.