### PR TITLE
Remove redundant View test

### DIFF
--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -484,17 +484,6 @@ describe('layoutView', function() {
     });
   });
 
-  describe('has a valid inheritance chain back to Backbone.View', function() {
-    beforeEach(function() {
-      this.constructor = this.sinon.spy(Backbone.View.prototype, 'constructor');
-      this.layoutView = new Marionette.View();
-    });
-
-    it('calls the parent Backbone.Views constructor function on instantiation', function() {
-      expect(this.constructor).to.have.been.called;
-    });
-  });
-
   describe('when getting a region', function() {
     beforeEach(function() {
       this.layoutView = new this.View();


### PR DESCRIPTION
### Proposed changes
Remove test that check for View inheritance in child-views.spec. This is a left over of LayoutView. The View inheritance is already tested elsewhere