### PR TITLE
If region selector is not found within a given context return nothing

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -193,8 +193,7 @@ const Region = MarionetteObject.extend({
     const context = _.result(this, 'parentEl');
 
     if (context && _.isString(el)) {
-      const $el = this.Dom.findEl(context, el);
-      if ($el.length) { return $el; }
+      return this.Dom.findEl(context, el);
     }
 
     return this.Dom.getEl(el);

--- a/test/unit/common/build-region.spec.js
+++ b/test/unit/common/build-region.spec.js
@@ -114,6 +114,32 @@ describe('Region', function() {
           it('uses the el', function() {
             expect(this.region.el).to.equal(this.fooSelector);
           });
+
+          describe('with `parentEl` also defined including the selector', function() {
+            beforeEach(function() {
+              this.setFixtures('<div id="parent"><div id="child">text</div></div>');
+              this.parentEl = $('#parent');
+              this.definition = _.defaults({parentEl: this.parentEl, el: '#child' }, this.definition);
+              this.region = this.view.addRegion(_.uniqueId('region_'),this.definition);
+            });
+
+            it('returns the jQuery(el)', function() {
+              expect(this.region.getEl(this.region.el).text()).to.equal($(this.region.el).text());
+            });
+          });
+
+          describe('with `parentEl` also defined excluding the selector', function() {
+            beforeEach(function() {
+              this.setFixtures('<div id="parent"></div><div id="not-child">text</div>');
+              this.parentEl = $('#parent');
+              this.definition = _.defaults({parentEl: this.parentEl, el: '#not-child' }, this.definition);
+              this.region = this.view.addRegion(_.uniqueId('region_'),this.definition);
+            });
+
+            it('returns the jQuery(el)', function() {
+              expect(this.region.getEl(this.region.el).text()).to.not.equal($(this.region.el).text());
+            });
+          });
         });
 
         describe('when el is an HTML node', function() {


### PR DESCRIPTION
Resolves #3424

v3.4.0 introduced a region selector that would fall back to a document query if not found within the `parentEl`, but if a `parentEl` exists the region should not search outside of it.

