### PR TITLE
Remove selector option in Region definition

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -83,7 +83,7 @@ var MyView = Mn.View.extend({
 ### Additional Options
 
 You can define regions with an object literal. Object literal definitions expect
-an `el` property - the CSS selector string to hook the region into. With this
+an `el` property - the selector string to hook the region into. With this
 format is possible to define whether showing the region overwrites the `el` or
 just overwrites the content (the default behavior).
 

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -83,9 +83,9 @@ var MyView = Mn.View.extend({
 ### Additional Options
 
 You can define regions with an object literal. Object literal definitions expect
-an `el` property - the jQuery selector string to hook the region into. The
-object literal is the most common way to define whether showing the region
-overwrites the `el` or just overwrites the content (the default behavior).
+an `el` property - the CSS selector string to hook the region into. With this
+format is possible to define whether showing the region overwrites the `el` or
+just overwrites the content (the default behavior).
 
 To overwrite the parent `el` of the region with the rendered contents of the
 inner View, use `replaceElement` as so:
@@ -122,15 +122,10 @@ removed from the DOM and replaced with an element of `.new-class` - this lets
 us do things like rendering views inside `table` or `select` more easily -
 these elements are usually very strict on what content they will allow.
 
-**_DEPRECATED: The `selector` option of a region is deprecated in favor of using `el`_**
 
 ```js
 var MyView = Mn.View.extend({
   regions: {
-    deprecatedRegionDefinition: {
-      selector: '.foo',
-      replaceElement: true
-    },
     regionDefinition: {
       el: '.bar',
       replaceElement: true

--- a/src/common/build-region.js
+++ b/src/common/build-region.js
@@ -28,11 +28,7 @@ function buildRegionFromDefinition(definition, defaults) {
   }
 
   if (_.isObject(definition)) {
-    if (definition.selector) {
-      deprecate('The selector option on a Region definition object is deprecated. Use el to pass a selector string');
-    }
-
-    _.extend(opts, { el: definition.selector }, definition);
+    _.extend(opts, definition);
 
     return buildRegionFromObject(opts);
   }

--- a/src/common/build-region.js
+++ b/src/common/build-region.js
@@ -1,5 +1,4 @@
 import _ from 'underscore';
-import deprecate from '../utils/deprecate';
 import MarionetteError from '../error';
 import Region from '../region';
 

--- a/test/unit/common/build-region.spec.js
+++ b/test/unit/common/build-region.spec.js
@@ -64,42 +64,6 @@ describe('Region', function() {
     });
 
     describe('with an object literal', function() {
-      describe('with `selector` defined', function() {
-        beforeEach(function() {
-          this.definition = {selector: this.fooSelector};
-          this.region = this.view.addRegion(_.uniqueId('region_'),this.definition);
-        });
-
-        it('uses the default region class', function() {
-          expect(this.region).to.be.an.instanceof(this.DefaultRegionClass);
-        });
-
-        it('uses the selector', function() {
-          expect(this.region.el).to.equal(this.fooSelector);
-        });
-
-        describe('when DEV_MODE is true', function() {
-          beforeEach(function() {
-            Marionette.DEV_MODE = true;
-            this.sinon.spy(Marionette.deprecate, '_warn');
-            this.sinon.stub(Marionette.deprecate, '_console', {
-              warn: this.sinon.stub()
-            });
-            Marionette.deprecate._cache = {};
-
-            this.region = this.view.addRegion(_.uniqueId('region_'),this.definition);
-          });
-
-          it('should call Marionette.deprecate', function() {
-            expect(Marionette.deprecate._warn).to.be.calledWith('Deprecation warning: The selector option on a Region definition object is deprecated. Use el to pass a selector string');
-          });
-
-          afterEach(function() {
-            Marionette.DEV_MODE = false;
-          });
-        });
-      });
-
       describe('with `el` defined', function() {
         describe('when el is a selector string', function() {
           beforeEach(function() {

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -87,16 +87,16 @@ describe('layoutView', function() {
         regionClass: this.CustomRegion1,
         regions: {
           regionOne: {
-            selector: '#regionOne',
+            el: '#regionOne',
             regionClass: this.CustomRegion1
           },
           regionTwo: {
-            selector: '#regionTwo',
+            el: '#regionTwo',
             regionClass: this.CustomRegion2,
             specialOption: true
           },
           regionThree: {
-            selector: '#regionThree'
+            el: '#regionThree'
           },
           regionFour: '#regionFour'
         }
@@ -558,7 +558,7 @@ describe('layoutView', function() {
         regions: {
           war: '@ui.war',
           mario: {
-            selector: '@ui.mario'
+            el: '@ui.mario'
           },
           princess: {
             el: '@ui.princess'


### PR DESCRIPTION
### Proposed changes
 - Using selector in region definition is deprecated. Should use el instead
