### PR TITLE
Remove specific throw error

### DIFF
--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -63,7 +63,7 @@ describe('item view', function() {
 
     it('should throw an exception because there was no valid template', function() {
       var self = this;
-      expect(function() {self.view.render()}).to.throw('template is not a function');
+      expect(function() {self.view.render()}).to.throw();
     });
   });
 


### PR DESCRIPTION
IE throws "Object expected" :crying_cat_face:

Due to travis issues with storing keys we're only running saucelabs on merge and not from a forked source PR.  So unfortunately odd-ball IE errors won't be caught until post merge.

