### PR TITLE
reorganize and refactor behaviors and features unit tests

### DIFF
--- a/test/unit/config/behaviors.spec.js
+++ b/test/unit/config/behaviors.spec.js
@@ -2,6 +2,7 @@ import Behavior from '../../../src/behavior';
 import Region from '../../../src/region';
 import View from '../../../src/view';
 import CollectionView from '../../../src/collection-view';
+import { bindEvents } from '../../../src/backbone.marionette';
 
 describe('Behaviors', function() {
 
@@ -233,7 +234,7 @@ describe('Behaviors', function() {
         bar: Behavior.extend({initialize: barStub})
       };
 
-      FooView = Marionette.View.extend({
+      FooView = View.extend({
         behaviors: [behaviorSpies.foo]
       });
     });
@@ -263,17 +264,17 @@ describe('Behaviors', function() {
       viewClickStub = this.sinon.stub();
 
       behaviorSpies = {
-        foo: Marionette.Behavior.extend({
+        foo: Behavior.extend({
           events: {
             'click': fooClickStub
           }
         }),
-        bar: Marionette.Behavior.extend({
+        bar: Behavior.extend({
           events: {
             'click': barClickStub
           }
         }),
-        baz: Marionette.Behavior.extend({
+        baz: Behavior.extend({
           events: {
             'click': 'handleClick'
           },
@@ -281,7 +282,7 @@ describe('Behaviors', function() {
         })
       };
 
-      FooView = Marionette.View.extend({
+      FooView = View.extend({
         events: {
           'click': viewClickStub
         },
@@ -337,7 +338,7 @@ describe('Behaviors', function() {
         })
       };
 
-      const FooView = Marionette.View.extend({
+      const FooView = View.extend({
         triggers: {
           'click': 'click:foo:view'
         },
@@ -390,14 +391,14 @@ describe('Behaviors', function() {
 
     beforeEach(function() {
       const behaviorSpies = {
-        foo: Marionette.Behavior.extend({
+        foo: Behavior.extend({
           initialize: function() {
             fooBehavior = this;
           }
         })
       };
 
-      const FooView = Marionette.View.extend({
+      const FooView = View.extend({
         behaviors: [behaviorSpies.foo]
       });
 
@@ -751,7 +752,7 @@ describe('Behaviors', function() {
       handleModelFooChangeStub = this.sinon.stub();
 
       const behaviorSpies = {
-        foo: Marionette.Behavior.extend({
+        foo: Behavior.extend({
           initialize: function() {
             fooBehavior = this;
           },
@@ -826,7 +827,7 @@ describe('Behaviors', function() {
       onRenderStub = this.sinon.stub();
 
       const behaviorSpies = {
-        foo: Marionette.Behavior.extend({
+        foo: Behavior.extend({
           onRender: onRenderStub
         })
       };
@@ -850,7 +851,7 @@ describe('Behaviors', function() {
 
     beforeEach(function() {
       const behaviorSpies = {
-        foo: Marionette.Behavior.extend({
+        foo: Behavior.extend({
           onFoo: function() {
             return 'behavior foo';
           }
@@ -883,10 +884,10 @@ describe('Behaviors', function() {
       listenToStub = this.sinon.stub();
       changeStub = this.sinon.stub();
 
-      behavior = new Marionette.Behavior({}, {});
+      behavior = new Behavior({}, {});
       fooModel = new Backbone.Model();
 
-      Marionette.bindEvents(behavior, fooModel, {
+      bindEvents(behavior, fooModel, {
         'change': changeStub
       });
 
@@ -938,7 +939,7 @@ describe('Behaviors', function() {
       barCollectionSyncStub = this.sinon.stub();
       bazClickStub = this.sinon.stub();
 
-      const BarBehavior = Marionette.Behavior.extend({
+      const BarBehavior = Behavior.extend({
         initialize: function() {
           initializeStub();
           barBehavior = this;
@@ -959,7 +960,7 @@ describe('Behaviors', function() {
       });
 
       const behaviorSpies = {
-        foo: Marionette.Behavior.extend({
+        foo: Behavior.extend({
           initialize: function() {
             fooBehavior = this;
           },

--- a/test/unit/config/features.spec.js
+++ b/test/unit/config/features.spec.js
@@ -1,15 +1,17 @@
+import { setEnabled, isEnabled } from '../../../src/config/features';
+
 describe('features', function() {
   it('enabled when its present and true', function() {
-    Marionette.setEnabled('foo', true);
-    expect(Marionette.isEnabled('foo')).to.be.true;
+    setEnabled('foo', true);
+    expect(isEnabled('foo')).to.be.true;
   });
 
   it('disabled when its present and false', function() {
-    Marionette.setEnabled('foo', false);
-    expect(Marionette.isEnabled('foo')).to.be.false;
+    setEnabled('foo', false);
+    expect(isEnabled('foo')).to.be.false;
   });
 
   it('disabled when not present', function() {
-    expect(Marionette.isEnabled('foo')).to.be.false;
+    expect(isEnabled('foo')).to.be.false;
   });
 });


### PR DESCRIPTION
### Proposed changes
- Reorganize tests to match order of codebase
- Import dependencies to move away from using global ones
- Use let in favor of this in beforeEach

Link to the issue: #3248

This pr is a small part of the work to refactor the whole unit tests directory. Merging this issue should keep #3248 open