### PR TITLE
refactor and reorg templateContext and unbind unit tests

### DIFF
--- a/test/unit/template-context.spec.js
+++ b/test/unit/template-context.spec.js
@@ -1,101 +1,121 @@
+import View from '../../src/view';
+
 describe('template context methods', function() {
   'use strict';
 
+  let templateStub;
+  let templateContext;
+  let templateContextFn;
+  let modelData;
+  let model;
+
   beforeEach(function() {
-    this.templateStub = this.sinon.stub();
-    this.templateContext = {foo: this.sinon.stub()};
-    this.templateContextFn = this.sinon.stub().returns(this.templateContext);
-    this.modelData = {bar: 'baz'};
-    this.model = new Backbone.Model(this.modelData);
+    templateStub = this.sinon.stub();
+    templateContext = {foo: this.sinon.stub()};
+    templateContextFn = this.sinon.stub().returns(templateContext);
+    modelData = {bar: 'baz'};
+    model = new Backbone.Model(modelData);
   });
 
   describe('view', function() {
     describe('when rendering with no model or collection and a templateContext is found', function() {
+      let TestView;
+      let view;
+
       beforeEach(function() {
-        this.View = Marionette.View.extend({
-          templateContext: this.templateContext,
-          template: this.templateStub
+        TestView = View.extend({
+          templateContext: templateContext,
+          template: templateStub
         });
 
-        this.view = new this.View();
-        this.view.render();
+        view = new TestView();
+        view.render();
       });
 
       it('should include the template context in the data object', function() {
-        expect(this.templateStub).to.have.been.calledOnce.and.calledWith(this.templateContext);
+        expect(templateStub).to.have.been.calledOnce.and.calledWith(templateContext);
       });
     });
 
     describe('when rendering with a model, and a templateContext is found', function() {
+      let TestView;
+      let view;
+
       beforeEach(function() {
-        this.View = Marionette.View.extend({
-          templateContext: this.templateContext,
-          template: this.templateStub
+        TestView = View.extend({
+          templateContext: templateContext,
+          template: templateStub
         });
 
-        this.view = new this.View({
-          model: this.model
+        view = new TestView({
+          model: model
         });
 
-        this.view.render();
+        view.render();
       });
 
       it('should include the template context in the data object', function() {
-        expect(this.templateStub.lastCall.args[0]).to.contain(this.templateContext);
+        expect(templateStub.lastCall.args[0]).to.contain(templateContext);
       });
 
       it('should still have the data from the model', function() {
-        expect(this.templateStub.lastCall.args[0]).to.contain(this.modelData);
+        expect(templateStub.lastCall.args[0]).to.contain(modelData);
       });
     });
 
     describe('when rendering and a templateContext is found as a function', function() {
+      let TestView;
+      let view;
+
       beforeEach(function() {
-        this.View = Marionette.View.extend({
-          templateContext: this.templateContextFn,
-          template: this.templateStub
+        TestView = View.extend({
+          templateContext: templateContextFn,
+          template: templateStub
         });
 
-        this.view = new this.View({
-          model: this.model
+        view = new TestView({
+          model: model
         });
 
-        this.view.render();
+        view.render();
       });
 
       it('should include the template context in the data object', function() {
-        expect(this.templateStub.lastCall.args[0]).to.contain(this.templateContext);
+        expect(templateStub.lastCall.args[0]).to.contain(templateContext);
       });
 
       it('should still have the data from the model', function() {
-        expect(this.templateStub.lastCall.args[0]).to.contain(this.modelData);
+        expect(templateStub.lastCall.args[0]).to.contain(modelData);
       });
 
       it('should maintain the view as the context for the templateContext function', function() {
-        expect(this.templateContextFn).to.have.been.calledOnce.and.calledOn(this.view);
+        expect(templateContextFn).to.have.been.calledOnce.and.calledOn(view);
       });
     });
 
     describe('when templateContext is provided to constructor options', function() {
+      let TestView;
+      let view;
+
       beforeEach(function() {
-        this.View = Marionette.View.extend({
-          template: this.templateStub
+        TestView = View.extend({
+          template: templateStub
         });
 
-        this.view = new this.View({
-          templateContext: this.templateContext,
-          model: this.model
+        view = new TestView({
+          templateContext: templateContext,
+          model: model
         });
 
-        this.view.render();
+        view.render();
       });
 
       it('should include the template context in the data object', function() {
-        expect(this.templateStub.lastCall.args[0]).to.contain(this.templateContext);
+        expect(templateStub.lastCall.args[0]).to.contain(templateContext);
       });
 
       it('should still have the data from the model', function() {
-        expect(this.templateStub.lastCall.args[0]).to.contain(this.modelData);
+        expect(templateStub.lastCall.args[0]).to.contain(modelData);
       });
     });
   });

--- a/test/unit/unbind-entity-events.spec.js
+++ b/test/unit/unbind-entity-events.spec.js
@@ -1,81 +1,89 @@
-describe('Marionette.unbindEntityEvents', function() {
+import { unbindEvents } from '../../src/backbone.marionette';
+
+describe('unbindEntityEvents', function() {
   'use strict';
 
-  beforeEach(function() {
-    this.fooStub = this.sinon.stub();
-    this.barStub = this.sinon.stub();
-    this.stopListeningStub = this.sinon.stub();
+  let fooStub;
+  let barStub;
+  let stopListeningStub;
+  let target;
+  let entity;
 
-    this.target = {
-      foo: this.fooStub,
-      bar: this.barStub,
-      stopListening: this.stopListeningStub
+  beforeEach(function() {
+    fooStub = this.sinon.stub();
+    barStub = this.sinon.stub();
+    stopListeningStub = this.sinon.stub();
+
+    target = {
+      foo: fooStub,
+      bar: barStub,
+      stopListening: stopListeningStub
     };
 
-    this.entity = this.sinon.spy();
+    entity = this.sinon.spy();
   });
 
   describe('when entity isnt passed', function() {
     beforeEach(function() {
-      Marionette.unbindEvents(this.target, false, {'foo': 'foo'});
+      unbindEvents(target, false, {'foo': 'foo'});
     });
 
     it('shouldnt unbind any events', function() {
-      expect(this.stopListeningStub).not.to.have.been.called;
+      expect(stopListeningStub).not.to.have.been.called;
     });
 
     it('should return the target', function() {
-      expect(Marionette.unbindEvents(this.target, false, {'foo': 'foo'})).to.equal(this.target);
+      expect(unbindEvents(target, false, {'foo': 'foo'})).to.equal(target);
     });
   });
 
   describe('when bindings isnt passed', function() {
     beforeEach(function() {
-      Marionette.unbindEvents(this.target, this.entity, null);
+      unbindEvents(target, entity, null);
     });
 
     it('should unbind all events', function() {
-      expect(this.stopListeningStub).to.have.been.calledOnce.and.calledWith(this.entity);
+      expect(stopListeningStub).to.have.been.calledOnce.and.calledWith(entity);
     });
 
     it('should return the target', function() {
-      expect(Marionette.unbindEvents(this.target, this.entity, null)).to.equal(this.target);
+      expect(unbindEvents(target, entity, null)).to.equal(target);
     });
   });
 
   describe('when bindings is an object with one event-handler pair', function() {
     describe('when handler is a function', function() {
       beforeEach(function() {
-        Marionette.unbindEvents(this.target, this.entity, {'foo': this.target.foo});
+        unbindEvents(target, entity, {'foo': target.foo});
       });
 
       it('should unbind an event', function() {
-        expect(this.stopListeningStub).to.have.been.calledOnce.and.calledWith(this.entity, 'foo', this.target.foo);
+        expect(stopListeningStub).to.have.been.calledOnce.and.calledWith(entity, 'foo', target.foo);
       });
     });
 
     describe('when handler is a string', function() {
       describe('when one handler is passed', function() {
         beforeEach(function() {
-          Marionette.unbindEvents(this.target, this.entity, {'foo': 'foo'});
+          unbindEvents(target, entity, {'foo': 'foo'});
         });
 
         it('should unbind an event', function() {
-          expect(this.stopListeningStub).to.have.been.calledOnce.and.calledWith(this.entity, 'foo', this.target.foo);
+          expect(stopListeningStub).to.have.been.calledOnce.and.calledWith(entity, 'foo', target.foo);
         });
       });
 
       describe('when multiple handlers are passed', function() {
         beforeEach(function() {
-          Marionette.unbindEvents(this.target, this.entity, {'baz': 'foo bar'});
+          unbindEvents(target, entity, {'baz': 'foo bar'});
         });
 
         it('should unbind first event', function() {
-          expect(this.stopListeningStub).to.have.been.calledWith(this.entity, 'baz', this.target.foo);
+          expect(stopListeningStub).to.have.been.calledWith(entity, 'baz', target.foo);
         });
 
         it('should unbind second event', function() {
-          expect(this.stopListeningStub).to.have.been.calledWith(this.entity, 'baz', this.target.bar);
+          expect(stopListeningStub).to.have.been.calledWith(entity, 'baz', target.bar);
         });
       });
     });
@@ -83,18 +91,18 @@ describe('Marionette.unbindEntityEvents', function() {
 
   describe('when bindings is an object with multiple event-handler pairs', function() {
     beforeEach(function() {
-      Marionette.unbindEvents(this.target, this.entity, {
+      unbindEvents(target, entity, {
         'foo': 'foo',
         'bar': 'bar'
       });
     });
 
     it('should unbind first event', function() {
-      expect(this.stopListeningStub).to.have.been.calledWith(this.entity, 'foo', this.target.foo);
+      expect(stopListeningStub).to.have.been.calledWith(entity, 'foo', target.foo);
     });
 
     it('should unbind second event', function() {
-      expect(this.stopListeningStub).to.have.been.calledWith(this.entity, 'bar', this.target.bar);
+      expect(stopListeningStub).to.have.been.calledWith(entity, 'bar', target.bar);
     });
   });
 });

--- a/test/unit/unbind-radio-requests.spec.js
+++ b/test/unit/unbind-radio-requests.spec.js
@@ -1,68 +1,76 @@
-describe('Marionette.unbindRequests', function() {
+import { unbindRequests } from '../../src/backbone.marionette';
+
+describe('unbindRequests', function() {
   'use strict';
 
-  beforeEach(function() {
-    this.replyFooStub = this.sinon.stub();
-    this.replyBarStub = this.sinon.stub();
-    this.stopReplyingStub = this.sinon.stub();
+  let replyFooStub;
+  let replyBarStub;
+  let stopReplyingStub;
+  let target;
+  let channel;
 
-    this.target = {
-      replyFoo: this.replyFooStub,
-      replyBar: this.replyBarStub
+  beforeEach(function() {
+    replyFooStub = this.sinon.stub();
+    replyBarStub = this.sinon.stub();
+    stopReplyingStub = this.sinon.stub();
+
+    target = {
+      replyFoo: replyFooStub,
+      replyBar: replyBarStub
     };
 
-    this.channel = {
-      stopReplying: this.stopReplyingStub
+    channel = {
+      stopReplying: stopReplyingStub
     };
   });
 
   describe('when channel isnt passed', function() {
     beforeEach(function() {
-      Marionette.unbindRequests(this.target, false, {'foo': 'foo'});
+      unbindRequests(target, false, {'foo': 'foo'});
     });
 
     it('shouldnt unbind any request', function() {
-      expect(this.stopReplyingStub).not.to.have.been.called;
+      expect(stopReplyingStub).not.to.have.been.called;
     });
 
     it('should return the target', function() {
-      expect(Marionette.unbindRequests(this.target, false, {'foo': 'foo'})).to.equal(this.target);
+      expect(unbindRequests(target, false, {'foo': 'foo'})).to.equal(target);
     });
   });
 
   describe('when bindings isnt passed', function() {
     beforeEach(function() {
-      Marionette.unbindRequests(this.target, this.channel, null);
+      unbindRequests(target, channel, null);
     });
 
     it('should unbind all requests', function() {
-      expect(this.stopReplyingStub).to.have.been.calledOnce.and.calledWith(null, null, this.target);
+      expect(stopReplyingStub).to.have.been.calledOnce.and.calledWith(null, null, target);
     });
 
     it('should return the target', function() {
-      expect(Marionette.unbindRequests(this.target, this.channel, null)).to.equal(this.target);
+      expect(unbindRequests(target, channel, null)).to.equal(target);
     });
   });
 
   describe('when bindings is an object with one request-handler pair', function() {
     describe('when handler is a function', function() {
       beforeEach(function() {
-        Marionette.unbindRequests(this.target, this.channel, {'foo': this.target.replyFoo});
+        unbindRequests(target, channel, {'foo': target.replyFoo});
       });
 
       it('should unbind an request', function() {
-        expect(this.stopReplyingStub).to.have.been.calledOnce.and.calledWith({'foo': this.target.replyFoo});
+        expect(stopReplyingStub).to.have.been.calledOnce.and.calledWith({'foo': target.replyFoo});
       });
     });
 
     describe('when handler is a string', function() {
       describe('when one handler is passed', function() {
         beforeEach(function() {
-          Marionette.unbindRequests(this.target, this.channel, {'foo': 'replyFoo'});
+          unbindRequests(target, channel, {'foo': 'replyFoo'});
         });
 
         it('should unbind an request', function() {
-          expect(this.stopReplyingStub).to.have.been.calledOnce.and.calledWith({'foo': this.target.replyFoo});
+          expect(stopReplyingStub).to.have.been.calledOnce.and.calledWith({'foo': target.replyFoo});
         });
       });
     });
@@ -70,14 +78,14 @@ describe('Marionette.unbindRequests', function() {
 
   describe('when bindings is an object with multiple request-handler pairs', function() {
     beforeEach(function() {
-      Marionette.unbindRequests(this.target, this.channel, {
+      unbindRequests(target, channel, {
         'foo': 'replyFoo',
         'bar': 'replyBar'
       });
     });
 
     it('should unbind first request', function() {
-      expect(this.stopReplyingStub).to.have.been.calledWith({'bar': this.target.replyBar, 'foo': this.target.replyFoo});
+      expect(stopReplyingStub).to.have.been.calledWith({'bar': target.replyBar, 'foo': target.replyFoo});
     });
   });
 });


### PR DESCRIPTION
### Proposed changes
- Reorganize tests to match order of codebase
- Import dependencies to move away from using global ones
- Use let in favor of this in beforeEach

Link to the issue: #3248

This pr is a small part of the work to refactor the whole unit tests directory. Merging this issue should keep #3248 open
