### PR TITLE
reimplement template: false to prevent render events

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -112,27 +112,22 @@ Marionette will [set the appropriate state of the view](./viewlifecycle.md#views
 
 ### Setting a `template` to `false`
 
-**Deprecated:** `template: false` is deprecated.  Use `template: _.noop`
-to render without adding html, or do not render the view. Pre-rendered
-views will instantiate `isRendered() === true`.
-
-Setting the `template` to `false` allows for the view to create all of
-the bindings and trigger all view events without re-rendering the el of
-the view. *Any other falsy value will throw an exception.*
+Setting the `template` to `false` prevents the creation of view bindings and
+does not trigger any view events.
 
 ```javascript
 var Mn = require('backbone.marionette');
 
 var MyView = Mn.View({
   el: '#base-element',
-
-  // template: false is deprecated
-  // Use template: _.noop instead
   template: false
 });
 
 new myView();
 myView.render();
+
+// logs as false
+myView.isRendered();
 ```
 
 ## Laying Out Views - Regions

--- a/src/mixins/template-render.js
+++ b/src/mixins/template-render.js
@@ -1,5 +1,4 @@
 import _ from 'underscore';
-import deprecate from '../utils/deprecate';
 
 // MixinOptions
 // - template
@@ -11,12 +10,6 @@ export default {
   // and template context
   _renderTemplate() {
     const template = this.getTemplate();
-
-    // Allow template-less views
-    if (template === false) {
-      deprecate('template:false is deprecated.  Use _.noop.');
-      return;
-    }
 
     // Add in entity data and template context
     const data = this.mixinTemplateContext(this.serializeData());

--- a/src/mixins/template-render.js
+++ b/src/mixins/template-render.js
@@ -8,9 +8,7 @@ export default {
 
   // Internal method to render the template with the serialized data
   // and template context
-  _renderTemplate() {
-    const template = this.getTemplate();
-
+  _renderTemplate(template) {
     // Add in entity data and template context
     const data = this.mixinTemplateContext(this.serializeData());
 

--- a/src/view.js
+++ b/src/view.js
@@ -71,7 +71,9 @@ const View = Backbone.View.extend({
   // Subsequent renders after the first will re-render all nested
   // views.
   render() {
-    if (this._isDestroyed) { return this; }
+    const template = this.getTemplate();
+
+    if (this._isDestroyed || template === false) { return this; }
 
     this.triggerMethod('before:render', this);
 

--- a/src/view.js
+++ b/src/view.js
@@ -73,7 +73,7 @@ const View = Backbone.View.extend({
   render() {
     const template = this.getTemplate();
 
-    if (this._isDestroyed || template === false) { return this; }
+    if (template === false || this._isDestroyed) { return this; }
 
     this.triggerMethod('before:render', this);
 
@@ -83,7 +83,7 @@ const View = Backbone.View.extend({
       this._reInitRegions();
     }
 
-    this._renderTemplate();
+    this._renderTemplate(template);
     this.bindUIElements();
 
     this._isRendered = true;

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -85,7 +85,6 @@ describe('item view', function() {
       this.view = new this.View();
 
       this.marionetteRendererSpy = this.sinon.spy(this.view, '_renderHtml');
-      this.triggerSpy = this.sinon.spy(this.view, 'trigger');
       this.serializeDataSpy = this.sinon.spy(this.view, 'serializeData');
       this.mixinTemplateContextSpy = this.sinon.spy(this.view, 'mixinTemplateContext');
       this.attachElContentSpy = this.sinon.spy(this.view, 'attachElContent');
@@ -110,14 +109,6 @@ describe('item view', function() {
       expect(this.bindUIElementsSpy).to.not.have.been.called;
     });
 
-    it('should not trigger a before:render event', function() {
-      expect(this.triggerSpy).to.not.have.been.calledWith('before:render', this.view);
-    });
-
-    it('should not trigger a rendered event', function() {
-      expect(this.triggerSpy).to.not.have.been.calledWith('render', this.view);
-    });
-
     it('should not add in data or template context', function() {
       expect(this.serializeDataSpy).to.not.have.been.called;
       expect(this.mixinTemplateContextSpy).to.not.have.been.called;
@@ -133,6 +124,17 @@ describe('item view', function() {
 
     it('should not claim isRendered', function() {
       expect(this.view.isRendered()).to.be.false;
+    });
+
+    describe('and there is prerendered content', function() {
+      beforeEach(function() {
+        this.setFixtures('<div id="foo">bar</div>');
+        this.elView = new this.View({ el: '#foo' });
+      });
+
+      it('should stay rendered', function() {
+        expect(this.elView.isRendered()).to.be.true;
+      });
     });
   });
 

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -94,48 +94,28 @@ describe('item view', function() {
       this.view.render();
     });
 
-    describe('when DEV_MODE is true', function() {
-      beforeEach(function() {
-        Marionette.DEV_MODE = true;
-        this.sinon.spy(Marionette.deprecate, '_warn');
-        this.sinon.stub(Marionette.deprecate, '_console', {
-          warn: this.sinon.stub()
-        });
-        Marionette.deprecate._cache = {};
-      });
-
-      it('should call Marionette.deprecate', function() {
-        this.view.render();
-        expect(Marionette.deprecate._warn).to.be.calledWith('Deprecation warning: template:false is deprecated.  Use _.noop.');
-      });
-
-      afterEach(function() {
-        Marionette.DEV_MODE = false;
-      });
-    });
-
     it('should not throw an exception for a false template', function() {
       expect(_.bind(this.view.render, this.view)).to.not.throw();
     });
 
-    it('should call an "onBeforeRender" method on the view', function() {
-      expect(this.onBeforeRenderStub).to.have.been.calledOnce;
+    it('should not call an "onBeforeRender" method on the view', function() {
+      expect(this.onBeforeRenderStub).to.not.have.been.called;
     });
 
-    it('should call an "onRender" method on the view', function() {
-      expect(this.onRenderStub).to.have.been.calledOnce;
+    it('should not call an "onRender" method on the view', function() {
+      expect(this.onRenderStub).to.not.have.been.called;
     });
 
-    it('should call bindUIElements', function() {
-      expect(this.bindUIElementsSpy).to.have.been.calledOnce;
+    it('should not call bindUIElements', function() {
+      expect(this.bindUIElementsSpy).to.not.have.been.called;
     });
 
-    it('should trigger a before:render event', function() {
-      expect(this.triggerSpy).to.have.been.calledWith('before:render', this.view);
+    it('should not trigger a before:render event', function() {
+      expect(this.triggerSpy).to.not.have.been.calledWith('before:render', this.view);
     });
 
-    it('should trigger a rendered event', function() {
-      expect(this.triggerSpy).to.have.been.calledWith('render', this.view);
+    it('should not trigger a rendered event', function() {
+      expect(this.triggerSpy).to.not.have.been.calledWith('render', this.view);
     });
 
     it('should not add in data or template context', function() {
@@ -151,8 +131,8 @@ describe('item view', function() {
       expect(this.attachElContentSpy).to.not.have.been.called;
     });
 
-    it('should claim isRendered', function() {
-      expect(this.view.isRendered()).to.be.true;
+    it('should not claim isRendered', function() {
+      expect(this.view.isRendered()).to.be.false;
     });
   });
 


### PR DESCRIPTION
### Proposed changes
 - Reimplement `template: false` value.
 - Check in view's `render` for falsy template value and will prevent view bindings and any view event triggers.

Link to the issue: https://github.com/marionettejs/backbone.marionette/issues/3484
