### PR TITLE
fix markdown linter warnings

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -259,12 +259,12 @@ defined class.
 ### The `options` Property
 
 The Marionette classes accept an `options` property in the class definition
-which is merged with the `options` argument passed at instantiation. The 
+which is merged with the `options` argument passed at instantiation. The
 values from the passed in `options` overrides the property values.
 
-> The `options` argument passed in `initialize` method is equal to the passed at 
-> class instantiation. To get the option inside initialize considering the 
-> `options` property is necessary to use `getOption`  
+> The `options` argument passed in `initialize` method is equal to the passed at
+> class instantiation. To get the option inside initialize considering the
+> `options` property is necessary to use `getOption`
 
 ```javascript
 var Bb = require('backbone');
@@ -275,15 +275,15 @@ var MyObject = Mn.Object.extend({
     foo: 'bar',
     another: 'thing'
   },
-  
+
   initialize: function(options) {
     console.log(options.foo) // undefined
     console.log(this.getOption('foo')) // 'bar'
-    console.log(this.getOption('another')) // 'value'            
+    console.log(this.getOption('another')) // 'value'
   }
 });
 
-var myObject = new MyObject({    
+var myObject = new MyObject({
   another: 'value'
 });
 ```

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -422,7 +422,7 @@ View [any HTML that doesn't belong to the View will remain](./upgrade.md#changes
 ### Preserving Existing Views
 
 If you replace the current view with a new view by calling `show`, it will
-automatically destroy the previous view. You can prevent this behavior by 
+automatically destroy the previous view. You can prevent this behavior by
 [detaching the view](#detaching-existing-views) before showing another one.
 
 ### Detaching Existing Views


### PR DESCRIPTION
### Proposed changes
 - Fix markdown warnings to clean up linter logs

I thought the trailing whitespaces might be required for ensuring formatting for paragraphs, but they seem to render just fine without the trailing spaces.
