### PR TITLE
Fix nextcollectionview render during init on empty

### DIFF
--- a/docs/marionette.nextcollectionview.md
+++ b/docs/marionette.nextcollectionview.md
@@ -189,6 +189,19 @@ var MyNextCollectionView = Mn.NextCollectionView.extend({
 });
 ```
 
+### NextCollectionView's `getEmptyRegion`
+
+When a `NextCollectionView` is instantiated it creates a region for showing the [`emptyView`](#nextcollectionviews-emptyview).
+This region can be requested using the `getEmptyRegion` method. The region will share the `el` with the `NextCollectionView`
+and is shown with [`replaceElement: false`](./marionette.region.md#additional-options).
+
+**Note** The `NextCollectionView` expects to be the only entity managing the region.
+Showing things in this region directly is not advised.
+
+```javascript
+const isEmptyShowing = myNextCollectionView.getEmptyRegion().hasView();
+```
+
 ### NextCollectionView's `emptyViewOptions`
 
 Similar to [`childView`](#nextcollectionviews-childview) and [`childViewOptions`](#nextcollectionviews-childviewoptions),

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -58,7 +58,8 @@ const CollectionView = Backbone.View.extend({
     args[0] = this.options;
     Backbone.View.prototype.constructor.apply(this, args);
 
-    this._initEmptyRegion();
+    // Init empty region
+    this.getEmptyRegion();
 
     this.delegateEntityEvents();
 
@@ -71,10 +72,16 @@ const CollectionView = Backbone.View.extend({
   },
 
   // Create an region to show the emptyView
-  _initEmptyRegion() {
-    this.emptyRegion = new Region({ el: this.el, replaceElement: false });
+  getEmptyRegion() {
+    if (this._emptyRegion && !this._emptyRegion.isDestroyed()) {
+      return this._emptyRegion;
+    }
 
-    this.emptyRegion._parentView = this;
+    this._emptyRegion = new Region({ el: this.el, replaceElement: false });
+
+    this._emptyRegion._parentView = this;
+
+    return this._emptyRegion;
   },
 
   // Configured the initial events that the collection view binds to.
@@ -327,7 +334,9 @@ const CollectionView = Backbone.View.extend({
 
     const options = this._getEmptyViewOptions();
 
-    this.emptyRegion.show(new EmptyView(options));
+    const emptyRegion = this.getEmptyRegion();
+
+    emptyRegion.show(new EmptyView(options));
   },
 
   // Retrieve the empty view class
@@ -341,11 +350,11 @@ const CollectionView = Backbone.View.extend({
 
   // Remove the emptyView
   _destroyEmptyView() {
-
+    const emptyRegion = this.getEmptyRegion();
     // Only empty if a view is show so the region
     // doesn't detach any other unrelated HTML
-    if (this.emptyRegion.hasView()) {
-      this.emptyRegion.empty();
+    if (emptyRegion.hasView()) {
+      emptyRegion.empty();
     }
   },
 
@@ -676,7 +685,8 @@ const CollectionView = Backbone.View.extend({
   // called by ViewMixin destroy
   _removeChildren() {
     this._destroyChildren();
-    this.emptyRegion.destroy();
+    const emptyRegion = this.getEmptyRegion();
+    emptyRegion.destroy();
     delete this._addedViews;
   },
 


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/3431

This seems like a big change, but this removed an undocumented attachment of the `emptyRegion` on a still "experimental" API.  `getEmptyRegion` also, to me, coincides better with `view.getRegion` rather than simply attaching it.  This also prevents having to call `_initEmptyRegion` for any edge case where it may be needed prior to the `el` existing.

This is however new API which should be tested and possibly documented?  I'm not sure this warrants v3.5... maybe, but I do think we should look into getting this in prior to v4 so those on v3 can attempt to switch to this collectionview prior to updating.

@marionettejs/marionette-core thoughts?