### PR TITLE
Remove binds from RadioMixin and DeletegateEntityEventsMixin

### DIFF
--- a/src/mixins/delegate-entity-events.js
+++ b/src/mixins/delegate-entity-events.js
@@ -1,10 +1,5 @@
 import _ from 'underscore';
 
-import {
-  bindEvents,
-  unbindEvents
-} from '../common/bind-events';
-
 // MixinOptions
 // - collectionEvents
 // - modelEvents
@@ -15,17 +10,17 @@ export default {
     this._undelegateEntityEvents(model, collection);
 
     const modelEvents = _.result(this, 'modelEvents');
-    bindEvents.call(this, model, modelEvents);
+    this.bindEvents(model, modelEvents);
 
     const collectionEvents = _.result(this, 'collectionEvents');
-    bindEvents.call(this, collection, collectionEvents);
+    this.bindEvents(collection, collectionEvents);
   },
 
   _undelegateEntityEvents(model, collection) {
     const modelEvents = _.result(this, 'modelEvents');
-    unbindEvents.call(this, model, modelEvents);
+    this.unbindEvents(model, modelEvents);
 
     const collectionEvents = _.result(this, 'collectionEvents');
-    unbindEvents.call(this, collection, collectionEvents);
+    this.unbindEvents(collection, collectionEvents);
   }
 };

--- a/src/mixins/radio.js
+++ b/src/mixins/radio.js
@@ -1,16 +1,6 @@
 import _ from 'underscore';
 import Radio from 'backbone.radio';
 
-import {
-  bindRequests,
-  unbindRequests
-} from '../common/bind-requests';
-
-import {
-  bindEvents,
-  unbindEvents
-} from '../common/bind-events';
-
 import MarionetteError from '../error';
 
 // MixinOptions
@@ -52,18 +42,5 @@ export default {
 
   getChannel() {
     return this._channel;
-  },
-
-  // Proxy `bindEvents`
-  bindEvents: bindEvents,
-
-  // Proxy `unbindEvents`
-  unbindEvents: unbindEvents,
-
-  // Proxy `bindRequests`
-  bindRequests: bindRequests,
-
-  // Proxy `unbindRequests`
-  unbindRequests: unbindRequests
-
+  }
 };


### PR DESCRIPTION
The binds are now in the common mixin so this is redundant.
It's not really hurting much, but it may as well not be there.