### PR TITLE
Actually detachContents for perf empty

### DIFF
--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -688,7 +688,7 @@ const CollectionView = Backbone.View.extend({
 
     this.triggerMethod('before:destroy:children', this);
     if (this.monitorViewEvents === false) {
-      this.Dom.detachContents();
+      this.Dom.detachContents(this.el, this.$el);
     }
     _.each(this.children._views, _.bind(this._removeChildView, this));
     this.triggerMethod('destroy:children', this);

--- a/test/unit/next-collection-view/collection-view-children.spec.js
+++ b/test/unit/next-collection-view/collection-view-children.spec.js
@@ -672,6 +672,7 @@ describe('next CollectionView Children', function() {
         myCollectionView.monitorViewEvents = false;
         myCollectionView.destroy();
         expect(myCollectionView.Dom.detachContents).to.have.been.calledOnce
+          .and.calledWith(myCollectionView.el, myCollectionView.$el)
           .and.calledAfter(myCollectionView.onBeforeDestroyChildren)
           .and.calledBefore(myCollectionView.onDestroyChildren);
       });


### PR DESCRIPTION
Fortunately/unfortunately this bug doesn't come up for `$()`, but it clearly wasn't detaching anything.

Not going to cause a problem for anyone upgrading to 3.4 unless they use `monitorViewEvents: false`, but it's definitely a problem
😿 