### PR TITLE
Make triggerMethod a default export instead of a named export

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -19,7 +19,7 @@
 
 import Backbone from 'backbone';
 import _ from 'underscore';
-import { triggerMethod } from './common/trigger-method';
+import triggerMethod from './common/trigger-method';
 import MarionetteError from './error';
 import CommonMixin from './mixins/common';
 

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -5,27 +5,21 @@ import proxy from './utils/proxy';
 import extend from './utils/extend';
 import deprecate from './utils/deprecate';
 
-import mergeOptions from './common/merge-options';
-import getOption from './common/get-option';
-import normalizeMethods from './common/normalize-methods';
-import monitorViewEvents from './common/monitor-view-events';
-
-import BackboneViewMixin from './mixins/backboneview';
-
 import {
   bindEvents,
   unbindEvents
 } from './common/bind-events';
-
 import {
   bindRequests,
   unbindRequests
 } from './common/bind-requests';
+import getOption from './common/get-option';
+import mergeOptions from './common/merge-options';
+import monitorViewEvents from './common/monitor-view-events';
+import normalizeMethods from './common/normalize-methods';
+import triggerMethod from './common/trigger-method';
 
-import {
-  triggerMethod
-} from './common/trigger-method';
-
+import BackboneViewMixin from './mixins/backboneview';
 
 import MarionetteObject from './object';
 import TemplateCache from './template-cache';

--- a/src/common/trigger-method.js
+++ b/src/common/trigger-method.js
@@ -24,7 +24,7 @@ const getOnMethodName = _.memoize(function(event) {
 //
 // `this.triggerMethod("foo:bar")` will trigger the "foo:bar" event and
 // call the "onFooBar" method.
-export function triggerMethod(event, ...args) {
+export default function triggerMethod(event, ...args) {
   // get the method name from the event name
   const methodName = getOnMethodName(event);
   const method = getOption.call(this, methodName);

--- a/src/mixins/backboneview.js
+++ b/src/mixins/backboneview.js
@@ -1,5 +1,5 @@
-import {triggerMethod} from '../common/trigger-method';
+import triggerMethod from '../common/trigger-method';
 
 export default {
-  triggerMethod: triggerMethod
+  triggerMethod
 }

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import _invoke from '../utils/invoke';
-import { triggerMethod } from '../common/trigger-method';
+import triggerMethod from '../common/trigger-method';
 import MarionetteError from '../error';
 
 // MixinOptions

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -3,7 +3,7 @@
 
 import Backbone from 'backbone';
 import _ from 'underscore';
-import { triggerMethod } from '../common/trigger-method';
+import triggerMethod from '../common/trigger-method';
 import BehaviorsMixin from './behaviors';
 import CommonMixin from './common';
 import DelegateEntityEventsMixin from './delegate-entity-events';

--- a/src/object.js
+++ b/src/object.js
@@ -4,7 +4,7 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
 import extend from './utils/extend';
-import { triggerMethod } from './common/trigger-method';
+import triggerMethod from './common/trigger-method';
 import CommonMixin from './mixins/common';
 import RadioMixin from './mixins/radio';
 


### PR DESCRIPTION
This is more consistent with other common modules that only contain a single method.

This can be done as a result of the removal of the awkward `triggerMethodOn` function.

I also alphabetized and grouped the common module imports together in `backbone.marionette.js`