### PR TITLE
Propagate only the third argument (options) passed to showChildView

### DIFF
--- a/src/mixins/regions.js
+++ b/src/mixins/regions.js
@@ -145,9 +145,9 @@ export default {
     return this._getRegions();
   },
 
-  showChildView(name, view, ...args) {
+  showChildView(name, view, options) {
     const region = this.getRegion(name);
-    region.show(view, ...args);
+    region.show(view, options);
     return view;
   },
 


### PR DESCRIPTION
### Proposed changes
 - In showChildView, pass only the third argument (options) instead of all arguments to region.show.
Similar to #3536 but in this case there's no change in functionality since `region.show` does not take into account the remaining arguments
 
 

