### PR TITLE
Create rest arguments in triggerMethod only when there's a method

### DIFF
--- a/src/common/trigger-method.js
+++ b/src/common/trigger-method.js
@@ -33,7 +33,7 @@ export default function triggerMethod(event) {
   // call the onMethodName if it exists
   if (_.isFunction(method)) {
     // pass all args, except the event name
-    result = method.apply(this, _.rest(arguments));
+    result = method.apply(this, _.drop(arguments));
   }
 
   // trigger the event

--- a/src/common/trigger-method.js
+++ b/src/common/trigger-method.js
@@ -24,7 +24,7 @@ const getOnMethodName = _.memoize(function(event) {
 //
 // `this.triggerMethod("foo:bar")` will trigger the "foo:bar" event and
 // call the "onFooBar" method.
-export default function triggerMethod(event, ...args) {
+export default function triggerMethod(event) {
   // get the method name from the event name
   const methodName = getOnMethodName(event);
   const method = getOption.call(this, methodName);
@@ -33,7 +33,7 @@ export default function triggerMethod(event, ...args) {
   // call the onMethodName if it exists
   if (_.isFunction(method)) {
     // pass all args, except the event name
-    result = method.apply(this, args);
+    result = method.apply(this, _.rest(arguments));
   }
 
   // trigger the event


### PR DESCRIPTION
### Proposed changes
 - Currently the rest arguments of triggerMethod are created regardless the existence of a matching method. Changes to only create the rest arguments when there's a method (the minority of cases)
