### PR TITLE
Add swapChildViews to NextCollectionView

### DIFF
--- a/docs/dom.api.md
+++ b/docs/dom.api.md
@@ -36,6 +36,11 @@ Detach `el` from the DOM without removing listeners.
 
 Remove `oldEl` from the DOM and put `newEl` in its place.
 
+### `swapEl(el1, el2)`
+
+Swaps the location of `el1` and `el2` in the DOM.
+Both els must have a parentNode to be able to swap.
+
 ### `setContents(el, html)`
 
 Replace the contents of `el` with the HTML string of `html`. Unlike other DOM

--- a/docs/marionette.nextcollectionviewadvanced.md
+++ b/docs/marionette.nextcollectionviewadvanced.md
@@ -16,6 +16,7 @@
     * [NextCollectionView children's: `findIndexByView`](#nextcollectionview-children-findindexbyview)
   * [NextCollectionView's `removeChildView`](#nextcollectionviews-removechildview)
   * [NextCollectionView's `detachChildView`](#nextcollectionviews-detachchildview)
+  * [NextCollectionView's `swapChildViews`](#nextcollectionviews-swapchildviews)
   * [NextCollectionView childView Iterators And Collection Functions](#nextcollectionview-childview-iterators-and-collection-functions)
 
 * [NextCollectionView's `filter`](#nextcollectionviews-filter)
@@ -181,6 +182,35 @@ Mn.NextCollectionView.extend({
 
 This method is the same as [`removeChildView`](#nextcollectionviews-removechildview)
 with the exception that the removed view is not destroyed.
+
+### NextCollectionView's `swapChildViews`
+
+Swap the location of two views in the `NextCollectionView` `children` and in the `el`.
+This can be useful when sorting is arbitrary or is not performant.
+
+If either of the two views aren't part of the `NextCollectionView` an error will be thrown.
+
+If one child is in the `el` but the other is not, [filter](#nextcollectionviews-filter) will be called.
+
+```javascript
+var Mn = require('backbone.marionette');
+
+var collection = new Backbone.Collection([
+  { name: 'first' },
+  { name: 'middle' },
+  { name: 'last' }
+]);
+
+var myCollection = new Mn.NextCollectionView({
+  collection: collection,
+  childView: MyChildView
+});
+
+myCollection.swapChildViews(myCollection.children.first(), myCollection.children.last());
+
+myCollection.children.first().model.get('name'); // "last"
+myCollection.children.last().model.get('name'); // "first"
+```
 
 ### NextCollectionView childView Iterators And Collection Functions
 

--- a/src/config/dom.js
+++ b/src/config/dom.js
@@ -33,6 +33,11 @@ export default {
     return _$el.find(selector);
   },
 
+  // Returns true if the el contains the node childEl
+  hasEl(el, childEl) {
+    return el.contains(childEl && childEl.parentNode);
+  },
+
   // Detach `el` from the DOM without removing listeners
   detachEl(el, _$el = getEl(el)) {
     _$el.detach();

--- a/src/config/dom.js
+++ b/src/config/dom.js
@@ -53,6 +53,26 @@ export default {
     parent.replaceChild(newEl, oldEl);
   },
 
+  // Swaps the location of `el1` and `el2` in the DOM
+  swapEl(el1, el2) {
+    if (el1 === el2) {
+      return;
+    }
+
+    const parent1 = el1.parentNode;
+    const parent2 = el2.parentNode;
+
+    if (!parent1 || !parent2) {
+      return;
+    }
+
+    const next1 = el1.nextSibling;
+    const next2 = el2.nextSibling;
+
+    parent1.insertBefore(el2, next1);
+    parent2.insertBefore(el1, next2);
+  },
+
   // Replace the contents of `el` with the HTML string of `html`
   setContents(el, html, _$el = getEl(el)) {
     _$el.html(html);

--- a/src/next-child-view-container.js
+++ b/src/next-child-view-container.js
@@ -79,6 +79,20 @@ _.extend(Container.prototype, {
     this._updateLength();
   },
 
+  // Swap views by index
+  _swap(view1, view2) {
+    const view1Index = this.findIndexByView(view1);
+    const view2Index = this.findIndexByView(view2);
+
+    if (view1Index === -1 || view2Index === -1) {
+      return;
+    }
+
+    const swapView = this._views[view1Index];
+    this._views[view1Index] = this._views[view2Index];
+    this._views[view2Index] = swapView;
+  },
+
   // Find a view by the model that was attached to it.
   // Uses the model's `cid` to find it.
   findByModel(model) {
@@ -106,6 +120,10 @@ _.extend(Container.prototype, {
   // Retrieve a view by its `cid` directly
   findByCid(cid) {
     return this._viewsByCid[cid];
+  },
+
+  hasView(view) {
+    return !!this.findByCid(view.cid);
   },
 
   // Remove a view and clean up index references.

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -588,6 +588,11 @@ const CollectionView = Backbone.View.extend({
     this.children._swap(view1, view2);
     this.Dom.swapEl(view1.el, view2.el);
 
+    // If the views are not filtered the same, refilter
+    if (this.Dom.hasEl(this.el, view1.el) !== this.Dom.hasEl(this.el, view2.el)) {
+      this.filter();
+    }
+
     return this;
   },
 

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -577,6 +577,20 @@ const CollectionView = Backbone.View.extend({
     this.Dom.appendContents(this.el, els, {_$el: this.$el});
   },
 
+  swapChildViews(view1, view2) {
+    if (!this.children.hasView(view1) || !this.children.hasView(view2)) {
+      throw new MarionetteError({
+        name: 'ChildSwapError',
+        message: 'Both views must be children of the collection view'
+      });
+    }
+
+    this.children._swap(view1, view2);
+    this.Dom.swapEl(view1.el, view2.el);
+
+    return this;
+  },
+
   // Render the child's view and add it to the HTML for the collection view at a given index, based on the current sort
   addChildView(view, index) {
     if (!view || view._isDestroyed) {

--- a/test/unit/config/dom.js
+++ b/test/unit/config/dom.js
@@ -88,6 +88,27 @@ describe('DomApi', function() {
     });
   });
 
+  describe('#hasEl', function() {
+    let domEl;
+
+    beforeEach(function() {
+      this.setFixtures('<div id="foo"><div id="bar"></div></div>');
+      domEl = $('#foo')[0];
+    });
+
+    describe('when the node is within the el', function() {
+      it('should return true', function() {
+        expect(DomApi.hasEl(domEl, $('#bar')[0])).to.be.true;
+      });
+    });
+
+    describe('when the node is not within the el', function() {
+      it('should return false', function() {
+        expect(DomApi.hasEl(domEl, $('<div>')[0])).to.be.false;
+      });
+    });
+  });
+
   describe('#detachEl', function() {
     let $domEl;
     let domEl;

--- a/test/unit/config/dom.js
+++ b/test/unit/config/dom.js
@@ -137,7 +137,7 @@ describe('DomApi', function() {
         oldEl = $oldEl[0];
         $oldEl.detach();
         newEl = $('<div>new</div>')[0];
-        expect(_.partial(DomApi.replaceEl, newEl, oldEl)).to.not.throw;
+        expect(_.partial(DomApi.replaceEl, newEl, oldEl)).to.not.throw();
       });
     });
 
@@ -147,6 +147,54 @@ describe('DomApi', function() {
         newEl = $('<div>new</div>')[0];
         DomApi.replaceEl(newEl, oldEl);
         expect(parentEl.innerHTML).to.have.string('new');
+      });
+    });
+  });
+
+  describe('#swapEl', function() {
+    let el1;
+    let el2;
+    let parentEl;
+
+    beforeEach(function() {
+      this.setFixtures('<div id="foo"><div id="bar">1</div><div id="baz">2</div></div>');
+      parentEl = $('#foo')[0];
+    });
+
+    describe('when el1 and el2 are the same', function() {
+      it('should not change anything', function() {
+        el1 = el2 = $('#bar')[0];
+        DomApi.swapEl(el1, el2);
+        expect(parentEl.textContent).to.have.string('12');
+      });
+    });
+
+    describe('when el1 is not attached', function() {
+      it('should not error', function() {
+        const $el1 = $('#bar');
+        el1 = $el1[0];
+        $el1.detach();
+        el2 = $('#baz')[0];
+        expect(_.partial(DomApi.swapEl, el1, el2)).to.not.throw();
+      });
+    });
+
+    describe('when el2 is not attached', function() {
+      it('should not error', function() {
+        const $el2 = $('#baz');
+        el2 = $el2[0];
+        $el2.detach();
+        el1 = $('#bar')[0];
+        expect(_.partial(DomApi.swapEl, el1, el2)).to.not.throw();
+      });
+    });
+
+    describe('when both els are attached', function() {
+      it('should swap the contents', function() {
+        el1 = $('#bar')[0];
+        el2 = $('#baz')[0];
+        DomApi.swapEl(el1, el2);
+        expect(parentEl.textContent).to.have.string('21');
       });
     });
   });

--- a/test/unit/next-child-view-container.spec.js
+++ b/test/unit/next-child-view-container.spec.js
@@ -386,11 +386,77 @@ describe('#NextChildViewContainer', function() {
         });
       });
 
-      it('should should re-sort the container', function() {
+      it('should re-sort the container', function() {
         expect(container.findByIndex(0).model).to.equal(collection.models[0]);
         expect(container.findByIndex(1).model).to.equal(collection.models[2]);
         expect(container.findByIndex(2).model).to.equal(collection.models[1]);
       });
+    });
+  });
+
+  describe('#_swap', function() {
+    let container;
+    let collection;
+
+    beforeEach(function() {
+      collection = new Backbone.Collection([
+        { id: 1 },
+        { id: 2 },
+        { id: 3 }
+      ]);
+
+      container = new NextChildViewContainer();
+
+      collection.each(model => {
+        const view = new Backbone.View({ model });
+        container._add(view);
+      });
+
+    });
+
+    describe('when both views are in the container', function() {
+      it('should swap the views', function() {
+        container._swap(container.findByIndex(0), container.findByIndex(2));
+
+        expect(container.findByIndex(0).model).to.equal(collection.get(3));
+        expect(container.findByIndex(1).model).to.equal(collection.get(2));
+        expect(container.findByIndex(2).model).to.equal(collection.get(1));
+      });
+    });
+
+    describe('when the first view is not in the container', function() {
+      it('should not swap views', function() {
+        container._swap(new Backbone.View(), container.findByIndex(2));
+
+        expect(container.findByIndex(0).model).to.equal(collection.get(1));
+        expect(container.findByIndex(1).model).to.equal(collection.get(2));
+        expect(container.findByIndex(2).model).to.equal(collection.get(3));
+      });
+    });
+
+    describe('when the second view is not in the container', function() {
+      it('should not swap views', function() {
+        container._swap(container.findByIndex(0), new Backbone.View());
+
+        expect(container.findByIndex(0).model).to.equal(collection.get(1));
+        expect(container.findByIndex(1).model).to.equal(collection.get(2));
+        expect(container.findByIndex(2).model).to.equal(collection.get(3));
+      });
+    });
+  });
+
+  describe('#hasView', function() {
+    it('should return true if a view exists in the container', function() {
+      const container = new NextChildViewContainer();
+      const view = new Backbone.View();
+      container._add(view);
+      expect(container.hasView(view)).to.be.true;
+    });
+
+    it('should return false if a view does not exist in the container', function() {
+      const container = new NextChildViewContainer();
+      const view = new Backbone.View();
+      expect(container.hasView(view)).to.be.false;
     });
   });
 });

--- a/test/unit/next-collection-view/collection-view-children.spec.js
+++ b/test/unit/next-collection-view/collection-view-children.spec.js
@@ -129,6 +129,28 @@ describe('next CollectionView Children', function() {
       it('should return the collectionView', function() {
         expect(collectionView.swapChildViews(view1, view2)).to.equal(collectionView);
       });
+
+      it('should not re-filter the collectionView', function() {
+        this.sinon.spy(collectionView, 'filter');
+
+        collectionView.swapChildViews(view1, view2);
+
+        expect(collectionView.filter).to.not.be.called;
+      });
+
+      describe('when one of the children is attached but the other is not', function() {
+        it('should re-filter the collectionView', function() {
+          collectionView.setFilter(view => {
+            return view.model.id !== 1;
+          });
+
+          this.sinon.spy(collectionView, 'filter');
+
+          collectionView.swapChildViews(view1, view2);
+
+          expect(collectionView.filter).to.have.been.calledOnce;
+        });
+      });
     });
 
     describe('when the first child is not in the collectionview', function() {

--- a/test/unit/next-collection-view/collection-view-children.spec.js
+++ b/test/unit/next-collection-view/collection-view-children.spec.js
@@ -91,6 +91,69 @@ describe('next CollectionView Children', function() {
     });
   });
 
+  describe('#swapChildViews', function() {
+    let collectionView;
+
+    beforeEach(function() {
+      collectionView = new MyCollectionView({ collection });
+      collectionView.render();
+    });
+
+    describe('when both children are in the collectionview', function() {
+      let view1;
+      let view2;
+
+      beforeEach(function() {
+        view1 = collectionView.children.first();
+        view2 = collectionView.children.last();
+      });
+
+      it('should swap the children', function() {
+        this.sinon.spy(collectionView.children, '_swap');
+
+        collectionView.swapChildViews(view1, view2);
+
+        expect(collectionView.children._swap).to.have.been.calledOnce
+          .and.calledWith(view1, view2);
+      });
+
+      it('should swap the els in the DOM', function() {
+        this.sinon.spy(collectionView.Dom, 'swapEl');
+
+        collectionView.swapChildViews(view1, view2);
+
+        expect(collectionView.Dom.swapEl).to.have.been.calledOnce
+          .and.calledWith(view1.el, view2.el);
+      });
+
+      it('should return the collectionView', function() {
+        expect(collectionView.swapChildViews(view1, view2)).to.equal(collectionView);
+      });
+    });
+
+    describe('when the first child is not in the collectionview', function() {
+      it('should throw an error', function() {
+        const view1 = new View();
+        const view2 = collectionView.children.first();
+
+        expect(function() {
+          collectionView.swapChildViews(view1, view2);
+        }).to.throw();
+      });
+    });
+
+    describe('when the second child is not in the collectionview', function() {
+      it('should throw an error', function() {
+        const view1 = collectionView.children.first();
+        const view2 = new View();
+
+        expect(function() {
+          collectionView.swapChildViews(view1, view2);
+        }).to.throw();
+      });
+    });
+  });
+
   describe('#addChildView', function() {
     let myCollectionView;
     let addView;


### PR DESCRIPTION
- Adds `DomApi.swapEl` similar to `DomApi.replaceEl`
- Adds `children.hasView` to `NextCollectionView`

When looking into `js-framework-benchmark` I found there was no real performant way to swap to views in a collectionview.

I'm not sure how I feel about this change, but it does seem rather difficult to achieve outside of such a solution.

There are a couple of things to consider here.  Not all collectionViews must have a collection... while you could still store data on the views and use the `viewComparator` somehow, that is a lot of work if all you want to do is swap them.

If the collectionView does have a collection and is sorting based on the collection _or_ other `viewComparator` even, then this API becomes decidedly less useful as the state of the view order is also managed elsewhere.. however the same could be said for `addChildView`

Before I do any testing or documentation, I thought I'd ask for :eyes:
