### PR TITLE
Implementation of named exports

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -1,4 +1,3 @@
-import Backbone from 'backbone';
 import {version} from '../package.json';
 
 import proxy from './utils/proxy';
@@ -33,17 +32,6 @@ import {
   isEnabled,
   setEnabled
 } from './config/features';
-
-const previousMarionette = Backbone.Marionette;
-
-// This allows you to run multiple instances of Marionette on the same
-// webapp. After loading the new version, call `noConflict()` to
-// get a reference to it. At the same time the old version will be
-// returned to Backbone.Marionette.
-export const noConflict = function() {
-  Backbone.Marionette = previousMarionette;
-  return this;
-};
 
 // Utilities
 export const bindEvents = proxy(_bindEvents);

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -3,31 +3,29 @@ import {version} from '../package.json';
 
 import proxy from './utils/proxy';
 import extend from './utils/extend';
-import deprecate from './utils/deprecate';
 
 import {
-  bindEvents,
-  unbindEvents
+  bindEvents as _bindEvents,
+  unbindEvents as _unbindEvents
 } from './common/bind-events';
 import {
-  bindRequests,
-  unbindRequests
+  bindRequests as _bindRequests,
+  unbindRequests as _unbindRequests
 } from './common/bind-requests';
-import getOption from './common/get-option';
-import mergeOptions from './common/merge-options';
+import _getOption from './common/get-option';
+import _mergeOptions from './common/merge-options';
 import monitorViewEvents from './common/monitor-view-events';
-import normalizeMethods from './common/normalize-methods';
-import triggerMethod from './common/trigger-method';
+import _normalizeMethods from './common/normalize-methods';
+import _triggerMethod from './common/trigger-method';
 
 import BackboneViewMixin from './mixins/backboneview';
 
-import MarionetteObject from './object';
+import MnObject from './object';
 import View from './view';
 import CollectionView from './collection-view';
 import Behavior from './behavior';
 import Region from './region';
 import Application from './application';
-import MarionetteError from './error';
 
 import DomApi from './config/dom';
 
@@ -38,56 +36,50 @@ import {
 } from './config/features';
 
 const previousMarionette = Backbone.Marionette;
-const Marionette = Backbone.Marionette = {};
 
 // This allows you to run multiple instances of Marionette on the same
 // webapp. After loading the new version, call `noConflict()` to
 // get a reference to it. At the same time the old version will be
 // returned to Backbone.Marionette.
-Marionette.noConflict = function() {
+export const noConflict = function() {
   Backbone.Marionette = previousMarionette;
   return this;
 };
 
 // Utilities
-Marionette.bindEvents = proxy(bindEvents);
-Marionette.unbindEvents = proxy(unbindEvents);
-Marionette.bindRequests = proxy(bindRequests);
-Marionette.unbindRequests = proxy(unbindRequests);
-Marionette.mergeOptions = proxy(mergeOptions);
-Marionette.getOption = proxy(getOption);
-Marionette.normalizeMethods = proxy(normalizeMethods);
-Marionette.extend = extend;
-Marionette.deprecate = deprecate;
-Marionette.triggerMethod = proxy(triggerMethod);
-Marionette.isEnabled = isEnabled;
-Marionette.setEnabled = setEnabled;
-Marionette.monitorViewEvents = monitorViewEvents;
-Marionette.BackboneViewMixin = BackboneViewMixin;
+export const bindEvents = proxy(_bindEvents);
+export const unbindEvents = proxy(_unbindEvents);
+export const bindRequests = proxy(_bindRequests);
+export const unbindRequests = proxy(_unbindRequests);
+export const mergeOptions = proxy(_mergeOptions);
+export const getOption = proxy(_getOption);
+export const normalizeMethods = proxy(_normalizeMethods);
+export const triggerMethod = proxy(_triggerMethod);
 
-// Classes
-Marionette.Application = Application;
-Marionette.View = View;
-Marionette.CollectionView = CollectionView;
-Marionette.Behavior = Behavior;
-Marionette.Region = Region;
-Marionette.Error = MarionetteError;
-Marionette.Object = MarionetteObject;
 
-// Configuration
-Marionette.FEATURES = FEATURES;
-Marionette.VERSION = version;
-Marionette.DomApi = DomApi;
-Marionette.setDomApi = function(mixin) {
+export const setDomApi = function(mixin) {
   CollectionView.setDomApi(mixin);
   Region.setDomApi(mixin);
   View.setDomApi(mixin);
 };
-Marionette.setRenderer = function(renderer) {
+export const setRenderer = function(renderer) {
   CollectionView.setRenderer(renderer);
   View.setRenderer(renderer);
 };
 
-export {View, CompositeView, CollectionView, NextCollectionView, Region, Behavior,
-  Application, AppRouter, Renderer, TemplateCache}
-export default Marionette;
+export {
+  View,
+  CollectionView,
+  MnObject,
+  Region,
+  Behavior,
+  Application,
+  isEnabled,
+  setEnabled,
+  monitorViewEvents,
+  BackboneViewMixin,
+  extend,
+  DomApi,
+  version as VERSION,
+  FEATURES
+}

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -30,7 +30,6 @@ import Application from './application';
 import DomApi from './config/dom';
 
 import {
-  FEATURES,
   isEnabled,
   setEnabled
 } from './config/features';
@@ -56,6 +55,7 @@ export const getOption = proxy(_getOption);
 export const normalizeMethods = proxy(_normalizeMethods);
 export const triggerMethod = proxy(_triggerMethod);
 
+// Configuration
 
 export const setDomApi = function(mixin) {
   CollectionView.setDomApi(mixin);
@@ -80,6 +80,5 @@ export {
   BackboneViewMixin,
   extend,
   DomApi,
-  version as VERSION,
-  FEATURES
-}
+  version as VERSION
+};

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -88,4 +88,6 @@ Marionette.setRenderer = function(renderer) {
   View.setRenderer(renderer);
 };
 
+export {View, CompositeView, CollectionView, NextCollectionView, Region, Behavior,
+  Application, AppRouter, Renderer, TemplateCache}
 export default Marionette;

--- a/test/unit/backbone.marionette.spec.js
+++ b/test/unit/backbone.marionette.spec.js
@@ -1,5 +1,4 @@
 import _ from 'underscore';
-import Backbone from 'backbone';
 import * as Marionette from '../../src/backbone.marionette';
 import CollectionView from '../../src/collection-view';
 import Region from '../../src/region';
@@ -9,12 +8,6 @@ describe('backbone.marionette', function() {
   'use strict';
 
   describe('when Marionettes on global namespace', function() {
-    it('should have a working noConflict method', function() {
-      var foo = Marionette;
-      expect(Marionette.noConflict()).to.deep.equal(Marionette);
-      Backbone.Marionette = foo;
-    });
-
     it('should have a working getOption method which just returns when no optionName is passed', function() {
       const result = Marionette.getOption();
       expect(result).to.be.equal(undefined);

--- a/test/unit/backbone.marionette.spec.js
+++ b/test/unit/backbone.marionette.spec.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
-import Marionette from '../../src/backbone.marionette';
+import * as Marionette from '../../src/backbone.marionette';
 import CollectionView from '../../src/collection-view';
 import Region from '../../src/region';
 import View from '../../src/view';

--- a/test/unit/common/bind-events.spec.js
+++ b/test/unit/common/bind-events.spec.js
@@ -1,4 +1,7 @@
-describe('Marionette.bindEntityEvents', function() {
+import * as Marionette from '../../../src/backbone.marionette';
+import MarionetteError from '../../../src/error';
+
+describe('Marionette.bindEvents', function() {
   'use strict';
 
   beforeEach(function() {
@@ -110,7 +113,7 @@ describe('Marionette.bindEntityEvents', function() {
     });
 
     it('should error', function() {
-      expect(this.run).to.throw(Marionette.Error, new Marionette.Error({
+      expect(this.run).to.throw(MarionetteError, new MarionetteError({
         message: 'Bindings must be an object.',
         url: 'marionette.functions.html#marionettebindevents'
       }));

--- a/test/unit/common/bind-request.spec.js
+++ b/test/unit/common/bind-request.spec.js
@@ -1,3 +1,6 @@
+import * as Marionette from '../../../src/backbone.marionette';
+import MarionetteError from '../../../src/error';
+
 describe('Marionette.bindRequests', function() {
   'use strict';
 
@@ -81,7 +84,7 @@ describe('Marionette.bindRequests', function() {
     });
 
     it('should error', function() {
-      expect(this.run).to.throw(Marionette.Error, new Marionette.Error({
+      expect(this.run).to.throw(MarionetteError, new MarionetteError({
         message: 'Bindings must be an object.',
         url: 'marionette.functions.html#marionettebindrequests'
       }));

--- a/test/unit/common/build-region.spec.js
+++ b/test/unit/common/build-region.spec.js
@@ -1,3 +1,6 @@
+import * as Marionette from '../../../src/backbone.marionette';
+import MarionetteError from '../../../src/error';
+
 describe('Region', function() {
   describe('.buildRegion', function() {
     beforeEach(function() {
@@ -286,7 +289,7 @@ describe('Region', function() {
       });
 
       it('throws an error', function() {
-        expect(this.buildRegion).to.throw(Marionette.Error, new Marionette.Error({
+        expect(this.buildRegion).to.throw(MarionetteError, new MarionetteError({
           message: 'Improper region configuration type.',
           url: 'marionette.region.html#region-configuration-types'
         }));

--- a/test/unit/error.spec.js
+++ b/test/unit/error.spec.js
@@ -1,11 +1,13 @@
-describe('Marionette.Error', function() {
+import MarionetteError from '../../src/error'
+
+describe('MarionetteError', function() {
   it('should be subclass of native Error', function() {
-    expect(new Marionette.Error()).to.be.instanceOf(Error);
+    expect(new MarionetteError()).to.be.instanceOf(Error);
   });
 
   describe('when passed a message', function() {
     beforeEach(function() {
-      this.error = new Marionette.Error('Foo');
+      this.error = new MarionetteError('Foo');
     });
 
     it('should contain the correct properties', function() {
@@ -22,7 +24,7 @@ describe('Marionette.Error', function() {
 
   describe('when passed a message and options', function() {
     beforeEach(function() {
-      this.error = new Marionette.Error('Foo', {
+      this.error = new MarionetteError('Foo', {
         name: 'Bar'
       });
     });
@@ -41,7 +43,7 @@ describe('Marionette.Error', function() {
 
   describe('when passed a message and options with a url', function() {
     beforeEach(function() {
-      this.error = new Marionette.Error('Foo', {
+      this.error = new MarionetteError('Foo', {
         name: 'Bar',
         url: 'Baz'
       });
@@ -62,7 +64,7 @@ describe('Marionette.Error', function() {
 
   describe('when passed options', function() {
     beforeEach(function() {
-      this.error = new Marionette.Error({
+      this.error = new MarionetteError({
         name: 'Foo',
         message: 'Bar'
       });
@@ -82,7 +84,7 @@ describe('Marionette.Error', function() {
 
   describe('when passed options with a url', function() {
     beforeEach(function() {
-      this.error = new Marionette.Error({
+      this.error = new MarionetteError({
         name: 'Foo',
         message: 'Bar',
         url: 'Baz'
@@ -112,7 +114,7 @@ describe('Marionette.Error', function() {
         message: 'myMessage',
         number: 'myNumber'
       };
-      this.error = new Marionette.Error(this.props);
+      this.error = new MarionetteError(this.props);
     });
 
     it('should contain all the valid error properties', function() {
@@ -127,7 +129,7 @@ describe('Marionette.Error', function() {
         bar: 'myBar',
         baz: 'myBaz'
       };
-      this.error = new Marionette.Error(this.props);
+      this.error = new MarionetteError(this.props);
     });
 
     it('should not contain invalid properties', function() {
@@ -137,14 +139,14 @@ describe('Marionette.Error', function() {
 
   describe('when extended', function() {
     beforeEach(function() {
-      this.TypeError = Marionette.Error.extend();
+      this.TypeError = MarionetteError.extend();
       this.typeError = new this.TypeError('Foo');
     });
 
     it('should subclass the error properly', function() {
       expect(this.typeError)
         .to.be.instanceOf(Error)
-        .to.be.instanceOf(Marionette.Error)
+        .to.be.instanceOf(MarionetteError)
         .to.be.instanceOf(this.TypeError);
     });
   });

--- a/test/unit/mixins/radio.spec.js
+++ b/test/unit/mixins/radio.spec.js
@@ -1,8 +1,11 @@
+import MnObject from '../../../src/object';
+
+
 describe('Radio Mixin on Marionette.Object', function() {
   'use strict';
 
   beforeEach(function() {
-    this.RadioObject = Marionette.Object.extend({
+    this.RadioObject = MnObject.extend({
       onBar: _.noop,
       getBaz: _.noop
     });

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -1,3 +1,5 @@
+import MnObject from '../../src/object';
+
 describe('marionette object', function() {
 
   describe('when creating an object', function() {
@@ -5,7 +7,7 @@ describe('marionette object', function() {
     let options;
 
     beforeEach(function() {
-      const Object = Marionette.Object.extend({
+      const Object = MnObject.extend({
         initialize(opts) {
           this.bindEvents(opts.model, this.modelEvents);
         },
@@ -77,7 +79,7 @@ describe('marionette object', function() {
     let object;
 
     beforeEach(function() {
-      const Object = Marionette.Object.extend({
+      const Object = MnObject.extend({
         onDestroy: this.sinon.stub()
       });
 
@@ -148,11 +150,11 @@ describe('marionette object', function() {
     let Object;
 
     beforeEach(function() {
-      Object = Marionette.Object.extend({
+      Object = MnObject.extend({
         constructor(options) {
           this.options = {};
           this.cid = 'foo';
-          Marionette.Object.apply(this, arguments);
+          MnObject.apply(this, arguments);
         }
       });
     });


### PR DESCRIPTION
### Proposed changes
 - Exports classes and functions as named exports instead of attaching to Marionette instance. The main benefit is to allow tree shaking of unused code. Also helps IDE to auto complete.
 
This is a proof of concept just to trigger discussion, missing to declare some classes and functions. 

It's breaking change.

umd or CommonJS users should not be affected but those using ES modules will not be able to use class definitions attached to Marionette instance

The code below

```
import Mn from 'backbone.marionette'

export default Mn.View.extend({})
```

must be converted to 

```
import {View} from 'backbone.marionette'

export default View.extend({})
```

Other issues
 * how to export Object and Error classes?
 * Backbone.Marionette will not be set to exported Marionette/global.Marionette even in umd build