### PR TITLE
Make NextCollectionView emptyRegion explictly replaceElement: false

### DIFF
--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -72,7 +72,7 @@ const CollectionView = Backbone.View.extend({
 
   // Create an region to show the emptyView
   _initEmptyRegion() {
-    this.emptyRegion = new Region({ el: this.el })
+    this.emptyRegion = new Region({ el: this.el, replaceElement: false });
 
     this.emptyRegion._parentView = this;
   },

--- a/test/unit/next-collection-view/collection-view-empty.spec.js
+++ b/test/unit/next-collection-view/collection-view-empty.spec.js
@@ -4,6 +4,7 @@ import _ from 'underscore';
 import Backbone from 'backbone';
 import CollectionView from '../../../src/next-collection-view';
 import View from '../../../src/view';
+import Region from '../../../src/region';
 
 describe('NextCollectionView -  Empty', function() {
   let MyEmptyView;
@@ -29,6 +30,12 @@ describe('NextCollectionView -  Empty', function() {
 
     beforeEach(function() {
       myCollectionView = new MyCollectionView();
+    });
+
+    it('should be replaceElement: false', function() {
+      Region.prototype.replaceElement = true;
+      expect(myCollectionView.emptyRegion.replaceElement).to.be.false;
+      Region.prototype.replaceElement = false;
     });
 
     it('should instantiate the emptyRegion', function() {


### PR DESCRIPTION
While this is already the default functionality, in the case where a user modifies the default `Marionette.Region.prototype.replaceElement = true` this will prevent the collectionview from being show in a region when empty.
