### PR TITLE
Make CollectionView a CompositeView

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -87,6 +87,7 @@ Marionette.setDomApi = function(mixin) {
   View.setDomApi(mixin);
 };
 Marionette.setRenderer = function(renderer) {
+  CollectionView.setRenderer(renderer);
   View.setRenderer(renderer);
 };
 

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -7,6 +7,7 @@ import triggerMethod from '../common/trigger-method';
 import BehaviorsMixin from './behaviors';
 import CommonMixin from './common';
 import DelegateEntityEventsMixin from './delegate-entity-events';
+import TemplateRenderMixin from './template-render';
 import TriggersMixin from './triggers';
 import UIMixin from './ui';
 import { isEnabled } from '../config/features';
@@ -229,6 +230,6 @@ const ViewMixin = {
   }
 };
 
-_.extend(ViewMixin, BehaviorsMixin, CommonMixin, DelegateEntityEventsMixin, TriggersMixin, UIMixin);
+_.extend(ViewMixin, BehaviorsMixin, CommonMixin, DelegateEntityEventsMixin, TemplateRenderMixin, TriggersMixin, UIMixin);
 
 export default ViewMixin;

--- a/src/view.js
+++ b/src/view.js
@@ -6,7 +6,6 @@ import Backbone from 'backbone';
 import monitorViewEvents from './common/monitor-view-events';
 import ViewMixin from './mixins/view';
 import RegionsMixin from './mixins/regions';
-import TemplateRenderMixin from './mixins/template-render';
 import { setDomApi } from './config/dom';
 import { setRenderer } from './config/renderer';
 
@@ -108,6 +107,6 @@ const View = Backbone.View.extend({
   setDomApi
 });
 
-_.extend(View.prototype, ViewMixin, RegionsMixin, TemplateRenderMixin);
+_.extend(View.prototype, ViewMixin, RegionsMixin);
 
 export default View;

--- a/test/unit/backbone.marionette.spec.js
+++ b/test/unit/backbone.marionette.spec.js
@@ -53,6 +53,7 @@ describe('backbone.marionette', function() {
     });
 
     const RendererClasses = {
+      CollectionView,
       View
     };
 

--- a/test/unit/collection-view/collection-view-childviewcontainer.sepc.js
+++ b/test/unit/collection-view/collection-view-childviewcontainer.sepc.js
@@ -1,0 +1,76 @@
+import _ from 'underscore';
+import Backbone from 'backbone';
+import CollectionView from '../../../src/collection-view';
+import View from '../../../src/view';
+
+describe('CollectionView - childViewContainer', function() {
+  let MyCollectionView;
+  let ChildView;
+  let template;
+  let collection;
+
+  beforeEach(function() {
+    collection = new Backbone.Collection([{ foo: 'bar' }, { foo: 'baz' }]);
+
+    template = _.template('<ul id="foo"></ul>bazinga');
+
+    ChildView = View.extend({
+      tagName: 'li',
+      template: _.template('<%=foo%>')
+    });
+
+    MyCollectionView = CollectionView.extend({
+      childView: ChildView
+    });
+  });
+
+  describe('when childViewContainer is undefined', function() {
+    it('should set the $container to the $el', function() {
+      const myCollectionView = new MyCollectionView({ collection });
+      myCollectionView.render();
+
+      expect(myCollectionView.$container).to.equal(myCollectionView.$el);
+    });
+  });
+
+  describe('when childViewContainer is defined', function() {
+    describe('when a selector within the el', function() {
+      it('should should put the children within the found $container', function() {
+        const myCollectionView = new MyCollectionView({
+          collection,
+          template,
+          childViewContainer: '#foo'
+        });
+        myCollectionView.render();
+
+        expect(myCollectionView.$container).to.have.$text('barbaz');
+      });
+    });
+
+    describe('when a selector not within the el', function() {
+      it('should should throw an error', function() {
+        const myCollectionView = new MyCollectionView({
+          collection,
+          template,
+          childViewContainer: '#bar'
+        });
+
+        expect(myCollectionView.render.bind(myCollectionView))
+          .to.throw('The specified "childViewContainer" was not found: #bar');
+      });
+    });
+
+    describe('when a function', function() {
+      it('should should put the children within the found $container', function() {
+        const myCollectionView = new MyCollectionView({
+          collection,
+          template,
+          childViewContainer: _.constant('#foo')
+        });
+        myCollectionView.render();
+
+        expect(myCollectionView.$container).to.have.$text('barbaz');
+      });
+    });
+  });
+});

--- a/test/unit/collection-view/collection-view-data.spec.js
+++ b/test/unit/collection-view/collection-view-data.spec.js
@@ -99,21 +99,47 @@ describe('CollectionView Data', function() {
 
     describe('when the collection resets', function() {
       let myCollectionView;
+      let renderChildrenStub;
+      let destroyChildrenStub;
 
       beforeEach(function() {
+        renderChildrenStub = this.sinon.stub();
+        destroyChildrenStub = this.sinon.stub();
+
         myCollectionView = new MyCollectionView({
-          collection: new Backbone.Collection()
+          collection: new Backbone.Collection([{ id: 1 }], { id: 2 })
         });
 
         myCollectionView.render();
 
-        this.sinon.spy(myCollectionView, 'render');
+        this.sinon.spy(myCollectionView.children, '_init');
 
-        myCollectionView.collection.reset([{ id: 1 }]);
+        myCollectionView.on({
+          'render:children': renderChildrenStub,
+          'destroy:children': destroyChildrenStub
+        });
+
+        myCollectionView.collection.reset([{ id: 3 }]);
       });
 
-      it('should call the render method', function() {
-        expect(myCollectionView.render).to.have.been.called;
+      it('should destroy the children', function() {
+        expect(destroyChildrenStub).to.have.been.calledOnce;
+      });
+
+      it('should re init the children', function() {
+        expect(myCollectionView.children._init).to.have.been.calledOnce;
+      });
+
+      it('should only contain the new children', function() {
+        const myModel = myCollectionView.collection.get(3);
+        const childView = myCollectionView.children.findByModel(myModel);
+
+        expect(childView).to.not.be.undefined;
+        expect(myCollectionView.children).to.have.lengthOf(1);
+      });
+
+      it('should render the new children', function() {
+        expect(renderChildrenStub).to.have.been.calledOnce;
       });
     });
   });

--- a/test/unit/collection-view/collection-view.spec.js
+++ b/test/unit/collection-view/collection-view.spec.js
@@ -44,6 +44,7 @@ describe('CollectionView', function() {
       const mergeOptions = {
         behaviors: {},
         childView: {},
+        childViewContainer: {},
         childViewEventPrefix: 'child',
         childViewEvents: {},
         childViewOptions: {},
@@ -53,6 +54,8 @@ describe('CollectionView', function() {
         emptyViewOptions: {},
         modelEvents: {},
         sortWithCollection: {},
+        template: {},
+        templateContext: {},
         triggers: {},
         ui: {},
         viewComparator: {},


### PR DESCRIPTION
Alternative to https://github.com/marionettejs/backbone.marionette/pull/3433

This PR attempts to make the CollectionView support most of the CompositeView API by default.

This also renders the collectionview if `addChildView` is called on a non-rendered collection.  I _think_ this should be implemented either way as if you add a child view and then show the collection in a region, the region will render any view that isn't flagged as rendered and will remove the added child.

Pros:
No additional class
No inheritance
A lot of functionality for little cost

Cons:
Adding to an already large API
Does add cost even if little

The cost for a regular collectionview:
- 3 additional merged options which would affect initialization
- `this.getTemplate()` and a check against the result
- `_.result(this, 'childViewContainer');` and a check against the result
- a check `!this.$container.length`

the last 3 affecting only the initial render

TODO:
- [x] additional code commenting
- [x] documentation
- [x] tests