### PR TITLE
Add isFirstRender flag during rendering phase

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -117,11 +117,13 @@ const View = Backbone.View.extend({
   render() {
     if (this._isDestroyed) { return this; }
 
-    this.triggerMethod('before:render', this);
+    const isFirstRender = !this._isRendered;
+
+    this.triggerMethod('before:render', this, isFirstRender);
 
     // If this is not the first render call, then we need to
     // re-initialize the `el` for each region
-    if (this._isRendered) {
+    if (!isFirstRender) {
       this._reInitRegions();
     }
 
@@ -129,7 +131,7 @@ const View = Backbone.View.extend({
     this.bindUIElements();
 
     this._isRendered = true;
-    this.triggerMethod('render', this);
+    this.triggerMethod('render', this, isFirstRender);
 
     return this;
   },

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -189,8 +189,26 @@ describe('item view', function() {
       expect(this.onBeforeRenderStub).to.have.been.calledOnce;
     });
 
+    it('should call a "onBeforeRender" with parameter on true if this is the 1st render', function() {
+      expect(this.onBeforeRenderStub).to.have.been.calledWith(this.view, true);
+    });
+
+    it('should call a "onBeforeRender" with parameter on false if this is not the 1st render', function() {
+      this.view.render();
+      expect(this.onBeforeRenderStub).to.have.been.calledWith(this.view, false);
+    });
+
     it('should call an "onRender" method on the view', function() {
       expect(this.onRenderStub).to.have.been.calledOnce;
+    });
+
+    it('should call a "onRender" with parameter on true if this is the 1st render', function() {
+      expect(this.onRenderStub).to.have.been.calledWith(this.view, true);
+    });
+
+    it('should call a "onRender" with parameter on false if this is not the 1st render', function() {
+      this.view.render();
+      expect(this.onRenderStub).to.have.been.calledWith(this.view, false);
     });
 
     it('should call "onBeforeRender" before "onRender"', function() {


### PR DESCRIPTION
Call on `showChildView` to set children views is usually set during `onRender`, but as regions & children are not always erased on re-rendering (it depends on the Renderer the user set) I think you should offer another way to know more easily if this call should be done or not.

Today we have this check

```js
if (!this.getRegion('foo').hasView()) {
  this.showChildView('foo', new myView());
}
```

or user can set its own flag

```js
onRender() {
  this._firstRender = this._firstRender === undefined;
  if (this._firstRender) {
    this.showChildView('foo', new myView());
  }
}
```

I would like Marionette offers the second logic to all Views, because it will be more versatile 

This will be a great feature along with #3427 