### PR TITLE
Fix Behavior _setOptions call 

### DIFF
--- a/src/behavior.js
+++ b/src/behavior.js
@@ -38,7 +38,7 @@ const Behavior = MarionetteObject.extend({
 
     this.defaults = _.clone(_.result(this, 'defaults', {}));
 
-    this._setOptions(this.defaults, options);
+    this._setOptions(_.extend({}, this.defaults, options));
     this.mergeOptions(this.options, ClassOptions);
 
     // Construct an internal UI hash using

--- a/test/unit/behavior.spec.js
+++ b/test/unit/behavior.spec.js
@@ -1,0 +1,15 @@
+describe('Behavior', function() {
+  'use strict';
+
+  describe('when instantiating a behavior with some options', function() {
+    beforeEach(function() {
+      this.createOptions = {foo: 'bar'};
+      this.behavior = new Marionette.Behavior(this.createOptions);
+    });
+
+    it('Those options should be merged into instance options', function() {
+      expect(this.behavior.options.foo).to.be.eq(this.createOptions.foo);
+    });
+  });
+
+});


### PR DESCRIPTION
Clone & merge `this.defaults` with `options` before calling `_setOptions` has it takes only one parameter

Fixes issue #3414
