### PR TITLE
Remove pkg.module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "3.4.0",
   "homepage": "https://marionettejs.com/",
   "main": "lib/backbone.marionette.js",
-  "module": "lib/backbone.marionette.esm.js",
   "keywords": [
     "backbone",
     "plugin",


### PR DESCRIPTION
This is breaking in some cases https://github.com/marionettejs/backbone.marionette/pull/3384#issuecomment-320964876

We'll still build the package so people can alias it or import it directly if they really want this, and we'll fix it for everyone for v4.

