### PR TITLE
Update npm-ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 bower_components
+coverage
 docs
 gulp
 jsdoc
@@ -12,6 +13,7 @@ tmp
 .gitignore
 .travis.yml
 bower.json
+cypress.json
 CONTRIBUTING.md
 gulpfile.babel.js
 ISSUE_TEMPLATE.md


### PR DESCRIPTION
Was including coverage reports and cypress.json  (I didn't know it would include files in the `.gitignore` O.o

Quick sanity check on this one @marionettejs/marionette-core 