### PR TITLE
Add at end perf improvement can only occur if no sorting occurred

### DIFF
--- a/src/next-collection-view.js
+++ b/src/next-collection-view.js
@@ -368,6 +368,9 @@ const CollectionView = Backbone.View.extend({
 
     if (!viewComparator) { return; }
 
+    // If children are sorted prevent added to end perf
+    delete this._addedViews;
+
     this.triggerMethod('before:sort', this);
 
     if (_.isFunction(viewComparator)) {
@@ -432,11 +435,6 @@ const CollectionView = Backbone.View.extend({
     return this;
   },
 
-  _isAddedAtEnd(addedView, index, addedViews) {
-    const viewIndex = this.children._views.length - addedViews.length + index;
-    return addedView === this.children._views[viewIndex];
-  },
-
   _filterChildren() {
     const viewFilter = this._getFilter();
     const addedViews = this._addedViews;
@@ -444,9 +442,7 @@ const CollectionView = Backbone.View.extend({
     delete this._addedViews;
 
     if (!viewFilter) {
-      if (!this.sortWithCollection && addedViews && _.every(addedViews, _.bind(this._isAddedAtEnd, this))) {
-        return addedViews;
-      }
+      if (addedViews) { return addedViews; }
 
       return this.children._views;
     }
@@ -621,8 +617,11 @@ const CollectionView = Backbone.View.extend({
       return view;
     }
 
+    // Only cache views if added to the end
+    if (!index || index >= this.children.length) {
+      this._addedViews = [view];
+    }
     this._addChild(view, index);
-    this._addedViews = [view];
     this._showChildren();
 
     return view;

--- a/test/unit/next-collection-view/collection-view-data.spec.js
+++ b/test/unit/next-collection-view/collection-view-data.spec.js
@@ -209,7 +209,7 @@ describe('next CollectionView Data', function() {
     let myCollectionView;
     let collection;
 
-    describe('when sortWithCollection is true', function() {
+    describe('when children are sorted', function() {
       beforeEach(function() {
         collection = new Backbone.Collection([{ id: 1 }, { id: 2 }, { id: 3 }]);
 
@@ -233,11 +233,11 @@ describe('next CollectionView Data', function() {
       });
     });
 
-    describe('when sortWithCollection is false', function() {
+    describe('when children are not sorted', function() {
       beforeEach(function() {
         collection = new Backbone.Collection([{ id: 1 }, { id: 2 }, { id: 3 }]);
 
-        myCollectionView = new MyCollectionView({ collection, sortWithCollection: false });
+        myCollectionView = new MyCollectionView({ collection, viewComparator: false });
         myCollectionView.render();
       });
 


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/3489

Sorting requires reappending of all children.  Rather than handling all of the various flag states to determine this, we can simply remove the added views cache if a sort occurs.
