### PR TITLE
Use backbone flags to determine whether sorting is before `update`

### DIFF
--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -95,22 +95,13 @@ const CollectionView = Backbone.View.extend({
 
   // Internal method. This checks for any changes in the order of the collection.
   // If the index of any view doesn't match, it will re-sort.
-  _onCollectionSort() {
+  _onCollectionSort(collection, { add, merge, remove }) {
     if (!this.sortWithCollection || this.viewComparator === false) {
       return;
     }
 
-    // If the data is changing we will handle the sort later
-    if (this.collection.length !== this.children.length) {
-      return;
-    }
-
-    // Additional check if the data is changing
-    const hasAddedModel = this.collection.some(model => {
-      return !this.children.findByModel(model);
-    });
-
-    if (hasAddedModel) {
+    // If the data is changing we will handle the sort later in `_onCollectionUpdate`
+    if (add || remove || merge) {
       return;
     }
 


### PR DESCRIPTION
Backbone will pass down flags as options when the `update` event is going to occur.  If all of these flags are false then `sort` was called directly on the collection not through a `set`.  If any of these are `true` then we can expect that the collection will trigger an `update` event which will subsequently resort the children.

I began looking into this from a message on gitter:
> @paulfalgout I'm revisiting code I had before that added an initial item to a collection view via addChildView, but I'm trying it with NextCollectionView now. You gave me some tips on this in Feb https://gitter.im/marionettejs/backbone.marionette?at=58a1f462de50490822c27ece.
However, I'm having an issue with sorting. I noticed the NextCollectionView doesn't resort itself, but now I see you skip sorting if the children length doesn't match the collection length https://github.com/marionettejs/backbone.marionette/blob/0b0cab9f648e0eb7c9d7eec64d31dd04823635a2/src/next-collection-view.js#L103. Doesn't this mean you'd never sort if you used addChildView manually?

But I can't reproduce the issue.  If I can find where this is solving a bug, I will add a test and we should possibly consider a `3.4.4`. Otherwise this can just go in with v4 I would suspect.
