### PR TITLE
set childViewEventPrefix flag to false

### DIFF
--- a/src/config/features.js
+++ b/src/config/features.js
@@ -1,7 +1,7 @@
 // Add Feature flags here
 // e.g. 'class' => false
 const FEATURES = {
-  childViewEventPrefix: true,
+  childViewEventPrefix: false,
   triggersStopPropagation: true,
   triggersPreventDefault: true
 };

--- a/test/unit/common/trigger-method.spec.js
+++ b/test/unit/common/trigger-method.spec.js
@@ -134,6 +134,7 @@ describe('trigger event and method name', function() {
 
       this.CollectionView = Marionette.CollectionView.extend({
         childView: this.View,
+        childViewEventPrefix: 'childview',
         onChildviewFooClick: this.onChildviewFooClickStub
       });
 

--- a/test/unit/mixins/view.spec.js
+++ b/test/unit/mixins/view.spec.js
@@ -425,7 +425,7 @@ describe('view mixin', function() {
         Marionette.setEnabled('childViewEventPrefix', false);
       });
 
-      it('should set childViewEventPrefix to false', function() {
+      it('should set childViewEventPrefix to "childview"', function() {
         expect(_.result(myView, 'childViewEventPrefix')).to.equal('childview');
       });
     });

--- a/test/unit/mixins/view.spec.js
+++ b/test/unit/mixins/view.spec.js
@@ -262,6 +262,8 @@ describe('view mixin', function() {
           'child': '.child',
         },
 
+        childViewEventPrefix: 'childview',
+
         childViewEvents: {
           'boom': 'onBoom'
         },
@@ -408,6 +410,23 @@ describe('view mixin', function() {
 
       it('should set childViewEventPrefix to false', function() {
         expect(_.result(myView, 'childViewEventPrefix')).to.be.false;
+      });
+    });
+
+    describe('when childViewEventPrefix flag is true', function() {
+      let myView;
+
+      beforeEach(function() {
+        Marionette.setEnabled('childViewEventPrefix', true);
+        myView = new Marionette.View();
+      });
+
+      afterEach(function() {
+        Marionette.setEnabled('childViewEventPrefix', false);
+      });
+
+      it('should set childViewEventPrefix to false', function() {
+        expect(_.result(myView, 'childViewEventPrefix')).to.equal('childview');
       });
     });
   });


### PR DESCRIPTION
### Proposed changes
 - Set `childViewEventPrefix: false` to be the default case for performance improvements

Link to the issue: https://github.com/marionettejs/backbone.marionette/issues/3476
