### PR TITLE
Refactor getUniqueEventName for better perf

### DIFF
--- a/src/utils/get-unique-event-name.js
+++ b/src/utils/get-unique-event-name.js
@@ -4,7 +4,7 @@ import _ from 'underscore';
 const delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
 function uniqueName(eventName, selector) {
-  return [eventName + _.uniqueId('.evt'), selector].join(' ');
+  return `${ eventName }${ _.uniqueId('.evt') } ${ selector }`;
 }
 
 // Set event name to be namespaced using a unique index


### PR DESCRIPTION
Template literal was much faster than array join and cleaner looking code.

@marionettejs/marionette-core I think this one should be pretty easy.