### PR TITLE
Propagate only the first argument (options) passed to destroy

### DIFF
--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -75,12 +75,12 @@ export default {
     _invoke(this._behaviors, 'undelegateEntityEvents');
   },
 
-  _destroyBehaviors(...args) {
+  _destroyBehaviors(options) {
     // Call destroy on each behavior after
     // destroying the view.
     // This unbinds event listeners
     // that behaviors have registered for.
-    _invoke(this._behaviors, 'destroy', ...args);
+    _invoke(this._behaviors, 'destroy', options);
   },
 
   // Remove a behavior

--- a/src/mixins/destroy.js
+++ b/src/mixins/destroy.js
@@ -5,12 +5,12 @@ export default {
     return this._isDestroyed;
   },
 
-  destroy(...args) {
+  destroy(options) {
     if (this._isDestroyed) { return this; }
 
-    this.triggerMethod('before:destroy', this, ...args);
+    this.triggerMethod('before:destroy', this, options);
     this._isDestroyed = true;
-    this.triggerMethod('destroy', this, ...args);
+    this.triggerMethod('destroy', this, options);
     this.stopListening();
 
     return this;

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -117,11 +117,11 @@ const ViewMixin = {
   },
 
   // Handle destroying the view and its children.
-  destroy(...args) {
+  destroy(options) {
     if (this._isDestroyed) { return this; }
     const shouldTriggerDetach = this._isAttached && !this._shouldDisableEvents;
 
-    this.triggerMethod('before:destroy', this, ...args);
+    this.triggerMethod('before:destroy', this, options);
     if (shouldTriggerDetach) {
       this.triggerMethod('before:detach', this);
     }
@@ -144,9 +144,9 @@ const ViewMixin = {
     this._isRendered = false;
 
     // Destroy behaviors after _isDestroyed flag
-    this._destroyBehaviors(...args);
+    this._destroyBehaviors(options);
 
-    this.triggerMethod('destroy', this, ...args);
+    this.triggerMethod('destroy', this, options);
 
     this.stopListening();
 

--- a/src/region.js
+++ b/src/region.js
@@ -388,13 +388,13 @@ _.extend(Region.prototype, Backbone.Events, CommonMixin, {
     return this._isDestroyed;
   },
 
-  destroy(...args) {
+  destroy(options) {
     if (this._isDestroyed) { return this; }
 
-    this.triggerMethod('before:destroy', this, ...args);
+    this.triggerMethod('before:destroy', this, options);
     this._isDestroyed = true;
 
-    this.reset(...args);
+    this.reset(options);
 
     if (this._name) {
       this._parentView._removeReferences(this._name);
@@ -402,7 +402,7 @@ _.extend(Region.prototype, Backbone.Events, CommonMixin, {
     delete this._parentView;
     delete this._name;
 
-    this.triggerMethod('destroy', this, ...args);
+    this.triggerMethod('destroy', this, options);
     this.stopListening();
 
     return this;

--- a/test/unit/mixins/behaviors.spec.js
+++ b/test/unit/mixins/behaviors.spec.js
@@ -337,17 +337,17 @@ describe('Behaviors Mixin', function() {
       behaviorsInstance._initBehaviors();
     });
 
-    it('should invoke destroy with arguments', function() {
-      behaviorsInstance._destroyBehaviors('foo', 'bar', 'baz');
+    it('should invoke destroy with options argument', function() {
+      behaviorsInstance._destroyBehaviors({foo: 'bar'});
 
       expect(FooBehavior.prototype.destroy)
-        .to.have.been.calledOnce.and.calledWith('foo', 'bar', 'baz');
+        .to.have.been.calledOnce.and.calledWith({foo: 'bar'});
       expect(BarBehavior.prototype.destroy)
-        .to.have.been.calledOnce.and.calledWith('foo', 'bar', 'baz');
+        .to.have.been.calledOnce.and.calledWith({foo: 'bar'});
     });
 
     it('should invoke destroy without arguments', function() {
-      behaviorsInstance._destroyBehaviors([]);
+      behaviorsInstance._destroyBehaviors();
 
       expect(FooBehavior.prototype.destroy).to.have.been.calledOnce;
       expect(BarBehavior.prototype.destroy).to.have.been.calledOnce;

--- a/test/unit/mixins/view.spec.js
+++ b/test/unit/mixins/view.spec.js
@@ -36,9 +36,6 @@ describe('view mixin', function() {
 
   describe('when destroying a view', function() {
     beforeEach(function() {
-      this.argumentOne = 'foo';
-      this.argumentTwo = 'bar';
-
       this.view = new Marionette.View();
 
       sinon.spy(this.view, '_removeElement');
@@ -50,17 +47,17 @@ describe('view mixin', function() {
       this.destroyStub = sinon.stub();
       this.view.on('destroy', this.destroyStub);
 
-      this.view.destroy(this.argumentOne, this.argumentTwo);
+      this.view.destroy({foo: 'bar'});
     });
 
     it('should trigger the destroy event', function() {
       expect(this.destroyStub).to.have.been.calledOnce;
     });
 
-    it('should call an onDestroy method with any arguments passed to destroy', function() {
+    it('should call an onDestroy method with options argument passed to destroy', function() {
       expect(this.onDestroyStub)
         .to.have.been.calledOnce
-        .and.calledWith(this.view, this.argumentOne, this.argumentTwo);
+        .and.calledWith(this.view, {foo: 'bar'});
     });
 
     it('should remove the view', function() {
@@ -98,70 +95,6 @@ describe('view mixin', function() {
         this.view.destroy();
         expect(this.view).to.be.have.property('_isDestroyed', true);
       });
-    });
-  });
-
-  describe('when destroying a view and returning false from the onBeforeDestroy method', function() {
-    beforeEach(function() {
-      this.view = new Marionette.View();
-
-      this.removeSpy = sinon.spy(this.view, '_removeElement');
-
-      this.destroyStub = sinon.stub();
-      this.view.on('destroy', this.destroyStub);
-
-      this.onBeforeDestroyStub = sinon.stub().returns(false);
-      this.view.onBeforeDestroy = this.onDestroyStub;
-
-      this.view.destroy();
-    });
-
-    it('should not trigger the destroy event', function() {
-      expect(this.destroyStub).to.have.been.calledOnce;
-    });
-
-    it('should not remove the view', function() {
-      expect(this.removeSpy).to.have.been.calledOnce;
-    });
-
-    it('should not set the view _isDestroyed to true', function() {
-      expect(this.view).to.be.have.property('_isDestroyed', true);
-    });
-  });
-
-  describe('when destroying a view and returning undefined from the onBeforeDestroy method', function() {
-    beforeEach(function() {
-      this.argumentOne = 'foo';
-      this.argumentTwo = 'bar';
-
-      this.view = new Marionette.View();
-
-      this.removeSpy = sinon.spy(this.view, '_removeElement');
-
-      this.destroyStub = sinon.stub();
-      this.view.on('destroy', this.destroyStub);
-
-      this.onBeforeDestroyStub = sinon.stub().returns(false);
-      this.view.onBeforeDestroy = this.onBeforeDestroyStub;
-      sinon.spy(this.view, 'destroy');
-
-      this.view.destroy(this.argumentOne, this.argumentTwo);
-    });
-
-    it('should trigger the destroy event', function() {
-      expect(this.destroyStub).to.have.been.calledOnce.and.calledWith(this.view, this.argumentOne, this.argumentTwo);
-    });
-
-    it('should remove the view', function() {
-      expect(this.removeSpy).to.have.been.calledOnce;
-    });
-
-    it('should set the view _isDestroyed to true', function() {
-      expect(this.view).to.have.property('_isDestroyed', true);
-    });
-
-    it('should return the view', function() {
-      expect(this.view.destroy).to.have.returned(this.view);
     });
   });
 


### PR DESCRIPTION
### Proposed changes
 - Instead of propagating all arguments  passed to destroy to events and other methods, pass only the first one (options)
 - Remove tests that are checking return of 'before:destroy' event that has no effect. The tests were different from the enunciate anyway

This change simplify the code and align with other method signatures like `region.reset`, `region.empty`, `region.show`


