### PR TITLE
Remove clones from serialization but extend empty on mixin

### DIFF
--- a/src/composite-view.js
+++ b/src/composite-view.js
@@ -80,7 +80,9 @@ const CompositeView = CollectionView.extend({
 
   // Return the serialized model
   serializeData() {
-    return this.serializeModel();
+    if (this.model) {
+      return this.serializeModel();
+    }
   },
 
   // Renders the model and the collection.

--- a/src/view.js
+++ b/src/view.js
@@ -55,10 +55,6 @@ const View = Backbone.View.extend({
   // Serialize the view's model *or* collection, if
   // it exists, for the template
   serializeData() {
-    if (!this.model && !this.collection) {
-      return {};
-    }
-
     // If we have a model, we serialize that
     if (this.model) {
       return this.serializeModel();
@@ -66,25 +62,23 @@ const View = Backbone.View.extend({
 
     // Otherwise, we serialize the collection,
     // making it available under the `items` property
-    return {
-      items: this.serializeCollection()
-    };
+    if (this.collection) {
+      return {
+        items: this.serializeCollection()
+      };
+    }
   },
 
   // Prepares the special `model` property of a view
-  // for being displayed in the template. By default
-  // we simply clone the attributes. Override this if
+  // for being displayed in the template. Override this if
   // you need a custom transformation for your view's model
   serializeModel() {
-    if (!this.model) { return {}; }
-    return _.clone(this.model.attributes);
+    return this.model.attributes;
   },
 
-  // Serialize a collection by cloning each of
-  // its model's attributes
+  // Serialize a collection
   serializeCollection() {
-    if (!this.collection) { return {}; }
-    return this.collection.map(function(model) { return _.clone(model.attributes); });
+    return _.map(this.collection.models, model => model.attributes);
   },
 
   // Overriding Backbone.View's `setElement` to handle
@@ -171,9 +165,9 @@ const View = Backbone.View.extend({
   // object literal, or a function that returns an object
   // literal. All methods and attributes from this object
   // are copies to the object passed in.
-  mixinTemplateContext(target = {}) {
+  mixinTemplateContext(target) {
     const templateContext = _.result(this, 'templateContext');
-    return _.extend(target, templateContext);
+    return _.extend({}, target, templateContext);
   },
 
   // Attaches the content of a given view.

--- a/test/unit/composite-view/composite-view.spec.js
+++ b/test/unit/composite-view/composite-view.spec.js
@@ -836,8 +836,8 @@ describe('composite view', function() {
       this.sinon.spy(this.view, 'serializeModel');
     });
 
-    it('should return an empty object without data', function() {
-      expect(this.view.serializeData()).to.deep.equal({});
+    it('should return undefined', function() {
+      expect(this.view.serializeData()).to.be.undefined;
     });
 
     describe('and the view has a model', function() {

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -426,8 +426,7 @@ describe('item view', function() {
     });
 
     it('should return an empty object without data', function() {
-      expect(this.itemView.serializeData()).to.deep.equal({});
-      expect(this.itemView.serializeCollection()).to.deep.equal({});
+      expect(this.itemView.serializeData()).to.be.undefined;
     });
 
     describe('and the view has a model', function() {


### PR DESCRIPTION
This is a small perf improvement, but significant over larger data sets.
This still clones model data effectively in the mixinTemplateContext function, but `_.extend({}, target, templateContext)` is a bit faster than `_.extend(_.clone(target), templateContext)`.  Additionally all of the serialize functions were returning `{}` (including, inexplicably `serializeCollection` which should have probably returned `[]`) but it is again cheaper to extend `undefined` rather than `{}`.  `_.map` is also cheaper than `collection.map`

No one of these changes is significant enough, but together it's a small win, and the code seem less complicated.

_However_ depending on how you define it.. this is breaking..  `mixinTemplateContext` which is overridable is currently expecting target to be an empty object when it arrives.. so if someone has overridden it, expecting that.. this is breaking.. or if someone is calling `serialize____` directly.. though I would suggest that is a misuse.

The other behavioral change.. even though model attributes are cloned.. collection attributes added to items are not..  It is super important to clone the model so that templateContext does not mutate the model, but I can't find a clear reason to clone the collection attributes.. since it isn't a deep clone it's a false sense of security.. and I would be highly suspicious of code that iterates of `items` inside `templateContext` and mutates it.  seems extremely unlikely.

I would bet this would be non-breaking for nearly everyone, but v4 is also probably not too far off.. thoughts?
