### PR TITLE
Replace viewFilter _.partition

### DIFF
--- a/src/next-child-view-container.js
+++ b/src/next-child-view-container.js
@@ -48,17 +48,17 @@ _.extend(Container.prototype, {
   },
 
   // Sort (mutate) and return the array of the child views.
-  _sort(comparator) {
+  _sort(comparator, context) {
     if (typeof comparator === 'string') {
       comparator = _.partial(stringComparator, comparator);
       return this._sortBy(comparator);
     }
 
     if (comparator.length === 1) {
-      return this._sortBy(comparator);
+      return this._sortBy(_.bind(comparator, context));
     }
 
-    return this._views.sort(comparator);
+    return this._views.sort(_.bind(comparator, context));
   },
 
   // Makes `_.sortBy` mutate the array to match `this._views.sort`

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -370,12 +370,7 @@ const CollectionView = Backbone.View.extend({
 
     this.triggerMethod('before:sort', this);
 
-    if (_.isFunction(viewComparator)) {
-      // Must use native bind to preserve length
-      viewComparator = viewComparator.bind(this);
-    }
-
-    this.children._sort(viewComparator);
+    this.children._sort(viewComparator, this);
 
     this.triggerMethod('sort', this);
   },

--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -453,13 +453,18 @@ const CollectionView = Backbone.View.extend({
 
     this.triggerMethod('before:filter', this);
 
-    const filteredViews = _.partition(this.children._views, _.bind(viewFilter, this));
+    const attachViews = [];
+    const detachViews = [];
 
-    this._detachChildren(filteredViews[1]);
+    _.each(this.children._views, (view, key, children) => {
+      (viewFilter.call(this, view, key, children) ? attachViews : detachViews).push(view);
+    });
 
-    this.triggerMethod('filter', this);
+    this._detachChildren(detachViews);
 
-    return filteredViews[0];
+    this.triggerMethod('filter', this, attachViews, detachViews);
+
+    return attachViews;
   },
 
   // This method returns a function for the viewFilter

--- a/test/unit/next-child-view-container.spec.js
+++ b/test/unit/next-child-view-container.spec.js
@@ -334,6 +334,7 @@ describe('#NextChildViewContainer', function() {
     describe('when using a sortBy iterator', function() {
       let container;
       let collection;
+      let comparator;
 
       beforeEach(function() {
         collection = new Backbone.Collection([
@@ -349,9 +350,17 @@ describe('#NextChildViewContainer', function() {
           container._add(view);
         });
 
-        container._sort(view => {
+        this.comparator = function(view) {
           return view.model.get('text').substring(1);
-        });
+        };
+
+        comparator = this.sinon.spy(this, 'comparator');
+
+        container._sort(this.comparator, this);
+      });
+
+      it('should call the comparator with context', function() {
+        expect(comparator).to.have.been.calledOn(this);
       });
 
       it('should should re-sort the container', function() {
@@ -364,6 +373,7 @@ describe('#NextChildViewContainer', function() {
     describe('when using a sort iterator', function() {
       let container;
       let collection;
+      let comparator;
 
       beforeEach(function() {
         collection = new Backbone.Collection([
@@ -379,11 +389,19 @@ describe('#NextChildViewContainer', function() {
           container._add(view);
         });
 
-        container._sort((viewa, viewb) => {
+        this.comparator = function(viewa, viewb) {
           const aText = viewa.model.get('text');
           const bText = viewb.model.get('text');
           return bText.localeCompare(aText);
-        });
+        };
+
+        comparator = this.sinon.spy(this, 'comparator');
+
+        container._sort(this.comparator, this);
+      });
+
+      it('should call the comparator with context', function() {
+        expect(comparator).to.have.been.calledOn(this);
       });
 
       it('should re-sort the container', function() {

--- a/test/unit/next-collection-view/collection-view-filtering.spec.js
+++ b/test/unit/next-collection-view/collection-view-filtering.spec.js
@@ -115,9 +115,11 @@ describe('#NextCollectionView - Filtering', function() {
       });
 
       it('should call "filter" event', function() {
-        expect(myCollectionView.onFilter)
-          .to.have.been.calledOnce
-          .and.calledWith(myCollectionView);
+        const calledWith = myCollectionView.onFilter.firstCall.args;
+        expect(myCollectionView.onFilter).to.have.been.calledOnce;
+        expect(calledWith[0]).to.equal(myCollectionView);
+        expect(_.map(calledWith[1], 'model')).to.have.same.members(collectionOddModels);
+        expect(_.map(calledWith[2], 'model')).to.have.same.members(collectionEvenModels);
       });
     });
 

--- a/test/unit/next-collection-view/collection-view-sorting.spec.js
+++ b/test/unit/next-collection-view/collection-view-sorting.spec.js
@@ -195,7 +195,9 @@ describe('NextCollectionView - Sorting', function() {
         viewComparator.returns('sort');
 
         myCollectionView = new MyCollectionView({
-          viewComparator,
+          viewComparator: function(val) {
+            return viewComparator.call(this, val);
+          },
           collection
         });
 


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/3412

Removing `_.partition` actually made a decent perf improvement since we are handling the predicate and since we could also remove the bind.  This also makes a small feature improvement of adding the partition results to the filter event.

Inspired by removing the bind, I also made a small change to the view comparator where comparator binding isn't done until calling `_sort` this is all within internal code and should be entirely non-breaking.  All it _really_ does is remove the `_.isFunction` check.  It also removes the `.bind()` in v3..  certainly not a big deal.. we're probably shortly to move in the opposite direction, but now everything in v3 is consistent.

If need-be I can move the comparator change to a separate PR.