### PR TITLE
Add hasContents to DomApi and fix view isRendered bug

### DIFF
--- a/docs/dom.api.md
+++ b/docs/dom.api.md
@@ -46,6 +46,10 @@ functions, this only takes a literal string for its second argument.
 Takes the DOM node `el` and appends the DOM node `contents` to the end of the
 element's contents.
 
+### `hasContents(el)`
+
+Returns a boolean indicating if the `el` has child nodes.
+
 ### `detachContents(el)`
 
 Remove the inner contents of `el` from the DOM while leaving `el` itself in the

--- a/src/config/dom.js
+++ b/src/config/dom.js
@@ -64,6 +64,11 @@ export default {
     _$el.append(_$contents);
   },
 
+  // Does the el have child nodes
+  hasContents(el) {
+    return el.hasChildNodes();
+  },
+
   // Remove the inner contents of `el` from the DOM while leaving
   // `el` itself in the DOM.
   detachContents(el, _$el = getEl(el)) {

--- a/src/view.js
+++ b/src/view.js
@@ -96,7 +96,7 @@ const View = Backbone.View.extend({
     Backbone.View.prototype.setElement.apply(this, arguments);
 
     if (hasEl) {
-      this._isRendered = !!this.$el.length;
+      this._isRendered = this.Dom.hasContents(this.el);
       this._isAttached = isNodeAttached(this.el);
     }
 

--- a/test/unit/config/dom.js
+++ b/test/unit/config/dom.js
@@ -185,6 +185,20 @@ describe('DomApi', function() {
     });
   });
 
+  describe('#hasContents', function() {
+    it('should return true when el has contents', function() {
+      this.setFixtures('<div id="foo">Existing Html</div>');
+      const domEl = $('#foo')[0];
+      expect(DomApi.hasContents(domEl)).to.be.true;
+    });
+
+    it('should return false when el has no contents', function() {
+      this.setFixtures('<div id="foo"></div>');
+      const domEl = $('#foo')[0];
+      expect(DomApi.hasContents(domEl)).to.be.false;
+    });
+  });
+
   describe('#detachContents', function() {
     let domEl;
     let $detachEl;


### PR DESCRIPTION
When we are determining if a view is previously rendered we were using `$el` which caused issues when trying to implement backbone.nativeview.

Not only that, but I believe the current implementation should be considered a bug.  A view is rendered if a template is render inside the view's _el_.  The current check is just seeing if the view already has an _el_ and not whether it contained any value.  I believe this is a broken behavior.  We should consider a view rendered only if the view's el contains content.
