### PR TITLE
Add module field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "3.4.3",
   "homepage": "https://marionettejs.com/",
   "main": "lib/backbone.marionette.js",
+  "module": "lib/backbone.marionette.esm.js",
   "keywords": [
     "backbone",
     "plugin",


### PR DESCRIPTION
### Proposed changes
 - Add module field to package.json so bundlers can enable tree shaking: https://github.com/rollup/rollup/wiki/pkg.module

It was added and removed in v3 due to backward compatibility (#3418). With v4 we can do the breaking change
