### PR TITLE
Implement setRenderer destructive option

### DIFF
--- a/src/config/renderer.js
+++ b/src/config/renderer.js
@@ -1,5 +1,8 @@
 // Static setter for the renderer
-export function setRenderer(renderer) {
+export function setRenderer(renderer, options) {
   this.prototype._renderHtml = renderer;
+  if (options && options.destructive === false) {
+    this.prototype._preventRegionReInit = true;
+  }
   return this;
 }

--- a/src/view.js
+++ b/src/view.js
@@ -85,7 +85,7 @@ const View = Backbone.View.extend({
 
     // If this is not the first render call, then we need to
     // re-initialize the `el` for each region
-    if (this._isRendered) {
+    if (this._isRendered && !this._preventRegionReInit) {
       this._reInitRegions();
     }
 

--- a/test/unit/backbone.marionette.spec.js
+++ b/test/unit/backbone.marionette.spec.js
@@ -59,5 +59,24 @@ describe('backbone.marionette', function() {
         expect(Class.setRenderer).to.be.calledOnce.and.calledWith(fakeRenderer);
       });
     });
+
+    describe('when destructive option is set to false', function() {
+      const TestView = View.extend({
+        template: _.noop
+      });
+      let view;
+
+      beforeEach(function() {
+        TestView.setRenderer(renderer, {destructive: false});
+        view = new TestView();
+        view.render();
+        this.sinon.spy(view, '_reInitRegions');
+        view.render();
+      });
+
+      it('should not re-init regions on view re-render', function() {
+        expect(view._reInitRegions).to.not.be.called;
+      });
+    });
   });
 });


### PR DESCRIPTION
### Proposed changes
 - when passing an options hash to `setRenderer` with destructive: false, do not reinit regions on view re-render
 
Link to the issue: #3427
