### PR TITLE
reorganize and refactor getOption, bindRequest, and BindEvents unit t…

### DIFF
--- a/test/unit/common/bind-events.spec.js
+++ b/test/unit/common/bind-events.spec.js
@@ -1,95 +1,103 @@
-import * as Marionette from '../../../src/backbone.marionette';
+import { bindEvents } from '../../../src/backbone.marionette';
+import { setEnabled } from '../../../src/config/features';
 import deprecate from '../../../src/utils/deprecate';
 
 describe('Marionette.bindEvents', function() {
-  beforeEach(function() {
-    this.handleFooStub = this.sinon.stub();
-    this.handleBarStub = this.sinon.stub();
-    this.handleMultiStub = this.sinon.stub();
-    this.listenToStub = this.sinon.stub();
-    this.entityStub = this.sinon.stub();
+  let handleFooStub;
+  let handleBarStub;
+  let handleMultiStub;
+  let listenToStub;
+  let entityStub;
+  let target;
+  let entity;
 
-    this.target = {
-      handleFoo: this.handleFooStub,
-      handleBar: this.handleBarStub,
-      handleMulti: this.handleMultiStub,
-      listenTo: this.listenToStub
+  beforeEach(function() {
+    handleFooStub = this.sinon.stub();
+    handleBarStub = this.sinon.stub();
+    handleMultiStub = this.sinon.stub();
+    listenToStub = this.sinon.stub();
+    entityStub = this.sinon.stub();
+
+    target = {
+      handleFoo: handleFooStub,
+      handleBar: handleBarStub,
+      handleMulti: handleMultiStub,
+      listenTo: listenToStub
     };
 
-    this.entity = this.entityStub;
+    entity = entityStub;
   });
 
   describe('when entity isnt passed', function() {
     beforeEach(function() {
-      Marionette.bindEvents(this.target, false, {'foo': 'handleFoo'});
+      bindEvents(target, false, {'foo': 'handleFoo'});
     });
 
     it('shouldnt bind any events', function() {
-      expect(this.listenToStub).not.to.have.been.called;
+      expect(listenToStub).not.to.have.been.called;
     });
 
     it('should return the target', function() {
-      expect(Marionette.bindEvents(this.target, false, {'foo': 'foo'})).to.equal(this.target);
+      expect(bindEvents(target, false, {'foo': 'foo'})).to.equal(target);
     });
   });
 
   describe('when bindings isnt passed', function() {
     beforeEach(function() {
-      Marionette.bindEvents(this.target, this.entity, null);
+      bindEvents(target, entity, null);
     });
 
     it('shouldnt bind any events', function() {
-      expect(this.listenToStub).not.to.have.been.called;
+      expect(listenToStub).not.to.have.been.called;
     });
 
     it('should return the target', function() {
-      expect(Marionette.bindEvents(this.target, this.entity, null)).to.equal(this.target);
+      expect(bindEvents(target, entity, null)).to.equal(target);
     });
   });
 
   describe('when bindings is an object with one event-handler pair', function() {
     describe('when handler is a function', function() {
       beforeEach(function() {
-        Marionette.bindEvents(this.target, this.entity, {'foo': this.handleFooStub});
+        bindEvents(target, entity, {'foo': handleFooStub});
       });
 
       it('should bind an event to targets handler', function() {
-        expect(this.listenToStub).to.have.been.calledOnce.and.calledWith(this.entity, 'foo', this.handleFooStub);
+        expect(listenToStub).to.have.been.calledOnce.and.calledWith(entity, 'foo', handleFooStub);
       });
     });
 
     describe('when handler is a string', function() {
       describe('when one handler is passed', function() {
         beforeEach(function() {
-          Marionette.bindEvents(this.target, this.entity, {'foo': 'handleFoo'});
+          bindEvents(target, entity, {'foo': 'handleFoo'});
         });
 
         it('should bind an event to targets handler', function() {
-          expect(this.listenToStub).to.have.been.calledOnce.and.calledWith(this.entity, 'foo', this.handleFooStub);
+          expect(listenToStub).to.have.been.calledOnce.and.calledWith(entity, 'foo', handleFooStub);
         });
       });
 
       describe('when multiple handlers are passed', function() {
         beforeEach(function() {
-          Marionette.bindEvents(this.target, this.entity, {
+          bindEvents(target, entity, {
             'baz': 'handleFoo handleBar'
           });
         });
 
         it('should bind first event to targets handler', function() {
-          expect(this.listenToStub).to.have.been.calledTwice.and.calledWith(this.entity, 'baz', this.handleFooStub);
+          expect(listenToStub).to.have.been.calledTwice.and.calledWith(entity, 'baz', handleFooStub);
         });
 
         it('should bind second event to targets handler', function() {
-          expect(this.listenToStub).to.have.been.calledTwice.and.calledWith(this.entity, 'baz', this.handleBarStub);
+          expect(listenToStub).to.have.been.calledTwice.and.calledWith(entity, 'baz', handleBarStub);
         });
       });
 
       describe('when handler method doesnt exist', function() {
         it('should throw an exception', function() {
-          var suite = this;
           expect(function() {
-            Marionette.bindEvents(suite.target, suite.entity, {'baz': 'doesNotExist'});
+            bindEvents(target, entity, {'baz': 'doesNotExist'});
           }).to.throw('Method "doesNotExist" was configured as an event handler, but does not exist.');
         });
       });
@@ -98,20 +106,20 @@ describe('Marionette.bindEvents', function() {
 
   describe('when bindings is an object with multiple event-handler pairs', function() {
     beforeEach(function() {
-      Marionette.setEnabled('DEV_MODE', true);
+      setEnabled('DEV_MODE', true);
       this.sinon.spy(deprecate, '_warn');
       this.sinon.stub(deprecate, '_console', {
         warn: this.sinon.stub()
       });
       deprecate._cache = {};
-      Marionette.bindEvents(this.target, this.entity, {
+      bindEvents(target, entity, {
         'foo': 'handleFoo handleMulti',
         'bar': 'handleBar'
       });
     });
 
     afterEach(function() {
-      Marionette.setEnabled('DEV_MODE', false);
+      setEnabled('DEV_MODE', false);
     });
 
     it('should call deprecate', function() {
@@ -119,25 +127,27 @@ describe('Marionette.bindEvents', function() {
     });
 
     it('should bind first event to targets handlers', function() {
-      expect(this.listenToStub).to.have.been.calledThrice
-        .and.calledWith(this.entity, 'foo', this.handleFooStub)
-        .and.calledWith(this.entity, 'foo', this.handleMultiStub);
+      expect(listenToStub).to.have.been.calledThrice
+        .and.calledWith(entity, 'foo', handleFooStub)
+        .and.calledWith(entity, 'foo', handleMultiStub);
     });
 
     it('should bind second event to targets handler', function() {
-      expect(this.listenToStub).to.have.been.calledThrice.and.calledWith(this.entity, 'bar', this.handleBarStub);
+      expect(listenToStub).to.have.been.calledThrice.and.calledWith(entity, 'bar', handleBarStub);
     });
   });
 
   describe('when bindings is not an object', function() {
+    let run;
+
     beforeEach(function() {
-      this.run = function() {
-        Marionette.bindEvents(this.target, this.entity, 'handleFoo');
+      run = function() {
+        bindEvents(target, entity, 'handleFoo');
       }.bind(this);
     });
 
     it('should error', function() {
-      expect(this.run).to.throw('Bindings must be an object.');
+      expect(run).to.throw('Bindings must be an object.');
     });
   });
 });

--- a/test/unit/common/bind-request.spec.js
+++ b/test/unit/common/bind-request.spec.js
@@ -1,69 +1,74 @@
-import * as Marionette from '../../../src/backbone.marionette';
+import { bindRequests } from '../../../src/backbone.marionette';
 
-describe('Marionette.bindRequests', function() {
+describe('bindRequests', function() {
+  let replyFooStub;
+  let replyBarStub;
+  let replyStub;
+  let target;
+  let channel;
 
   beforeEach(function() {
-    this.replyFooStub = this.sinon.stub();
-    this.replyBarStub = this.sinon.stub();
-    this.replyStub = this.sinon.stub();
+    replyFooStub = this.sinon.stub();
+    replyBarStub = this.sinon.stub();
+    replyStub = this.sinon.stub();
 
-    this.target = {
-      replyFoo: this.replyFooStub,
-      replyBar: this.replyBarStub
+    target = {
+      replyFoo: replyFooStub,
+      replyBar: replyBarStub
     };
 
-    this.channel = {
-      reply: this.replyStub
+    channel = {
+      reply: replyStub
     };
   });
 
   describe('when channel isnt passed', function() {
     beforeEach(function() {
-      Marionette.bindRequests(this.target, false, {'foo': 'replyFoo'});
+      bindRequests(target, false, {'foo': 'replyFoo'});
     });
 
     it('shouldnt bind any requests', function() {
-      expect(this.replyStub).not.to.have.been.called;
+      expect(replyStub).not.to.have.been.called;
     });
 
     it('should return the target', function() {
-      expect(Marionette.bindRequests(this.target, false, {'foo': 'replyFoo'})).to.equal(this.target);
+      expect(bindRequests(target, false, {'foo': 'replyFoo'})).to.equal(target);
     });
   });
 
   describe('when bindings isnt passed', function() {
     beforeEach(function() {
-      Marionette.bindRequests(this.target, this.channel, null);
+      bindRequests(target, channel, null);
     });
 
     it('shouldnt bind any requests', function() {
-      expect(this.replyStub).not.to.have.been.called;
+      expect(replyStub).not.to.have.been.called;
     });
 
     it('should return the target', function() {
-      expect(Marionette.bindRequests(this.target, this.channel, null)).to.equal(this.target);
+      expect(bindRequests(target, channel, null)).to.equal(target);
     });
   });
 
   describe('when bindings is an object with one request-handler pair', function() {
     describe('when handler is a function', function() {
       beforeEach(function() {
-        Marionette.bindRequests(this.target, this.channel, {'foo': this.replyFooStub});
+        bindRequests(target, channel, {'foo': replyFooStub});
       });
 
       it('should bind a request to targets handler', function() {
-        expect(this.replyStub).to.have.been.calledOnce.and.calledWith({'foo': this.replyFooStub});
+        expect(replyStub).to.have.been.calledOnce.and.calledWith({'foo': replyFooStub});
       });
     });
 
     describe('when handler is a string', function() {
       describe('when one handler is passed', function() {
         beforeEach(function() {
-          Marionette.bindRequests(this.target, this.channel, {'foo': 'replyFoo'});
+          bindRequests(target, channel, {'foo': 'replyFoo'});
         });
 
         it('should bind a request to targets handler', function() {
-          expect(this.replyStub).to.have.been.calledOnce.and.calledWith({'foo': this.replyFooStub});
+          expect(replyStub).to.have.been.calledOnce.and.calledWith({'foo': replyFooStub});
         });
       });
     });
@@ -71,26 +76,28 @@ describe('Marionette.bindRequests', function() {
 
   describe('when bindings is an object with multiple event-handler pairs', function() {
     beforeEach(function() {
-      Marionette.bindRequests(this.target, this.channel, {
+      bindRequests(target, channel, {
         'foo': 'replyFoo',
         'bar': 'replyBar'
       });
     });
 
     it('should bind both requests to target handlers', function() {
-      expect(this.replyStub).to.have.been.calledOnce.and.calledWith({bar: this.replyBarStub, foo: this.replyFooStub});
+      expect(replyStub).to.have.been.calledOnce.and.calledWith({bar: replyBarStub, foo: replyFooStub});
     });
   });
 
   describe('when bindings is not an object', function() {
+    let run;
+
     beforeEach(function() {
-      this.run = function() {
-        Marionette.bindRequests(this.target, this.channel, 'replyFooStub');
+      run = function() {
+        bindRequests(target, channel, 'replyFooStub');
       }.bind(this);
     });
 
     it('should error', function() {
-      expect(this.run).to.throw('Bindings must be an object.');
+      expect(run).to.throw('Bindings must be an object.');
     });
   });
 

--- a/test/unit/common/get-option.spec.js
+++ b/test/unit/common/get-option.spec.js
@@ -1,58 +1,75 @@
+import { getOption } from '../../../src/backbone.marionette';
+
 describe('get option', function() {
   'use strict';
 
   describe('when an object only has the option set on the definition', function() {
+    let target;
+    let value;
+
     beforeEach(function() {
-      this.target = {foo: 'bar'};
-      this.value = Marionette.getOption(this.target, 'foo');
+      target = {foo: 'bar'};
+      value = getOption(target, 'foo');
     });
 
     it('should return that definitions option', function() {
-      expect(this.value).to.equal(this.target.foo);
+      expect(value).to.equal(target.foo);
     });
   });
 
   describe('when an object only has the option set on the options', function() {
+    let target;
+    let value;
+
     beforeEach(function() {
-      this.target = {options: {foo: 'bar'}};
-      this.value = Marionette.getOption(this.target, 'foo');
+      target = {options: {foo: 'bar'}};
+      value = getOption(target, 'foo');
     });
 
     it('should return value from the options', function() {
-      expect(this.value).to.equal(this.target.options.foo);
+      expect(value).to.equal(target.options.foo);
     });
   });
 
   describe('when an object has the option set on the options, and it is a "falsey" value', function() {
+    let target;
+    let value;
+
     beforeEach(function() {
-      this.target = {options: {foo: false}};
-      this.value = Marionette.getOption(this.target, 'foo');
+      target = {options: {foo: false}};
+      value = getOption(target, 'foo');
     });
 
     it('should return value from the options', function() {
-      expect(this.value).to.equal(this.target.options.foo);
+      expect(value).to.equal(target.options.foo);
     });
   });
 
   describe('when an object has the option set on the options, and it is a "undefined" value', function() {
+    let target;
+    let value;
+
     beforeEach(function() {
-      this.target = {foo: 'bar', options: {foo: undefined}};
-      this.value = Marionette.getOption(this.target, 'foo');
+      target = {foo: 'bar', options: {foo: undefined}};
+      value = getOption(target, 'foo');
     });
 
     it('should return the objects value', function() {
-      expect(this.value).to.equal(this.target.foo);
+      expect(value).to.equal(target.foo);
     });
   });
 
   describe('when an object has the option set on both the defininition and options', function() {
+    let target;
+    let value;
+
     beforeEach(function() {
-      this.target = {foo: 'bar', options: {foo: 'baz'}};
-      this.value = Marionette.getOption(this.target, 'foo');
+      target = {foo: 'bar', options: {foo: 'baz'}};
+      value = getOption(target, 'foo');
     });
 
     it('should return that value from the options', function() {
-      expect(this.value).to.equal(this.target.options.foo);
+      expect(value).to.equal(target.options.foo);
     });
   });
 });


### PR DESCRIPTION
### Proposed changes
- Reorganize tests to match order of codebase
- Import dependencies to move away from using global ones
- Use let in favor of this in beforeEach

Link to the issue: #3248

This pr is a small part of the work to refactor the whole unit tests directory. Merging this issue should keep #3248 open
