### PR TITLE
Append only added views if they're added at the end

### DIFF
--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -122,7 +122,7 @@ const CollectionView = Backbone.View.extend({
     // Remove first since it'll be a shorter array lookup.
     const removedViews = this._removeChildModels(changes.removed);
 
-    this._addChildModels(changes.added);
+    this._addedViews = this._addChildModels(changes.added);
 
     this._detachChildren(removedViews);
 
@@ -425,10 +425,22 @@ const CollectionView = Backbone.View.extend({
     return this;
   },
 
+  _isAddedAtEnd(addedView, index, addedViews) {
+    const viewIndex = this.children._views.length - addedViews.length + index;
+    return addedView === this.children._views[viewIndex];
+  },
+
   _filterChildren() {
     const viewFilter = this._getFilter();
+    const addedViews = this._addedViews;
+
+    delete this._addedViews;
 
     if (!viewFilter) {
+      if (addedViews && _.every(addedViews, _.bind(this._isAddedAtEnd, this))) {
+        return addedViews;
+      }
+
       return this.children._views;
     }
 
@@ -584,6 +596,7 @@ const CollectionView = Backbone.View.extend({
     }
 
     this._addChild(view, index);
+    this._addedViews = [view];
     this._showChildren();
 
     return view;
@@ -644,6 +657,7 @@ const CollectionView = Backbone.View.extend({
   _removeChildren() {
     this._destroyChildren();
     this.emptyRegion.destroy();
+    delete this._addedViews;
   },
 
   // Destroy the child views that this collection view is holding on to, if any

--- a/test/unit/next-collection-view/collection-view-children.spec.js
+++ b/test/unit/next-collection-view/collection-view-children.spec.js
@@ -1,5 +1,6 @@
 // Tests for the children container integration
 
+import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 import CollectionView from '../../../src/next-collection-view';
@@ -355,6 +356,38 @@ describe('next CollectionView Children', function() {
             anotherView = new AnotherView();
             childView.onBeforeAttach.reset();
             childView.onAttach.reset();
+            myCollectionView.addChildView(anotherView, 0);
+          });
+
+          it('should not trigger "before:attach" event on the childView', function() {
+            expect(childView.onBeforeAttach).to.not.be.called;
+          });
+
+          it('should not trigger "attach" event on the childView', function() {
+            expect(childView.onAttach).to.not.be.called;
+          });
+
+          it('should trigger "before:attach" event on anotherView', function() {
+            expect(anotherView.onBeforeAttach).to.have.been.calledOnce.and.calledWith(anotherView);
+          });
+
+          it('should trigger "attach" event on anotherView', function() {
+            expect(anotherView.onAttach).to.have.been.calledOnce.and.calledWith(anotherView);
+          });
+        });
+
+        describe('when attaching another childview at the end', function() {
+          let anotherView;
+
+          beforeEach(function() {
+            const AnotherView = View.extend({
+              template: _.noop,
+              onBeforeAttach: this.sinon.stub(),
+              onAttach: this.sinon.stub()
+            })
+            anotherView = new AnotherView();
+            childView.onBeforeAttach.reset();
+            childView.onAttach.reset();
             myCollectionView.addChildView(anotherView);
           });
 
@@ -372,6 +405,18 @@ describe('next CollectionView Children', function() {
 
           it('should trigger "attach" event on anotherView', function() {
             expect(anotherView.onAttach).to.have.been.calledOnce.and.calledWith(anotherView);
+          });
+
+          it('should only append the added child', function() {
+            this.sinon.stub(myCollectionView, 'attachHtml');
+            myCollectionView.addChildView(anotherView);
+            const callArgs = myCollectionView.attachHtml.args[0];
+            const attachHtmlEls = callArgs[0];
+            expect($(attachHtmlEls).children()).to.have.lengthOf(1);
+          });
+
+          it('should still have all children attached', function() {
+            expect(myCollectionView.$el.children()).to.have.lengthOf(2);
           });
         });
 

--- a/test/unit/next-collection-view/collection-view-data.spec.js
+++ b/test/unit/next-collection-view/collection-view-data.spec.js
@@ -1,5 +1,6 @@
 // Anything related to Bb.collection events
 
+import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 import CollectionView from '../../../src/next-collection-view';
@@ -201,6 +202,33 @@ describe('next CollectionView Data', function() {
       it('should destroy the child', function() {
         expect(removingViewDestroyStub).to.have.been.calledOnce;
       });
+    });
+  });
+
+  describe('when adding models only to the end of the collection', function() {
+    let myCollectionView;
+    let collection;
+
+    beforeEach(function() {
+      collection = new Backbone.Collection([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+      myCollectionView = new MyCollectionView({ collection });
+      myCollectionView.render();
+    });
+
+    it('should only append the added children', function() {
+      this.sinon.stub(myCollectionView, 'attachHtml');
+      collection.add([{ id: 4 }, { id: 5 }]);
+
+      const callArgs = myCollectionView.attachHtml.args[0];
+      const attachHtmlEls = callArgs[0];
+      expect($(attachHtmlEls).children()).to.have.lengthOf(2);
+    });
+
+    it('should still have all children attached', function() {
+      collection.add([{ id: 4 }, { id: 5 }]);
+
+      expect(myCollectionView.$el.children()).to.have.lengthOf(5);
     });
   });
 });


### PR DESCRIPTION
Prevents a large re-append when not necessary.  This adds performance benefits when a number of views are added to a large collectionview at the end.

It is unlikely to cause perf issues when it can't be done as the `_.every` will bail at the first moment it can't be used.

It is possible that if you have a small collection and are adding a very large number of views that it isn't worth it, but it shouldn't be too costly even in those circumstances.

In the following screenshot this is how long it takes to create 10000 rows and how long it takes to add 100 rows to the 10000:
<img width="147" alt="screen shot 2017-06-26 at 4 28 27 pm" src="https://user-images.githubusercontent.com/2028470/27530074-fa4aafd6-5a91-11e7-8648-9972fb98ed72.png">

