### PR TITLE
Tests/view destroy error get immediate children object

### DIFF
--- a/test/unit/destroying-views.spec.js
+++ b/test/unit/destroying-views.spec.js
@@ -1,45 +1,54 @@
+import View from '../../src/view';
+
+
 describe('destroying views', function() {
   'use strict';
 
   describe('when destroying a Marionette.View multiple times', function() {
+    let onDestroyStub;
+    let view;
+
     beforeEach(function() {
-      this.onDestroyStub = this.sinon.spy(function() {
+      onDestroyStub = this.sinon.spy(function() {
         return this.isRendered();
       });
 
-      this.view = new Marionette.View();
-      this.view.onDestroy = this.onDestroyStub;
+      view = new View();
+      view.onDestroy = onDestroyStub;
 
-      this.view.destroy();
-      this.view.destroy();
+      view.destroy();
+      view.destroy();
     });
 
     it('should only run the destroying code once', function() {
-      expect(this.onDestroyStub).to.have.been.calledOnce;
+      expect(onDestroyStub).to.have.been.calledOnce;
     });
 
     it('should mark the view as destroyed', function() {
-      expect(this.view).to.have.property('_isDestroyed', true);
+      expect(view).to.have.property('_isDestroyed', true);
     });
   });
 
   describe('when destroying a Marionette.View multiple times', function() {
+    let onBeforeDestroyStub;
+    let itemView;
+
     beforeEach(function() {
-      this.onBeforeDestroyStub = this.sinon.stub();
+      onBeforeDestroyStub = this.sinon.stub();
 
-      this.itemView = new Marionette.View();
-      this.itemView.onBeforeDestroy = this.onBeforeDestroyStub;
+      itemView = new View();
+      itemView.onBeforeDestroy = onBeforeDestroyStub;
 
-      this.itemView.destroy();
-      this.itemView.destroy();
+      itemView.destroy();
+      itemView.destroy();
     });
 
     it('should only run the destroying code once', function() {
-      expect(this.onBeforeDestroyStub).to.have.been.calledOnce;
+      expect(onBeforeDestroyStub).to.have.been.calledOnce;
     });
 
     it('should mark the view as destroyed', function() {
-      expect(this.itemView).to.have.property('_isDestroyed', true);
+      expect(itemView).to.have.property('_isDestroyed', true);
     });
   });
 });

--- a/test/unit/get-immediate-children.spec.js
+++ b/test/unit/get-immediate-children.spec.js
@@ -1,74 +1,87 @@
-describe('_getImmediateChildren', function() {
-  beforeEach(function() {
+import View from '../../src/view';
 
+describe('_getImmediateChildren', function() {
+  let BaseView;
+
+  beforeEach(function() {
     // A suitable view to use as a child
-    this.BaseView = Marionette.View.extend({
+    BaseView = View.extend({
       template: _.noop
     });
   });
 
   describe('Marionette.View', function() {
+    let view;
+
     beforeEach(function() {
-      this.view = new Marionette.View();
+      view = new View();
     });
     it('should return an empty array for getImmediateChildren', function() {
-      expect(this.view._getImmediateChildren())
+      expect(view._getImmediateChildren())
         .to.be.instanceof(Array)
         .and.to.have.length(0);
     });
 
     describe('without regions', function() {
+      let layoutView;
+
       beforeEach(function() {
-        this.layoutView = new Marionette.View({
+        layoutView = new View({
           template: _.noop
         });
       });
       it('should return an empty array for getImmediateChildren', function() {
-        expect(this.layoutView._getImmediateChildren())
+        expect(layoutView._getImmediateChildren())
           .to.be.instanceof(Array)
           .and.to.have.length(0);
       });
     });
 
     describe('when there are empty regions', function() {
+      let layoutView;
+
       beforeEach(function() {
-        this.layoutView = new Marionette.View({
+        layoutView = new View({
           template: _.template('<main></main><footer></footer>'),
           regions: {
             main: '.main',
             footer: '.footer'
           }
         });
-        this.layoutView.render();
+        layoutView.render();
       });
       it('should return an empty array for getImmediateChildren', function() {
-        expect(this.layoutView._getImmediateChildren())
+        expect(layoutView._getImmediateChildren())
           .to.be.instanceof(Array)
           .and.to.have.length(0);
       });
     });
 
     describe('when there are non-empty regions', function() {
+      let layoutView;
+      let childOne;
+      let childTwo;
+
       beforeEach(function() {
-        this.layoutView = new Marionette.View({
+        layoutView = new View({
           template: _.template('<main></main><footer></footer>'),
           regions: {
             main: 'main',
             footer: 'footer'
           }
         });
-        this.layoutView.render();
-        this.childOne = new this.BaseView();
-        this.childTwo = new this.BaseView();
-        this.layoutView.getRegion('main').show(this.childOne);
-        this.layoutView.getRegion('footer').show(this.childTwo);
+        layoutView.render();
+        childOne = new BaseView();
+        childTwo = new BaseView();
+        layoutView.getRegion('main').show(childOne);
+        layoutView.getRegion('footer').show(childTwo);
       });
       it('should return an empty array for getImmediateChildren', function() {
-        expect(this.layoutView._getImmediateChildren())
+        expect(layoutView._getImmediateChildren())
           .to.be.instanceof(Array)
           .and.to.have.length(2)
-          .and.to.contain(this.childOne)
-          .and.to.contain(this.childTwo);
+          .and.to.contain(childOne)
+          .and.to.contain(childTwo);
       });
     });
   });

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -7,7 +7,7 @@ describe('marionette object', function() {
     let options;
 
     beforeEach(function() {
-      const Object = MnObject.extend({
+      const Obj = MnObject.extend({
         initialize(opts) {
           this.bindEvents(opts.model, this.modelEvents);
         },
@@ -19,7 +19,7 @@ describe('marionette object', function() {
         onBar: this.sinon.stub()
       });
 
-      this.sinon.spy(Object.prototype, '_initRadio');
+      this.sinon.spy(Obj.prototype, '_initRadio');
 
       const model = new Backbone.Model();
 
@@ -30,7 +30,7 @@ describe('marionette object', function() {
         radioRequests: {}
       };
 
-      object = new Object(options);
+      object = new Obj(options);
     });
 
     it('should merge the class options to the object', function() {
@@ -79,11 +79,11 @@ describe('marionette object', function() {
     let object;
 
     beforeEach(function() {
-      const Object = MnObject.extend({
+      const Obj = MnObject.extend({
         onDestroy: this.sinon.stub()
       });
 
-      object = new Object();
+      object = new Obj();
 
       this.sinon.spy(object, 'destroy');
     });


### PR DESCRIPTION
### Proposed changes
- Reorganize tests to match order of codebase
- Import dependencies to move away from using global ones
- Use let in favor of this in beforeEach

Link to the issue: #3248

This pr is a small part of the work to refactor the whole unit tests directory. Merging this issue should keep #3248 open
