### PR TITLE
Remove Marionette.Object Inheritance

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -198,6 +198,10 @@ app.start({
 The Marionette Application provides helper methods for managing its attached
 region.
 
+### `initialize`
+
+### `triggerMethod`
+
 ### `getRegion()`
 
 Return the attached [region object](./marionette.region.md) for the Application.
@@ -212,8 +216,6 @@ Return the view currently being displayed in the Application's attached
 `region`. If the Application is not currently displaying a view, this method
 returns `undefined`.
 
-### Marionette.Object Methods
+### `isDestroyed`
 
-`Marionette.Application` extends `Marionette.Object` and, as such, implements
-the same method interface. See the [`Object`](./marionette.object.md)
-reference for the full list.
+### `destroy`

--- a/docs/marionette.object.md
+++ b/docs/marionette.object.md
@@ -1,8 +1,6 @@
 # Marionette.Object
 
-A base class which other classes can extend from.
-Object incorporates many backbone conventions and utilities
-like `initialize` and `Backbone.Events`.
+Object incorporates backbone conventions `initialize` and `Backbone.Events`.
 Object has all of the [Common Marionette Functionality](./common.md).
 
 ## Documentation Index

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -7,8 +7,6 @@ identify where your region must be displayed.
 See the documentation for [laying out views](./marionette.view.md#laying-out-views---regions) for an introduction in
 managing regions throughout your application.
 
-A Region is a [`Marionette.Object`](./marionette.object.md) and has all of its functionality.
-
 Regions maintain the [View's lifecycle](./viewlifecycle.md#regions-and-the-view-lifecycle) while showing or emptying a view.
 
 ## Documentation Index

--- a/src/application.js
+++ b/src/application.js
@@ -1,26 +1,52 @@
 // Application
 // -----------
+
+import _ from 'underscore';
+import Backbone from 'backbone';
+import extend from './utils/extend';
 import buildRegion from './common/build-region';
-import MarionetteObject from './object';
+import triggerMethod from './common/trigger-method';
+import CommonMixin from './mixins/common';
+import DestroyMixin from './mixins/destroy';
+import RadioMixin from './mixins/radio';
 import Region from './region';
 
 const ClassOptions = [
+  'channelName',
+  'radioEvents',
+  'radioRequests',
   'region',
   'regionClass'
 ];
 
-// A container for a Marionette application.
-const Application = MarionetteObject.extend({
+const Application = function(options) {
+  this._setOptions(options);
+  this.mergeOptions(options, ClassOptions);
+  this.cid = _.uniqueId(this.cidPrefix);
+  this._initRegion();
+  this._initRadio();
+  this.initialize.apply(this, arguments);
+};
+
+Application.extend = extend;
+
+// Application Methods
+// --------------
+
+// Ensure it can trigger events with Backbone.Events
+_.extend(Application.prototype, Backbone.Events, CommonMixin, DestroyMixin, RadioMixin, {
   cidPrefix: 'mna',
 
-  constructor(options) {
-    this._setOptions(options);
+  // This is a noop method intended to be overridden
+  initialize() {},
 
-    this.mergeOptions(options, ClassOptions);
+  triggerMethod,
 
-    this._initRegion();
-
-    MarionetteObject.prototype.constructor.apply(this, arguments);
+  // Kick off all of the application's processes.
+  start(options) {
+    this.triggerMethod('before:start', this, options);
+    this.triggerMethod('start', this, options);
+    return this;
   },
 
   regionClass: Region,
@@ -49,15 +75,7 @@ const Application = MarionetteObject.extend({
 
   getView() {
     return this.getRegion().currentView;
-  },
-
-  // kick off all of the application's processes.
-  start(options) {
-    this.triggerMethod('before:start', this, options);
-    this.triggerMethod('start', this, options);
-    return this;
   }
-
 });
 
 export default Application;

--- a/src/mixins/destroy.js
+++ b/src/mixins/destroy.js
@@ -1,0 +1,18 @@
+export default {
+  _isDestroyed: false,
+
+  isDestroyed() {
+    return this._isDestroyed;
+  },
+
+  destroy(...args) {
+    if (this._isDestroyed) { return this; }
+
+    this.triggerMethod('before:destroy', this, ...args);
+    this._isDestroyed = true;
+    this.triggerMethod('destroy', this, ...args);
+    this.stopListening();
+
+    return this;
+  }
+};

--- a/src/object.js
+++ b/src/object.js
@@ -6,6 +6,7 @@ import Backbone from 'backbone';
 import extend from './utils/extend';
 import triggerMethod from './common/trigger-method';
 import CommonMixin from './mixins/common';
+import DestroyMixin from './mixins/destroy';
 import RadioMixin from './mixins/radio';
 
 const ClassOptions = [
@@ -14,14 +15,11 @@ const ClassOptions = [
   'radioRequests'
 ];
 
-// A Base Class that other Classes should descend from.
 // Object borrows many conventions and utilities from Backbone.
 const MarionetteObject = function(options) {
-  if (!this.hasOwnProperty('options')) {
-    this._setOptions(options);
-  }
+  this._setOptions(options);
   this.mergeOptions(options, ClassOptions);
-  this._setCid();
+  this.cid = _.uniqueId(this.cidPrefix);
   this._initRadio();
   this.initialize.apply(this, arguments);
 };
@@ -32,35 +30,11 @@ MarionetteObject.extend = extend;
 // --------------
 
 // Ensure it can trigger events with Backbone.Events
-_.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, RadioMixin, {
+_.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, DestroyMixin, RadioMixin, {
   cidPrefix: 'mno',
 
-  // for parity with Marionette.AbstractView lifecyle
-  _isDestroyed: false,
-
-  isDestroyed() {
-    return this._isDestroyed;
-  },
-
-  //this is a noop method intended to be overridden by classes that extend from this base
+  // This is a noop method intended to be overridden
   initialize() {},
-
-  _setCid() {
-    if (this.cid) { return; }
-    this.cid = _.uniqueId(this.cidPrefix);
-  },
-
-  destroy(...args) {
-    if (this._isDestroyed) { return this; }
-
-    this.triggerMethod('before:destroy', this, ...args);
-
-    this._isDestroyed = true;
-    this.triggerMethod('destroy', this, ...args);
-    this.stopListening();
-
-    return this;
-  },
 
   triggerMethod
 });

--- a/test/unit/common/bind-events.spec.js
+++ b/test/unit/common/bind-events.spec.js
@@ -1,5 +1,6 @@
 import * as Marionette from '../../../src/backbone.marionette';
 import MarionetteError from '../../../src/error';
+import deprecate from '../../../src/utils/deprecate';
 
 describe('Marionette.bindEvents', function() {
   'use strict';
@@ -101,11 +102,11 @@ describe('Marionette.bindEvents', function() {
   describe('when bindings is an object with multiple event-handler pairs', function() {
     beforeEach(function() {
       Marionette.setEnabled('DEV_MODE', true);
-      this.sinon.spy(Marionette.deprecate, '_warn');
-      this.sinon.stub(Marionette.deprecate, '_console', {
+      this.sinon.spy(deprecate, '_warn');
+      this.sinon.stub(deprecate, '_console', {
         warn: this.sinon.stub()
       });
-      Marionette.deprecate._cache = {};
+      deprecate._cache = {};
       Marionette.bindEvents(this.target, this.entity, {
         'foo': 'handleFoo handleMulti',
         'bar': 'handleBar'
@@ -116,8 +117,8 @@ describe('Marionette.bindEvents', function() {
       Marionette.setEnabled('DEV_MODE', false);
     });
 
-    it('should call Marionette.deprecate', function() {
-      expect(Marionette.deprecate._warn).to.be.calledWith('Deprecation warning: Multiple handlers for a single event are deprecated. If needed, use a single handler to call multiple methods.');
+    it('should call deprecate', function() {
+      expect(deprecate._warn).to.be.calledWith('Deprecation warning: Multiple handlers for a single event are deprecated. If needed, use a single handler to call multiple methods.');
     });
 
     it('should bind first event to targets handlers', function() {

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -144,33 +144,4 @@ describe('marionette object', function() {
       });
     });
   });
-
-  // Testing internal use cases.
-  describe('when extending an object', function() {
-    let Object;
-
-    beforeEach(function() {
-      Object = MnObject.extend({
-        constructor(options) {
-          this.options = {};
-          this.cid = 'foo';
-          MnObject.apply(this, arguments);
-        }
-      });
-    });
-
-    it('should not re-set the options', function() {
-      this.sinon.spy(Object.prototype, '_setOptions');
-
-      const object = new Object();
-
-      expect(object._setOptions).to.not.have.been.called;
-    });
-
-    it('should not re-set the cid', function() {
-      const object = new Object();
-
-      expect(object.cid).to.equal('foo');
-    });
-  });
 });


### PR DESCRIPTION
~~Would resolve https://github.com/marionettejs/backbone.marionette/issues/3429~~

Before this is dismissed outright.. hear me out.. I believe there's a good case for this.

1. We know that we must rename `Object` for Mn v4 in order for exports to work correctly.  So users will _have_ to rename all instance of `Object` for v4.

2. Object was used as the base for only `Application`, `Region`, and `Behavior`.  It provided the `RadioMixin` interface, `CommonMixin` API, `triggerMethod`, `cid`, `initialize`, and `destroy`.
  - `Application` re-sets options in order for options to be available for `_initRegion`; otherwise it is a `Object`
  - `Behavior` re-sets options as well so they would be available for `ui`.  Additional it completely overrode the `destroy` function and did not implement `_isDestroyed` breaking `isDestroyed()`.  Additionally Behavior gets the full `RadioMixin` API which we do not give to Views because Radio requests cannot be duplicated.. so it does not follow that a behavior should allow for it.  It gets almost no benefit from being an `Object` if anything it causes more issues than it helps.
  - `Region` again re-sets options.  Additionally it added functionality within it's `destroy` that occurred unfortunately before `before:destroy` due to inheritence.  It also broke the destroy api by only passing `options` (though I think it may be reasonable to do that everywhere anyhow, I didn't make that change here)

So I think there is a case, whether or not we decide to remove Object that it should be removed from the inheritence chain of `Region` and `Behavior`.  So this would leave _only_ `Application`.

`Application` has historically been a single point of origin for the app and prior to v3 you could not have multiple instances of it.  However in v3 you can, making `Application` a slightly more useful `Object` with very little perf differences... if any..  I personally have nearly stopped using `Object` altogether using `Application` in its place and find it useful.

Regardless if anyone finds it useful, reducing the API and the inheritance is a good thing.  The inheritance is not buying us anything.  It definitely does not reduce much if any repetition..  Again users will have to rename `Object` as it is.. let's simply remove it.

For those wanting to keep `Object` by some other name.. why would `Application` not work for that use case?

For those wanting to keep `Object` as an inheritance.. why?