### PR TITLE
Allow chaining after setRenderer

### DIFF
--- a/src/config/dom.js
+++ b/src/config/dom.js
@@ -11,6 +11,7 @@ function getEl(el) {
 // Static setter
 export function setDomApi(mixin) {
   this.prototype.Dom = _.extend({}, this.prototype.Dom, mixin);
+  return this;
 }
 
 export default {

--- a/src/view.js
+++ b/src/view.js
@@ -209,6 +209,7 @@ const View = Backbone.View.extend({
   // Sets the renderer for the Marionette.View class
   setRenderer(renderer) {
     this.prototype._renderHtml = renderer;
+    return this;
   },
 
   setDomApi

--- a/test/unit/config/dom.js
+++ b/test/unit/config/dom.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import _ from 'underscore';
-import DomApi from '../../../src/config/dom';
+import DomApi, { setDomApi } from '../../../src/config/dom';
 
 // Copied from https://github.com/jashkenas/underscore/blob/1.8.3/underscore.js#L137
 const MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;
@@ -22,6 +22,14 @@ chai.use(function(_chai, utils) {
 
 
 describe('DomApi', function() {
+  describe('#setDomApi', function() {
+    it('should return the current class', function() {
+      const MyObject = function() {};
+      MyObject.setDomApi = setDomApi;
+      expect(MyObject.setDomApi()).to.be.eq(MyObject);
+    });
+  });
+
   describe('#createBuffer', function() {
     it('should return an appendable node', function() {
       expect(DomApi.createBuffer().appendChild).to.be.a('function');

--- a/test/unit/view.renderer.js
+++ b/test/unit/view.renderer.js
@@ -16,6 +16,12 @@ describe('View.setRenderer', function() {
     model = new Backbone.Model(data);
   });
 
+  describe('when setting a renderer on a View class', function() {
+    it('should return the View class', function() {
+      expect(ViewClass.setRenderer()).to.be.eq(ViewClass);
+    });
+  });
+
   describe('when changing a renderer on a View class', function() {
     let rendererStub;
 


### PR DESCRIPTION
Because one day I get bitten by `export default Mn.View.extend(...).setRenderer(...)`