### PR TITLE
Fix test-browser

### DIFF
--- a/test/unit/collection-view/collection-view.item-view-options.spec.js
+++ b/test/unit/collection-view/collection-view.item-view-options.spec.js
@@ -63,9 +63,10 @@ describe('collection view - childViewOptions', function() {
   });
 
   describe('when rendering with an empty collection and emptyView', function() {
-    let BBView = Backbone.View.extend();
-    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
     beforeEach(function() {
+      const BBView = Backbone.View.extend();
+      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
       this.EmptyCollectionView = Marionette.CollectionView.extend({
         emptyView: BBView,
         childViewOptions: this.childViewOptionsStub

--- a/test/unit/collection-view/collection-view.spec.js
+++ b/test/unit/collection-view/collection-view.spec.js
@@ -48,9 +48,10 @@ describe('collection view', function() {
     });
 
     describe('and it\'s not attached to the document', function() {
-      const BBView = Backbone.View.extend();
-      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
       beforeEach(function() {
+        const BBView = Backbone.View.extend();
+        _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
         this.collectionView = new this.CollectionView({el: this.$fixtureEl[0]});
         this.view1 = this.collectionView.addChildView(new BBView({el: this.$fixtureEl.children()[0]}), 0);
       });
@@ -66,7 +67,7 @@ describe('collection view', function() {
 
     describe('and it\'s attached to the document', function() {
       beforeEach(function() {
-        var BBView = Backbone.View.extend({});
+        const BBView = Backbone.View.extend({});
         _.extend(BBView.prototype, Marionette.BackboneViewMixin);
         this.setFixtures(this.$fixtureEl);
         this.collectionView = new this.CollectionView({el: '#fixture-collectionview'});
@@ -899,9 +900,10 @@ describe('collection view', function() {
   });
 
   describe('when removing a childView that does not have a "destroy" method', function() {
-    const BBView = Backbone.View.extend();
-    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
     beforeEach(function() {
+      const BBView = Backbone.View.extend();
+      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
       const collection = new Backbone.Collection([{id: 1}]);
       this.collectionView = new this.CollectionView({
         childView: BBView,
@@ -927,9 +929,10 @@ describe('collection view', function() {
   });
 
   describe('when destroying all children', function() {
-    const BBView = Backbone.View.extend();
-    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
     beforeEach(function() {
+      const BBView = Backbone.View.extend();
+      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
       this.collectionView = new this.CollectionView({
         childView: BBView,
         collection: new Backbone.Collection([{id: 1}, {id: 2}])

--- a/test/unit/next-collection-view/collection-view-empty.spec.js
+++ b/test/unit/next-collection-view/collection-view-empty.spec.js
@@ -5,6 +5,7 @@ import Backbone from 'backbone';
 import CollectionView from '../../../src/next-collection-view';
 import View from '../../../src/view';
 import Region from '../../../src/region';
+import BackboneViewMixin from '../../../src/mixins/backboneview';
 
 describe('NextCollectionView -  Empty', function() {
   let MyEmptyView;
@@ -137,7 +138,7 @@ describe('NextCollectionView -  Empty', function() {
   describe('#emptyView', function() {
     const collection = new Backbone.Collection();
     const BBView = Backbone.View.extend();
-    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+    _.extend(BBView.prototype, BackboneViewMixin);
 
     describe('when emptyView is falsey', function() {
       it('should not show an emptyView', function() {

--- a/test/unit/next-collection-view/collection-view.spec.js
+++ b/test/unit/next-collection-view/collection-view.spec.js
@@ -5,6 +5,7 @@ import _ from 'underscore';
 import Backbone from 'backbone';
 import CollectionView from '../../../src/next-collection-view';
 import View from '../../../src/view';
+import BackboneViewMixin from '../../../src/mixins/backboneview';
 
 describe('NextCollectionView', function() {
   let MyChildView;
@@ -25,7 +26,7 @@ describe('NextCollectionView', function() {
       onBeforeDestroy: this.sinon.stub(),
       onDestroy: this.sinon.stub(),
     });
-    _.extend(MyBbChildView.prototype, Marionette.BackboneViewMixin);
+    _.extend(MyBbChildView.prototype, BackboneViewMixin);
   });
 
   describe('#constructor', function() {
@@ -146,7 +147,7 @@ describe('NextCollectionView', function() {
     describe('when childView is a Backbone.View', function() {
       it('should build children from the defined view', function() {
         let BBView = Backbone.View.extend();
-        _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+        _.extend(BBView.prototype, BackboneViewMixin);
         const myCollectionView = new CollectionView({
           collection,
           childView: BBView
@@ -161,7 +162,7 @@ describe('NextCollectionView', function() {
       let myCollectionView;
       let childViewStub;
       let BBView = Backbone.View.extend();
-      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+      _.extend(BBView.prototype, BackboneViewMixin);
       beforeEach(function() {
         childViewStub = this.sinon.stub();
         childViewStub.returns(BBView);

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -1,10 +1,10 @@
 describe('layoutView', function() {
   'use strict';
 
-  const BBView = Backbone.View.extend();
-  _.extend(BBView.prototype, Marionette.BackboneViewMixin);
-
   beforeEach(function() {
+    const BBView = Backbone.View.extend();
+    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
     this.layoutViewManagerTemplateFn = _.template('<div id="regionOne"></div><div id="regionTwo"></div>');
     this.template = function() {
       return '<span class=".craft"></span><h1 id="#a-fun-game"></h1>';
@@ -256,6 +256,9 @@ describe('layoutView', function() {
 
   describe('when showing a childView as a basic Backbone.View', function() {
     beforeEach(function() {
+      const BBView = Backbone.View.extend();
+      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
       this.layoutView = new this.View();
       this.layoutView.render();
 
@@ -273,6 +276,9 @@ describe('layoutView', function() {
     var options = {myOption: 'some value'};
 
     beforeEach(function() {
+      const BBView = Backbone.View.extend();
+      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
       this.layoutView = new this.View().render();
       this.regionOne = this.layoutView.getRegion('regionOne');
       this.childView = new BBView();
@@ -432,6 +438,9 @@ describe('layoutView', function() {
 
   describe('when re-rendering an already rendered layoutView', function() {
     beforeEach(function() {
+      const BBView = Backbone.View.extend();
+      _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
       this.ViewBoundRender = this.View.extend({
         initialize: function() {
           if (this.model) {

--- a/test/unit/view.dynamic-regions.spec.js
+++ b/test/unit/view.dynamic-regions.spec.js
@@ -1,10 +1,12 @@
 describe('itemView - dynamic regions', function() {
   'use strict';
 
-  const BBView = Backbone.View.extend();
-  _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+  let BBView;
 
   beforeEach(function() {
+    BBView = Backbone.View.extend();
+    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
+
     this.template = function() {
       return '<div id="foo"></div><div id="bar"></div>';
     };


### PR DESCRIPTION
BBView was being created outside of the test scope which is problematic when relying on globals instead of imports for browser testing.

I thought saucelabs was just being flaky as it definitely was on and off for a while, but turns out the tests were just broken.