### PR TITLE
Optimize _getUIBindings

### DIFF
--- a/src/mixins/ui.js
+++ b/src/mixins/ui.js
@@ -67,8 +67,7 @@ export default {
 
   _getUIBindings() {
     const uiBindings = _.result(this, '_uiBindings');
-    const ui = _.result(this, 'ui');
-    return uiBindings || ui;
+    return uiBindings || _.result(this, 'ui');
   },
 
   // This method binds the elements specified in the "ui" hash inside the view's code with


### PR DESCRIPTION
### Proposed changes
 - Takes advantage of short circuit evaluation to only execute `_.result(this, 'ui')` when `uiBindings` is falsy
