### PR TITLE
reorganize and refactor application, and childView unit tests

### DIFF
--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import _ from 'underscore';
 import Application from '../../src/application';
 import View from '../../src/view';
 

--- a/test/unit/child-view-container.spec.js
+++ b/test/unit/child-view-container.spec.js
@@ -31,42 +31,6 @@ describe('#ChildViewContainer', function() {
     });
   });
 
-  describe('#_set', function() {
-    let container;
-    let views;
-    let originalViews;
-
-    beforeEach(function() {
-      views = [
-        new Backbone.View(),
-        new Backbone.View()
-      ];
-
-      container = new ChildViewContainer();
-
-      container._add(new Backbone.View());
-      container._add(new Backbone.View());
-      container._add(new Backbone.View());
-
-      originalViews = container._views;
-
-      container._set(views);
-    });
-
-    it('should replace the contents of _views', function() {
-      expect(container._views[0]).to.equal(views[0]);
-    });
-
-    it('should keep the _views array reference', function() {
-      expect(container._views).to.equal(originalViews);
-    });
-
-    it('should update the container length', function() {
-      expect(container.length).to.equal(2);
-    });
-
-  });
-
   describe('#_add', function() {
     describe('when adding a view that does not have a model', function() {
       let container;
@@ -147,6 +111,42 @@ describe('#ChildViewContainer', function() {
       it('should make the view retrievable by the index', function() {
         expect(foundView).to.equal(view);
       });
+    });
+
+  });
+
+  describe('#_set', function() {
+    let container;
+    let views;
+    let originalViews;
+
+    beforeEach(function() {
+      views = [
+        new Backbone.View(),
+        new Backbone.View()
+      ];
+
+      container = new ChildViewContainer();
+
+      container._add(new Backbone.View());
+      container._add(new Backbone.View());
+      container._add(new Backbone.View());
+
+      originalViews = container._views;
+
+      container._set(views);
+    });
+
+    it('should replace the contents of _views', function() {
+      expect(container._views[0]).to.equal(views[0]);
+    });
+
+    it('should keep the _views array reference', function() {
+      expect(container._views).to.equal(originalViews);
+    });
+
+    it('should update the container length', function() {
+      expect(container.length).to.equal(2);
     });
 
   });


### PR DESCRIPTION
### Proposed changes
 - Reorganize tests to match order of codebase
 - Import dependencies to move away from using global ones
- Use `let` in favor of `this` in beforeEach

Link to the issue: https://github.com/marionettejs/backbone.marionette/issues/3248

This pr is a small part of the work to refactor the whole unit tests directory. Merging this issue should keep #3248 open
