### PR TITLE
allow unbindEvents and unbindRequests to work without bindings hash

### DIFF
--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -300,7 +300,7 @@ The first parameter, `target`, must have the Backbone.Events module mixed in.
 The second parameter is the `entity` (Backbone.Model, Backbone.Collection or
 any object that has Backbone.Events mixed in) to bind the events from.
 
-The third parameter is a hash of { 'event:name': 'eventHandler' }
+The third parameter is a hash of `{ 'event:name': 'eventHandler' }`
 configuration. A function can be supplied instead of a string handler name.
 
 **Note** Multiple handlers are deprecated
@@ -345,7 +345,7 @@ Bb.View.extend({
 
 ## Marionette.bindRequests
 
-This method is used to bind a radio requests to methods on a target object.
+This method is used to bind radio requests to methods on a target object.
 All Marionette Objects come with this method.
 
 ```javascript
@@ -380,14 +380,20 @@ The first parameter, `this`, is a context of current entity.
 
 The second parameter, `channel`, reference to a channel by name.
 
-The third parameter is a hash either { 'event:name': 'eventHandler' } or
-{ 'event:name': 'eventHandler', 'event:otherName': 'otherEventHandler', ...} of
+The third parameter is a hash either `{ 'event:name': 'eventHandler' }` or
+`{ 'event:name': 'eventHandler', 'event:otherName': 'otherEventHandler', ...}` of
 configuration.
 
 ## Marionette.unbindRequests
 
-This method is used to unbind a radio requests to methods on a target object.
+This method is used to unbind radio requests to methods on a target object.
 All Marionette Objects come with this method.
+
+Calling this method without a radio requests hash will unbind all requests
+from the channel.
+
+**NOTE: To avoid memory leaks, `unbindRequests` should be called
+in or before `onBeforeDestroy`.**
 
 ```javascript
 var Mn = require('backbone.marionette');
@@ -419,8 +425,8 @@ The first parameter, `this`, is a context of current entity.
 
 The second parameter, `channel`, reference to a channel by name.
 
-The third parameter is a hash either { 'event:name': 'eventHandler' } or
-{ 'event:name': 'eventHandler', 'event:otherName': 'otherEventHandler', ...} of
+The third parameter is a hash either `{ 'event:name': 'eventHandler' }` or
+`{ 'event:name': 'eventHandler', 'event:otherName': 'otherEventHandler', ...}` of
 configuration.
 
 ## Marionette.normalizeMethods

--- a/src/common/bind-events.js
+++ b/src/common/bind-events.js
@@ -38,8 +38,6 @@ function bindFromStrings(target, entity, evt, methods, actionName) {
 
 // generic looping function
 function iterateEvents(target, entity, bindings, actionName) {
-  if (!entity || !bindings) { return; }
-
   // type-check bindings
   if (!_.isObject(bindings)) {
     throw new MarionetteError({
@@ -62,11 +60,20 @@ function iterateEvents(target, entity, bindings, actionName) {
 }
 
 function bindEvents(entity, bindings) {
+  if (!entity || !bindings) { return this; }
+
   iterateEvents(this, entity, bindings, 'listenTo');
   return this;
 }
 
 function unbindEvents(entity, bindings) {
+  if (!entity) { return this; }
+
+  if (!bindings) {
+    this.stopListening(entity);
+    return this;
+  }
+
   iterateEvents(this, entity, bindings, 'stopListening');
   return this;
 }

--- a/src/common/bind-requests.js
+++ b/src/common/bind-requests.js
@@ -16,8 +16,6 @@ import normalizeMethods from './normalize-methods';
 import MarionetteError from '../error';
 
 function iterateReplies(target, channel, bindings, actionName) {
-  if (!channel || !bindings) { return; }
-
   // type-check bindings
   if (!_.isObject(bindings)) {
     throw new MarionetteError({
@@ -32,11 +30,20 @@ function iterateReplies(target, channel, bindings, actionName) {
 }
 
 function bindRequests(channel, bindings) {
+  if (!channel || !bindings) { return this; }
+
   iterateReplies(this, channel, bindings, 'reply');
   return this;
 }
 
 function unbindRequests(channel, bindings) {
+  if (!channel) { return this; }
+
+  if (!bindings) {
+    channel.stopReplying(null, null, this);
+    return this;
+  }
+
   iterateReplies(this, channel, bindings, 'stopReplying');
   return this;
 }

--- a/test/unit/common/bind-events.spec.js
+++ b/test/unit/common/bind-events.spec.js
@@ -26,6 +26,10 @@ describe('Marionette.bindEntityEvents', function() {
     it('shouldnt bind any events', function() {
       expect(this.listenToStub).not.to.have.been.called;
     });
+
+    it('should return the target', function() {
+      expect(Marionette.bindEvents(this.target, false, {'foo': 'foo'})).to.equal(this.target);
+    });
   });
 
   describe('when bindings isnt passed', function() {
@@ -35,6 +39,10 @@ describe('Marionette.bindEntityEvents', function() {
 
     it('shouldnt bind any events', function() {
       expect(this.listenToStub).not.to.have.been.called;
+    });
+
+    it('should return the target', function() {
+      expect(Marionette.bindEvents(this.target, this.entity, null)).to.equal(this.target);
     });
   });
 

--- a/test/unit/common/bind-request.spec.js
+++ b/test/unit/common/bind-request.spec.js
@@ -24,6 +24,10 @@ describe('Marionette.bindRequests', function() {
     it('shouldnt bind any requests', function() {
       expect(this.replyStub).not.to.have.been.called;
     });
+
+    it('should return the target', function() {
+      expect(Marionette.bindRequests(this.target, false, {'foo': 'replyFoo'})).to.equal(this.target);
+    });
   });
 
   describe('when bindings isnt passed', function() {
@@ -33,6 +37,10 @@ describe('Marionette.bindRequests', function() {
 
     it('shouldnt bind any requests', function() {
       expect(this.replyStub).not.to.have.been.called;
+    });
+
+    it('should return the target', function() {
+      expect(Marionette.bindRequests(this.target, this.channel, null)).to.equal(this.target);
     });
   });
 

--- a/test/unit/unbind-entity-events.spec.js
+++ b/test/unit/unbind-entity-events.spec.js
@@ -23,6 +23,10 @@ describe('Marionette.unbindEntityEvents', function() {
     it('shouldnt unbind any events', function() {
       expect(this.stopListeningStub).not.to.have.been.called;
     });
+
+    it('should return the target', function() {
+      expect(Marionette.unbindEvents(this.target, false, {'foo': 'foo'})).to.equal(this.target);
+    });
   });
 
   describe('when bindings isnt passed', function() {
@@ -30,8 +34,12 @@ describe('Marionette.unbindEntityEvents', function() {
       Marionette.unbindEvents(this.target, this.entity, null);
     });
 
-    it('shouldnt unbind any events', function() {
-      expect(this.stopListeningStub).not.to.have.been.called;
+    it('should unbind all events', function() {
+      expect(this.stopListeningStub).to.have.been.calledOnce.and.calledWith(this.entity);
+    });
+
+    it('should return the target', function() {
+      expect(Marionette.unbindEvents(this.target, this.entity, null)).to.equal(this.target);
     });
   });
 

--- a/test/unit/unbind-radio-requests.spec.js
+++ b/test/unit/unbind-radio-requests.spec.js
@@ -24,6 +24,10 @@ describe('Marionette.unbindRequests', function() {
     it('shouldnt unbind any request', function() {
       expect(this.stopReplyingStub).not.to.have.been.called;
     });
+
+    it('should return the target', function() {
+      expect(Marionette.unbindRequests(this.target, false, {'foo': 'foo'})).to.equal(this.target);
+    });
   });
 
   describe('when bindings isnt passed', function() {
@@ -31,8 +35,12 @@ describe('Marionette.unbindRequests', function() {
       Marionette.unbindRequests(this.target, this.channel, null);
     });
 
-    it('shouldnt unbind any requests', function() {
-      expect(this.stopReplyingStub).not.to.have.been.called;
+    it('should unbind all requests', function() {
+      expect(this.stopReplyingStub).to.have.been.calledOnce.and.calledWith(null, null, this.target);
+    });
+
+    it('should return the target', function() {
+      expect(Marionette.unbindRequests(this.target, this.channel, null)).to.equal(this.target);
     });
   });
 


### PR DESCRIPTION
### Proposed changes
 - These changes allow for `unbindEvents` and `unbindRequests` to be called without the bindings hash. Doing so will unbind all events from the entity and all requests, respectively.

- [ ] Todo docs about needing to unbind when destroying

Link to the issue: https://github.com/marionettejs/backbone.marionette/issues/3507

Note that this fix only resolves one part of #3507
