### PR TITLE
Remove triggerMethodOn

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -11,6 +11,8 @@ import getOption from './common/get-option';
 import normalizeMethods from './common/normalize-methods';
 import monitorViewEvents from './common/monitor-view-events';
 
+import BackboneViewMixin from './mixins/backboneview';
+
 import {
   bindEvents,
   unbindEvents
@@ -77,6 +79,7 @@ Marionette.triggerMethodOn = triggerMethodOn;
 Marionette.isEnabled = isEnabled;
 Marionette.setEnabled = setEnabled;
 Marionette.monitorViewEvents = monitorViewEvents;
+Marionette.BackboneViewMixin = BackboneViewMixin;
 
 Marionette.Behaviors = {};
 Marionette.Behaviors.behaviorsLookup = behaviorsLookup;

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -6,7 +6,6 @@ import Backbone from 'backbone';
 import { renderView, destroyView } from './common/view';
 import isNodeAttached from './common/is-node-attached';
 import monitorViewEvents from './common/monitor-view-events';
-import { triggerMethodOn } from './common/trigger-method';
 import ChildViewContainer from './child-view-container';
 import MarionetteError from './error';
 import ViewMixin from './mixins/view';
@@ -82,14 +81,14 @@ const CollectionView = Backbone.View.extend({
     this._isBuffering = false;
 
     _.each(triggerOnChildren, child => {
-      triggerMethodOn(child, 'before:attach', child);
+      child.triggerMethod('before:attach', child);
     });
 
     this.attachBuffer(this, this._createBuffer());
 
     _.each(triggerOnChildren, child => {
       child._isAttached = true;
-      triggerMethodOn(child, 'attach', child);
+      child.triggerMethod('attach', child);
     });
 
     this._bufferedChildren = [];
@@ -604,14 +603,14 @@ const CollectionView = Backbone.View.extend({
     const shouldTriggerAttach = !view._isAttached && !this._isBuffering && this._isAttached && this.monitorViewEvents !== false;
 
     if (shouldTriggerAttach) {
-      triggerMethodOn(view, 'before:attach', view);
+      view.triggerMethod('before:attach', view);
     }
 
     this.attachHtml(this, view, index);
 
     if (shouldTriggerAttach) {
       view._isAttached = true;
-      triggerMethodOn(view, 'attach', view);
+      view.triggerMethod('attach', view);
     }
   },
 

--- a/src/common/monitor-view-events.js
+++ b/src/common/monitor-view-events.js
@@ -2,14 +2,13 @@
 // -----------
 
 import _ from 'underscore';
-import { triggerMethodOn } from './trigger-method';
 
 // Trigger method on children unless a pure Backbone.View
 function triggerMethodChildren(view, event, shouldTrigger) {
   if (!view._getImmediateChildren) { return; }
   _.each(view._getImmediateChildren(), child => {
     if (!shouldTrigger(child)) { return; }
-    triggerMethodOn(child, event, child);
+    child.triggerMethod(event, child);
   });
 }
 
@@ -35,13 +34,13 @@ function shouldDetach(view) {
 
 function triggerDOMRefresh(view) {
   if (view._isAttached && view._isRendered) {
-    triggerMethodOn(view, 'dom:refresh', view);
+    view.triggerMethod('dom:refresh', view);
   }
 }
 
 function triggerDOMRemove(view) {
   if (view._isAttached && view._isRendered) {
-    triggerMethodOn(view, 'dom:remove', view);
+    view.triggerMethod('dom:remove', view);
   }
 }
 

--- a/src/common/trigger-method.js
+++ b/src/common/trigger-method.js
@@ -41,15 +41,3 @@ export function triggerMethod(event, ...args) {
 
   return result;
 }
-
-// triggerMethodOn invokes triggerMethod on a specific context
-//
-// e.g. `Marionette.triggerMethodOn(view, 'show')`
-// will trigger a "show" event or invoke onShow the view.
-export function triggerMethodOn(context, ...args) {
-  if (_.isFunction(context.triggerMethod)) {
-    return context.triggerMethod.apply(context, args);
-  }
-
-  return triggerMethod.apply(context, args);
-}

--- a/src/common/view.js
+++ b/src/common/view.js
@@ -1,19 +1,17 @@
-import { triggerMethodOn } from '../common/trigger-method';
-
 export function renderView(view) {
   if (view._isRendered) {
     return;
   }
 
   if (!view.supportsRenderLifecycle) {
-    triggerMethodOn(view, 'before:render', view);
+    view.triggerMethod('before:render', view);
   }
 
   view.render();
 
   if (!view.supportsRenderLifecycle) {
     view._isRendered = true;
-    triggerMethodOn(view, 'render', view);
+    view.triggerMethod('render', view);
   }
 }
 
@@ -24,25 +22,25 @@ export function destroyView(view) {
   }
 
   if (!view.supportsDestroyLifecycle) {
-    triggerMethodOn(view, 'before:destroy', view);
+    view.triggerMethod('before:destroy', view);
   }
 
   const shouldTriggerDetach = view._isAttached && !view._shouldDisableEvents;
 
   if (shouldTriggerDetach) {
-    triggerMethodOn(view, 'before:detach', view);
+    view.triggerMethod('before:detach', view);
   }
 
   view.remove();
 
   if (shouldTriggerDetach) {
     view._isAttached = false;
-    triggerMethodOn(view, 'detach', view);
+    view.triggerMethod('detach', view);
   }
 
   view._isDestroyed = true;
 
   if (!view.supportsDestroyLifecycle) {
-    triggerMethodOn(view, 'destroy', view);
+    view.triggerMethod('destroy', view);
   }
 }

--- a/src/mixins/backboneview.js
+++ b/src/mixins/backboneview.js
@@ -1,0 +1,5 @@
+import {triggerMethod} from '../common/trigger-method';
+
+export default {
+  triggerMethod: triggerMethod
+}

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -6,7 +6,6 @@ import Backbone from 'backbone';
 import { renderView, destroyView } from './common/view';
 import isNodeAttached from './common/is-node-attached';
 import monitorViewEvents from './common/monitor-view-events';
-import { triggerMethodOn } from './common/trigger-method';
 import ChildViewContainer from './next-child-view-container';
 import MarionetteError from './error';
 import Region from './region';
@@ -528,14 +527,14 @@ const CollectionView = Backbone.View.extend({
   _detachChildView(view) {
     const shouldTriggerDetach = view._isAttached && this.monitorViewEvents !== false;
     if (shouldTriggerDetach) {
-      triggerMethodOn(view, 'before:detach', view);
+      view.triggerMethod('before:detach', view);
     }
 
     this.detachHtml(view);
 
     if (shouldTriggerDetach) {
       view._isAttached = false;
-      triggerMethodOn(view, 'detach', view);
+      view.triggerMethod('detach', view);
     }
   },
 
@@ -568,7 +567,7 @@ const CollectionView = Backbone.View.extend({
 
     _.each(views, view => {
       if (view._isAttached) { return; }
-      triggerMethodOn(view, 'before:attach', view);
+      view.triggerMethod('before:attach', view);
     });
 
     this.attachHtml(els);
@@ -576,7 +575,7 @@ const CollectionView = Backbone.View.extend({
     _.each(views, view => {
       if (view._isAttached) { return; }
       view._isAttached = true;
-      triggerMethodOn(view, 'attach', view);
+      view.triggerMethod('attach', view);
     });
   },
 

--- a/src/region.js
+++ b/src/region.js
@@ -7,7 +7,6 @@ import deprecate from './utils/deprecate';
 import { renderView, destroyView } from './common/view';
 import monitorViewEvents from './common/monitor-view-events';
 import isNodeAttached from './common/is-node-attached';
-import { triggerMethodOn } from './common/trigger-method';
 import MarionetteObject from './object';
 import MarionetteError from './error';
 import View from './view';
@@ -114,7 +113,7 @@ const Region = MarionetteObject.extend({
     const shouldReplaceEl = typeof options.replaceElement === 'undefined' ? !!_.result(this, 'replaceElement') : !!options.replaceElement;
 
     if (shouldTriggerAttach) {
-      triggerMethodOn(view, 'before:attach', view);
+      view.triggerMethod('before:attach', view);
     }
 
     if (shouldReplaceEl) {
@@ -125,7 +124,7 @@ const Region = MarionetteObject.extend({
 
     if (shouldTriggerAttach) {
       view._isAttached = true;
-      triggerMethodOn(view, 'attach', view);
+      view.triggerMethod('attach', view);
     }
   },
 
@@ -329,7 +328,7 @@ const Region = MarionetteObject.extend({
     const shouldTriggerDetach = view._isAttached && !this._shouldDisableMonitoring();;
     const shouldRestoreEl = this._isReplaced;
     if (shouldTriggerDetach) {
-      triggerMethodOn(view, 'before:detach', view);
+      view.triggerMethod('before:detach', view);
     }
 
     if (shouldRestoreEl) {
@@ -340,7 +339,7 @@ const Region = MarionetteObject.extend({
 
     if (shouldTriggerDetach) {
       view._isAttached = false;
-      triggerMethodOn(view, 'detach', view);
+      view.triggerMethod('detach', view);
     }
   },
 

--- a/test/unit/collection-view/collection-view.item-view-options.spec.js
+++ b/test/unit/collection-view/collection-view.item-view-options.spec.js
@@ -63,9 +63,11 @@ describe('collection view - childViewOptions', function() {
   });
 
   describe('when rendering with an empty collection and emptyView', function() {
+    let BBView = Backbone.View.extend();
+    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
     beforeEach(function() {
       this.EmptyCollectionView = Marionette.CollectionView.extend({
-        emptyView: Backbone.View,
+        emptyView: BBView,
         childViewOptions: this.childViewOptionsStub
       });
 

--- a/test/unit/collection-view/collection-view.spec.js
+++ b/test/unit/collection-view/collection-view.spec.js
@@ -11,6 +11,8 @@ describe('collection view', function() {
       }
     });
 
+    _.extend(this.ChildView.prototype, Marionette.BackboneViewMixin);
+
     this.MnChildView = Marionette.View.extend({
       tagName: 'span',
       render: function() {
@@ -46,9 +48,11 @@ describe('collection view', function() {
     });
 
     describe('and it\'s not attached to the document', function() {
+      const BBView = Backbone.View.extend();
+      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
       beforeEach(function() {
         this.collectionView = new this.CollectionView({el: this.$fixtureEl[0]});
-        this.view1 = this.collectionView.addChildView(new Backbone.View({el: this.$fixtureEl.children()[0]}), 0);
+        this.view1 = this.collectionView.addChildView(new BBView({el: this.$fixtureEl.children()[0]}), 0);
       });
 
       it('should have _isAttached set to false', function() {
@@ -62,9 +66,11 @@ describe('collection view', function() {
 
     describe('and it\'s attached to the document', function() {
       beforeEach(function() {
+        var BBView = Backbone.View.extend({});
+        _.extend(BBView.prototype, Marionette.BackboneViewMixin);
         this.setFixtures(this.$fixtureEl);
         this.collectionView = new this.CollectionView({el: '#fixture-collectionview'});
-        this.view1 = this.collectionView.addChildView(new Backbone.View({el: '#el1'}), 0);
+        this.view1 = this.collectionView.addChildView(new BBView({el: '#el1'}), 0);
       });
 
       it('should have _isAttached set to true', function() {
@@ -635,6 +641,7 @@ describe('collection view', function() {
       this.EmptyView = Backbone.View.extend({
         render: function() {}
       });
+      _.extend(this.EmptyView.prototype, Marionette.BackboneViewMixin);
 
       this.CollectionView = this.CollectionView.extend({
         emptyView: this.EmptyView,
@@ -890,10 +897,12 @@ describe('collection view', function() {
   });
 
   describe('when removing a childView that does not have a "destroy" method', function() {
+    const BBView = Backbone.View.extend();
+    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
     beforeEach(function() {
       const collection = new Backbone.Collection([{id: 1}]);
       this.collectionView = new this.CollectionView({
-        childView: Backbone.View,
+        childView: BBView,
         collection
       });
 
@@ -916,9 +925,11 @@ describe('collection view', function() {
   });
 
   describe('when destroying all children', function() {
+    const BBView = Backbone.View.extend();
+    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
     beforeEach(function() {
       this.collectionView = new this.CollectionView({
-        childView: Backbone.View,
+        childView: BBView,
         collection: new Backbone.Collection([{id: 1}, {id: 2}])
       });
 

--- a/test/unit/common/trigger-method.spec.js
+++ b/test/unit/common/trigger-method.spec.js
@@ -151,47 +151,4 @@ describe('trigger event and method name', function() {
       expect(this.onChildviewFooClickStub).to.have.been.calledOnce;
     });
   });
-
-  describe('when triggering an event on another context', function() {
-    describe('when the context has triggerMethod defined', function() {
-      beforeEach(function() {
-        this.view = new Marionette.View();
-        this.triggerMethodSpy = this.sinon.spy(this.view, 'triggerMethod');
-        this.view.onFoo = this.methodHandler;
-        this.view.on('foo', this.eventHandler);
-        Marionette.triggerMethodOn(this.view, 'foo');
-      });
-
-      it('should trigger the event', function() {
-        expect(this.eventHandler).to.have.been.calledOnce;
-      });
-
-      it('should call a method named on{Event}', function() {
-        expect(this.methodHandler).to.have.been.calledOnce;
-      });
-
-      it('should return the value returned by the on{Event} method', function() {
-        expect(this.triggerMethodSpy)
-          .to.have.been.calledOnce
-          .and.returned(this.returnValue);
-      });
-    });
-
-    describe('when the context does not have triggerMethod defined', function() {
-      beforeEach(function() {
-        this.obj = _.extend({}, Backbone.Events);
-        this.obj.onFoo = this.methodHandler;
-        this.obj.on('foo', this.eventHandler);
-        Marionette.triggerMethodOn(this.obj, 'foo');
-      });
-
-      it('should trigger the event', function() {
-        expect(this.eventHandler).to.have.been.calledOnce;
-      });
-
-      it('should call a method named on{Event}', function() {
-        expect(this.methodHandler).to.have.been.calledOnce;
-      });
-    });
-  });
 });

--- a/test/unit/next-collection-view/collection-view-children.spec.js
+++ b/test/unit/next-collection-view/collection-view-children.spec.js
@@ -401,6 +401,8 @@ describe('next CollectionView Children', function() {
         onDestroy: this.sinon.stub()
       });
 
+      _.extend(ChildView.prototype, Marionette.BackboneViewMixin);
+
       childView = new ChildView();
     });
 

--- a/test/unit/next-collection-view/collection-view-empty.spec.js
+++ b/test/unit/next-collection-view/collection-view-empty.spec.js
@@ -136,6 +136,8 @@ describe('NextCollectionView -  Empty', function() {
 
   describe('#emptyView', function() {
     const collection = new Backbone.Collection();
+    const BBView = Backbone.View.extend();
+    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
 
     describe('when emptyView is falsey', function() {
       it('should not show an emptyView', function() {
@@ -172,7 +174,7 @@ describe('NextCollectionView -  Empty', function() {
       it('should show an emptyView from the defined view', function() {
         const myCollectionView = new CollectionView({
           collection,
-          emptyView: Backbone.View
+          emptyView: BBView
         });
 
         this.sinon.spy(myCollectionView.getEmptyRegion(), 'show');
@@ -180,14 +182,14 @@ describe('NextCollectionView -  Empty', function() {
 
         expect(myCollectionView.getEmptyRegion().show)
           .to.be.calledOnce
-          .and.calledWith(sinon.match.instanceOf(Backbone.View));
+          .and.calledWith(sinon.match.instanceOf(BBView));
       });
     });
 
     describe('when emptyView is a function returning a view', function() {
       it('should show an emptyView from the returned view', function() {
         const emptyViewStub = this.sinon.stub();
-        emptyViewStub.returns(Backbone.View);
+        emptyViewStub.returns(BBView);
 
         const myCollectionView = new CollectionView({
           collection,
@@ -199,7 +201,7 @@ describe('NextCollectionView -  Empty', function() {
 
         expect(myCollectionView.getEmptyRegion().show)
           .to.be.calledOnce
-          .and.calledWith(sinon.match.instanceOf(Backbone.View));
+          .and.calledWith(sinon.match.instanceOf(BBView));
       });
     });
 

--- a/test/unit/next-collection-view/collection-view.spec.js
+++ b/test/unit/next-collection-view/collection-view.spec.js
@@ -25,6 +25,7 @@ describe('NextCollectionView', function() {
       onBeforeDestroy: this.sinon.stub(),
       onDestroy: this.sinon.stub(),
     });
+    _.extend(MyBbChildView.prototype, Marionette.BackboneViewMixin);
   });
 
   describe('#constructor', function() {
@@ -144,22 +145,26 @@ describe('NextCollectionView', function() {
 
     describe('when childView is a Backbone.View', function() {
       it('should build children from the defined view', function() {
+        let BBView = Backbone.View.extend();
+        _.extend(BBView.prototype, Marionette.BackboneViewMixin);
         const myCollectionView = new CollectionView({
           collection,
-          childView: Backbone.View
+          childView: BBView
         });
         myCollectionView.render();
 
-        expect(myCollectionView.buildChildView).to.be.calledWith(model, Backbone.View);
+        expect(myCollectionView.buildChildView).to.be.calledWith(model, BBView);
       });
     });
 
     describe('when childView is a function returning a view', function() {
       let myCollectionView;
       let childViewStub;
+      let BBView = Backbone.View.extend();
+      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
       beforeEach(function() {
         childViewStub = this.sinon.stub();
-        childViewStub.returns(Backbone.View);
+        childViewStub.returns(BBView);
 
         myCollectionView = new CollectionView({
           collection,
@@ -169,7 +174,7 @@ describe('NextCollectionView', function() {
       });
 
       it('should build children from the returned view', function() {
-        expect(myCollectionView.buildChildView).to.be.calledWith(model, Backbone.View);
+        expect(myCollectionView.buildChildView).to.be.calledWith(model, BBView);
       });
 
       it('should call childView with the model', function() {

--- a/test/unit/on-attach.spec.js
+++ b/test/unit/on-attach.spec.js
@@ -57,9 +57,11 @@ describe('onAttach', function() {
     EmptyView = Backbone.View.extend(extendAttachMethods(Backbone.View)({
       template: _.noop
     }));
+    _.extend(EmptyView.prototype, Marionette.BackboneViewMixin);
     ChildView = Backbone.View.extend(extendAttachMethods(Backbone.View)({
       template: _.noop
     }));
+    _.extend(ChildView.prototype, Marionette.BackboneViewMixin);
     CollectionView = Marionette.CollectionView.extend({
       childView: ChildView,
       emptyView: EmptyView

--- a/test/unit/on-dom-refresh.spec.js
+++ b/test/unit/on-dom-refresh.spec.js
@@ -8,6 +8,7 @@ describe('onDomRefresh', function() {
     this.BbView = Backbone.View.extend({
       onDomRefresh: this.sinon.stub()
     });
+    _.extend(this.BbView.prototype, Marionette.BackboneViewMixin);
     this.MnView = Marionette.View.extend({
       template: _.noop,
       onDomRefresh: this.sinon.stub()

--- a/test/unit/on-dom-remove.spec.js
+++ b/test/unit/on-dom-remove.spec.js
@@ -8,6 +8,7 @@ describe('onDomRemove', function() {
     this.BbView = Backbone.View.extend({
       onDomRemove: this.sinon.stub()
     });
+    _.extend(this.BbView.prototype, Marionette.BackboneViewMixin);
     this.MnView = Marionette.View.extend({
       template: _.noop,
       onDomRemove: this.sinon.stub()

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -196,6 +196,8 @@ describe('region', function() {
         onClick: this.sinon.stub()
       });
 
+      _.extend(this.MyView.prototype, Marionette.BackboneViewMixin);
+
       this.sinon.stub(this.MyView.prototype, 'onBeforeRender', _.bind(function() { return this.region.currentView; }, this));
 
       this.setFixtures('<div id="region"></div>');
@@ -310,6 +312,8 @@ describe('region', function() {
             $(this.el).addClass('onShowClass');
           }
         });
+
+        _.extend(this.MyView2.prototype, Marionette.BackboneViewMixin);
 
         this.view1 = new this.MyView();
         this.view2 = new this.MyView2();
@@ -671,6 +675,8 @@ describe('region', function() {
         }
       });
 
+      _.extend(this.SubView.prototype, Marionette.BackboneViewMixin);
+
       this.setFixtures('<div id="region"></div>');
       this.region = new this.MyRegion();
       this.attachHtmlSpy = this.sinon.spy(this.region, 'attachHtml');
@@ -712,6 +718,8 @@ describe('region', function() {
         destroy: function() {}
       });
 
+      _.extend(this.MyView.prototype, Marionette.BackboneViewMixin);
+
       this.setFixtures('<div id="region"></div>');
 
       this.view1 = new this.MyView();
@@ -746,6 +754,8 @@ describe('region', function() {
         destroy: function() {},
         attachHtml: function() {}
       });
+
+      _.extend(this.MyView.prototype, Marionette.BackboneViewMixin);
 
       this.setFixtures('<div id="region"></div>');
 
@@ -859,6 +869,8 @@ describe('region', function() {
         destroy: function() {}
       });
 
+      _.extend(this.MyView.prototype, Marionette.BackboneViewMixin);
+
       this.region = new this.MyRegion();
       this.view = new this.MyView();
       this.sinon.spy(this.view, 'destroy');
@@ -914,6 +926,8 @@ describe('region', function() {
 
         destroy: function() {}
       });
+
+      _.extend(this.MyView.prototype, Marionette.BackboneViewMixin);
 
       this.setFixtures('<div id="region"></div>');
 
@@ -983,6 +997,7 @@ describe('region', function() {
           $(this.el).html('some content');
         }
       });
+      _.extend(this.MyView.prototype, Marionette.BackboneViewMixin);
 
       this.view = new this.MyView();
       this.sinon.spy(this.view, '_removeElement');
@@ -1231,6 +1246,8 @@ describe('region', function() {
         onBeforeDestroy: this.sinon.stub(),
         onDestroy: this.sinon.stub()
       });
+      _.extend(BbView.prototype, Marionette.BackboneViewMixin);
+
       this.region = new Marionette.Region({
         el: $('<div></div>')
       });

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -1,6 +1,9 @@
 describe('layoutView', function() {
   'use strict';
 
+  const BBView = Backbone.View.extend();
+  _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
   beforeEach(function() {
     this.layoutViewManagerTemplateFn = _.template('<div id="regionOne"></div><div id="regionTwo"></div>');
     this.template = function() {
@@ -257,7 +260,7 @@ describe('layoutView', function() {
       this.layoutView.render();
 
       // create a basic Backbone child view
-      this.childView = new Backbone.View();
+      this.childView = new BBView();
       this.layoutView.showChildView('regionOne', this.childView);
     });
 
@@ -272,7 +275,7 @@ describe('layoutView', function() {
     beforeEach(function() {
       this.layoutView = new this.View().render();
       this.regionOne = this.layoutView.getRegion('regionOne');
-      this.childView = new Backbone.View();
+      this.childView = new BBView();
       this.sinon.spy(this.regionOne, 'show');
       this.layoutView.showChildView('regionOne', this.childView, options);
     });
@@ -443,7 +446,7 @@ describe('layoutView', function() {
       this.layoutView.render();
 
       this.sinon.spy(this.layoutView.getRegion('regionOne'), 'empty');
-      this.view = new Backbone.View();
+      this.view = new BBView();
       this.view.destroy = function() {};
       this.layoutView.getRegion('regionOne').show(this.view);
 

--- a/test/unit/view.dynamic-regions.spec.js
+++ b/test/unit/view.dynamic-regions.spec.js
@@ -267,8 +267,6 @@ describe('itemView - dynamic regions', function() {
   });
 
   describe('when calling emptyRegions', function() {
-    let BBView = Backbone.View.extend();
-    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
     beforeEach(function() {
 
       this.view = new Marionette.View({

--- a/test/unit/view.dynamic-regions.spec.js
+++ b/test/unit/view.dynamic-regions.spec.js
@@ -1,6 +1,9 @@
 describe('itemView - dynamic regions', function() {
   'use strict';
 
+  const BBView = Backbone.View.extend();
+  _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
   beforeEach(function() {
     this.template = function() {
       return '<div id="foo"></div><div id="bar"></div>';
@@ -29,7 +32,7 @@ describe('itemView - dynamic regions', function() {
 
       this.region = this.layoutView.addRegion('foo', '#foo');
 
-      this.view = new Backbone.View();
+      this.view = new BBView();
       this.layoutView.getRegion('foo').show(this.view);
     });
 
@@ -70,7 +73,7 @@ describe('itemView - dynamic regions', function() {
 
       this.layoutView.render();
 
-      this.view = new Backbone.View();
+      this.view = new BBView();
       this.layoutView.getRegion('foo').show(this.view);
     });
 
@@ -98,7 +101,7 @@ describe('itemView - dynamic regions', function() {
       this.layoutView.render();
       this.layoutView.render();
 
-      this.view = new Backbone.View();
+      this.view = new BBView();
       this.layoutView.getRegion('foo').show(this.view);
     });
 
@@ -131,7 +134,7 @@ describe('itemView - dynamic regions', function() {
       this.layoutView.render();
       this.layoutView.render();
 
-      this.view = new Backbone.View();
+      this.view = new BBView();
       this.layoutView.getRegion('foo').show(this.view);
     });
 
@@ -144,7 +147,7 @@ describe('itemView - dynamic regions', function() {
     });
 
     it('should set the parent of the region to the layoutView', function() {
-      this.region.show(new Backbone.View());
+      this.region.show(new BBView());
       expect(this.region.$el.parent()[0]).to.equal(this.layoutView.el);
     });
 
@@ -176,7 +179,7 @@ describe('itemView - dynamic regions', function() {
       this.onRemoveSpy = this.sinon.spy(this.layoutView, 'onRemoveRegion');
 
       this.layoutView.render();
-      this.layoutView.getRegion('foo').show(new Backbone.View());
+      this.layoutView.getRegion('foo').show(new BBView());
       this.region = this.layoutView.getRegion('foo');
 
       this.region.on('empty', this.emptyHandler);
@@ -227,7 +230,7 @@ describe('itemView - dynamic regions', function() {
       this.layoutView = new this.View();
 
       this.layoutView.render();
-      this.layoutView.getRegion('foo').show(new Backbone.View());
+      this.layoutView.getRegion('foo').show(new BBView());
 
       this.layoutView.removeRegion('foo');
       this.layoutView.render();
@@ -252,7 +255,7 @@ describe('itemView - dynamic regions', function() {
       this.region = this.layoutView.addRegion('foo', '#foo');
       this.region.on('empty', this.emptyHandler);
 
-      this.view = new Backbone.View();
+      this.view = new BBView();
       this.layoutView.getRegion('foo').show(this.view);
 
       this.layoutView.destroy();
@@ -264,6 +267,8 @@ describe('itemView - dynamic regions', function() {
   });
 
   describe('when calling emptyRegions', function() {
+    let BBView = Backbone.View.extend();
+    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
     beforeEach(function() {
 
       this.view = new Marionette.View({
@@ -272,7 +277,7 @@ describe('itemView - dynamic regions', function() {
       this.view.render();
       this.region = this.view.addRegion('foo', '#foo');
       this.regions = this.view.getRegions();
-      this.region.show(new Backbone.View());
+      this.region.show(new BBView());
 
       this.emptyHandler = this.sinon.stub();
       this.region.on('empty', this.emptyHandler);


### PR DESCRIPTION
### Proposed changes
 - Removes `triggerMethodOn`
 - Add `BackboneViewMixin` to support vanilla `Backbone.View`

`triggerMethodOn` is an util function used to support View classes that do not implement `triggerMethod` method and is called in various places. Its implementation adds overhead by adding an extra function call and manipulating the arguments which can impact performance specially in `CollectionView`. Currently this performance penalty affects all Marionette users regardless using vanilla `Backbone.View` or not

With this change, if the developer needs to use vanilla `Backbone.View` with `Marionette` it should apply the `BackboneViewMixin` once, in the start of the app:

```
_.extend(Backbone.View.prototype, Marionette.BackboneViewMixin);
```