### PR TITLE
Fix spelling error in upgrade documentation

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -79,7 +79,7 @@ arguments passed as part of `triggerMethod`. This means that the arguments
 passed to `onEvent` and `onChildviewEvent` are now identical. See the
 [documentation on event lifecycles](./viewlifecycle.md) for more information.
 
-In Marionette 2, `childEvents` where bound on every event. In Marionette 3,
+In Marionette 2, `childEvents` were bound on every event. In Marionette 3,
 `childViewEvents` are bound once and cached. This means that you cannot add new
 events after the view has been created.
 


### PR DESCRIPTION
### Proposed changes
In upgrade.md, located at https://marionettejs.com/docs/v3.0.0/upgrade.html#child-event-handlers , there is a spelling error. "`childEvents` where bound" should be "`childEvents` were bound". 

Link to the issue: I didn't create an issue for this, though I will do if you desire. 

This is my first pull request for you guys, apologies if I got the formatting or process wrong, please let me know and I will correct any mistakes. Thanks for all your hard work on marionette, it's a life saver :) 
