### PR TITLE
POC Make MnObject extend Object

### DIFF
--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -61,6 +61,7 @@ export {
   View,
   CollectionView,
   MnObject,
+  MnObject as Object,
   Region,
   Behavior,
   Application,

--- a/src/object.js
+++ b/src/object.js
@@ -15,28 +15,24 @@ const ClassOptions = [
   'radioRequests'
 ];
 
-// Object borrows many conventions and utilities from Backbone.
-const MarionetteObject = function(options) {
-  this._setOptions(options);
-  this.mergeOptions(options, ClassOptions);
-  this.cid = _.uniqueId(this.cidPrefix);
-  this._initRadio();
-  this.initialize.apply(this, arguments);
-};
+const MnObject = extend.call(Object, {
+  constructor(options) {
+    Object.prototype.constructor.apply(this, arguments);
+    this._setOptions(options);
+    this.mergeOptions(options, ClassOptions);
+    this.cid = _.uniqueId(this.cidPrefix);
+    this._initRadio();
+    this.initialize.apply(this, arguments);
+  },
 
-MarionetteObject.extend = extend;
-
-// Object Methods
-// --------------
-
-// Ensure it can trigger events with Backbone.Events
-_.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, DestroyMixin, RadioMixin, {
   cidPrefix: 'mno',
 
   // This is a noop method intended to be overridden
   initialize() {},
 
   triggerMethod
-});
+}, { extend });
 
-export default MarionetteObject;
+_.extend(MnObject.prototype, Backbone.Events, CommonMixin, DestroyMixin, RadioMixin);
+
+export default MnObject;


### PR DESCRIPTION
Makes Object slightly more purposeful maybe and makes renaming `Object` to `MnObject` possible less important.

We _could_ even export under both names?

There could be some significant downsides to this, but what are they?
