### PR TITLE
Return data without extend if either data isn't defined.

### DIFF
--- a/src/mixins/template-render.js
+++ b/src/mixins/template-render.js
@@ -10,7 +10,7 @@ export default {
   // and template context
   _renderTemplate(template) {
     // Add in entity data and template context
-    const data = this.mixinTemplateContext(this.serializeData());
+    const data = this.mixinTemplateContext(this.serializeData()) || {};
 
     // Render and add to el
     const html = this._renderHtml(template, data);
@@ -32,9 +32,11 @@ export default {
   // object literal, or a function that returns an object
   // literal. All methods and attributes from this object
   // are copies to the object passed in.
-  mixinTemplateContext(target) {
+  mixinTemplateContext(serializedData) {
     const templateContext = _.result(this, 'templateContext');
-    return _.extend({}, target, templateContext);
+    if (!templateContext) { return serializedData; };
+    if (!serializedData) { return templateContext; };
+    return _.extend({}, serializedData, templateContext);
   },
 
   // Serialize the view's model *or* collection, if


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/3500

The `_.extend` is expensive if it is not needed where-as the simple `if`s are cheap.

For those being extremely perf sensitive this will be the ideal scenario with minor change to the typical case where both are defined.

Additionally this is still far cheaper than what is happening in v3.

I also renamed the `target` variable to make this function more explicit in its use.