### PR TITLE
Remove Mn alias

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -36,7 +36,6 @@ function generateBundle(bundle) {
     sourceMap: true,
     sourceMapFile: 'backbone.marionette.js',
     banner: banner,
-    footer: 'this && this.Marionette && (this.Mn = this.Marionette);',
     globals: rollupGlobals
   });
 }


### PR DESCRIPTION
### Proposed changes
 - Remove Mn alias that is set to global object (window) in umd build. This does not align with current best practices and can be easily set for those that use it: `window.Mn = window.Marionette`
