### PR TITLE
Prevent undelegateEntityEvents from over removing

### DIFF
--- a/src/mixins/delegate-entity-events.js
+++ b/src/mixins/delegate-entity-events.js
@@ -12,13 +12,20 @@ import {
 export default {
   // Handle `modelEvents`, and `collectionEvents` configuration
   _delegateEntityEvents(model, collection) {
-    this._undelegateEntityEvents(model, collection);
-
     const modelEvents = _.result(this, 'modelEvents');
-    bindEvents.call(this, model, modelEvents);
+
+    if (modelEvents) {
+      unbindEvents.call(this, model, modelEvents);
+      bindEvents.call(this, model, modelEvents);
+    }
+
 
     const collectionEvents = _.result(this, 'collectionEvents');
-    bindEvents.call(this, collection, collectionEvents);
+
+    if (collectionEvents) {
+      unbindEvents.call(this, collection, collectionEvents);
+      bindEvents.call(this, collection, collectionEvents);
+    }
   },
 
   _undelegateEntityEvents(model, collection) {

--- a/test/unit/view.entity-events.spec.js
+++ b/test/unit/view.entity-events.spec.js
@@ -217,4 +217,25 @@ describe('view entity events', function() {
       expect(this.barStub).to.have.been.calledOnce;
     });
   });
+
+  // Fixes https://github.com/marionettejs/backbone.marionette/issues/3527
+  describe('when entity events are added in initialize', function() {
+    it('should not undelegate them', function() {
+      const View = Marionette.View.extend({
+        template: false,
+        initialize() {
+          this.listenTo(this.model, 'foo', this.onFoo);
+        },
+        onFoo: this.sinon.stub()
+      });
+
+      const model = new Backbone.Model();
+
+      const view = new View({ model });
+
+      model.trigger('foo');
+
+      expect(view.onFoo).to.have.been.calledOnce;
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/marionettejs/backbone.marionette/issues/3527
