### PR TITLE
Improve triggerMethod

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -2,10 +2,8 @@
 // -----------
 
 import _ from 'underscore';
-import Backbone from 'backbone';
 import extend from './utils/extend';
 import buildRegion from './common/build-region';
-import triggerMethod from './common/trigger-method';
 import CommonMixin from './mixins/common';
 import DestroyMixin from './mixins/destroy';
 import RadioMixin from './mixins/radio';
@@ -32,14 +30,11 @@ Application.extend = extend;
 // Application Methods
 // --------------
 
-// Ensure it can trigger events with Backbone.Events
-_.extend(Application.prototype, Backbone.Events, CommonMixin, DestroyMixin, RadioMixin, {
+_.extend(Application.prototype, CommonMixin, DestroyMixin, RadioMixin, {
   cidPrefix: 'mna',
 
   // This is a noop method intended to be overridden
   initialize() {},
-
-  triggerMethod,
 
   // Kick off all of the application's processes.
   start(options) {

--- a/src/behavior.js
+++ b/src/behavior.js
@@ -7,10 +7,8 @@
 // into portable logical chunks, keeping your views simple and your code DRY.
 
 import _ from 'underscore';
-import Backbone from 'backbone';
 import extend from './utils/extend';
 import getNamespacedEventName from './utils/get-namespaced-event-name';
-import triggerMethod from './common/trigger-method';
 import CommonMixin from './mixins/common';
 import DelegateEntityEventsMixin from './mixins/delegate-entity-events';
 import TriggersMixin from './mixins/triggers';
@@ -44,6 +42,9 @@ const Behavior = function(options, view) {
   // selector under an UI key.
   this.ui = _.extend({}, _.result(this, 'ui'), _.result(view, 'ui'));
 
+  // Proxy view triggers
+  this.listenTo(view, 'all', this.triggerMethod);
+
   this.initialize.apply(this, arguments);
 };
 
@@ -52,8 +53,7 @@ Behavior.extend = extend;
 // Behavior Methods
 // --------------
 
-// Ensure it can trigger events with Backbone.Events
-_.extend(Behavior.prototype, Backbone.Events, CommonMixin, DelegateEntityEventsMixin, TriggersMixin, UIMixin, {
+_.extend(Behavior.prototype, CommonMixin, DelegateEntityEventsMixin, TriggersMixin, UIMixin, {
   cidPrefix: 'mnb',
 
   // This is a noop method intended to be overridden
@@ -141,9 +141,7 @@ _.extend(Behavior.prototype, Backbone.Events, CommonMixin, DelegateEntityEventsM
     const behaviorTriggers = this.normalizeUIKeys(_.result(this, 'triggers'));
 
     return this._getViewTriggers(this.view, behaviorTriggers);
-  },
-
-  triggerMethod
+  }
 });
 
 export default Behavior;

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -63,7 +63,7 @@ const CollectionView = Backbone.View.extend({
 
     this.delegateEntityEvents();
 
-    this._triggerEventOnBehaviors('initialize', this);
+    this._triggerEventOnBehaviors('initialize', this, options);
   },
 
   // Internal method to set up the `children` object for storing all of the child views

--- a/src/common/trigger-method.js
+++ b/src/common/trigger-method.js
@@ -7,15 +7,22 @@ import getOption from './get-option';
 // split the event name on the ":"
 const splitter = /(^|:)(\w)/gi;
 
+// Only calc getOnMethodName once
+const methodCache = {};
+
 // take the event section ("section1:section2:section3")
 // and turn it in to uppercase name onSection1Section2Section3
 function getEventName(match, prefix, eventName) {
   return eventName.toUpperCase();
 }
 
-const getOnMethodName = _.memoize(function(event) {
-  return 'on' + event.replace(splitter, getEventName);
-});
+const getOnMethodName = function(event) {
+  if (!methodCache[event]) {
+    methodCache[event] = 'on' + event.replace(splitter, getEventName);
+  }
+
+  return methodCache[event];
+};
 
 // Trigger an event and/or a corresponding method name. Examples:
 //

--- a/src/mixins/behaviors.js
+++ b/src/mixins/behaviors.js
@@ -1,7 +1,6 @@
 import _ from 'underscore';
 import MarionetteError from '../utils/error';
 import _invoke from '../utils/invoke';
-import triggerMethod from '../common/trigger-method';
 
 // MixinOptions
 // - behaviors
@@ -102,11 +101,7 @@ export default {
     _invoke(this._behaviors, 'unbindUIElements');
   },
 
-  _triggerEventOnBehaviors() {
-    const behaviors = this._behaviors;
-    // Use good ol' for as this is a very hot function
-    for (let i = 0, length = behaviors && behaviors.length; i < length; i++) {
-      triggerMethod.apply(behaviors[i], arguments);
-    }
+  _triggerEventOnBehaviors(eventName, view, options) {
+    _invoke(this._behaviors, 'triggerMethod', eventName, view, options);
   }
 };

--- a/src/mixins/common.js
+++ b/src/mixins/common.js
@@ -1,8 +1,10 @@
 import _ from 'underscore';
+import Backbone from 'backbone';
 
 import getOption from '../common/get-option';
 import mergeOptions from '../common/merge-options';
 import normalizeMethods from '../common/normalize-methods';
+import triggerMethod from '../common/trigger-method';
 import {
   bindEvents,
   unbindEvents
@@ -12,7 +14,7 @@ import {
   unbindRequests
 } from '../common/bind-requests';
 
-export default {
+const CommonMixin = {
 
   // Imports the "normalizeMethods" to transform hashes of
   // events=>function references/names to a hash of events=>function references
@@ -39,5 +41,11 @@ export default {
   bindRequests,
 
   // Enable unbinding view's requests.
-  unbindRequests
+  unbindRequests,
+
+  triggerMethod
 };
+
+_.extend(CommonMixin, Backbone.Events);
+
+export default CommonMixin;

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -3,7 +3,6 @@
 
 import Backbone from 'backbone';
 import _ from 'underscore';
-import triggerMethod from '../common/trigger-method';
 import BehaviorsMixin from './behaviors';
 import CommonMixin from './common';
 import DelegateEntityEventsMixin from './delegate-entity-events';
@@ -142,6 +141,7 @@ const ViewMixin = {
     this._deleteEntityEventHandlers();
 
     this.triggerMethod('destroy', this, options);
+    this._triggerEventOnBehaviors('destroy', this, options);
 
     this.stopListening();
 
@@ -171,16 +171,6 @@ const ViewMixin = {
 
   getUI(name) {
     return this._getUI(name);
-  },
-
-  // import the `triggerMethod` to trigger events with corresponding
-  // methods if the method exists
-  triggerMethod() {
-    const ret = triggerMethod.apply(this, arguments);
-
-    this._triggerEventOnBehaviors.apply(this, arguments);
-
-    return ret;
   },
 
   // Cache `childViewEvents` and `childViewTriggers`

--- a/src/object.js
+++ b/src/object.js
@@ -2,9 +2,7 @@
 // ------
 
 import _ from 'underscore';
-import Backbone from 'backbone';
 import extend from './utils/extend';
-import triggerMethod from './common/trigger-method';
 import CommonMixin from './mixins/common';
 import DestroyMixin from './mixins/destroy';
 import RadioMixin from './mixins/radio';
@@ -28,14 +26,11 @@ MarionetteObject.extend = extend;
 // Object Methods
 // --------------
 
-// Ensure it can trigger events with Backbone.Events
-_.extend(MarionetteObject.prototype, Backbone.Events, CommonMixin, DestroyMixin, RadioMixin, {
+_.extend(MarionetteObject.prototype, CommonMixin, DestroyMixin, RadioMixin, {
   cidPrefix: 'mno',
 
   // This is a noop method intended to be overridden
-  initialize() {},
-
-  triggerMethod
+  initialize() {}
 });
 
 export default MarionetteObject;

--- a/src/region.js
+++ b/src/region.js
@@ -5,9 +5,8 @@ import _ from 'underscore';
 import Backbone from 'backbone';
 import MarionetteError from './utils/error';
 import extend from './utils/extend';
-import { renderView, destroyView } from './common/view';
 import monitorViewEvents from './common/monitor-view-events';
-import triggerMethod from './common/trigger-method';
+import { renderView, destroyView } from './common/view';
 import CommonMixin from './mixins/common';
 import View from './view';
 import DomApi, { setDomApi } from './config/dom';
@@ -50,8 +49,7 @@ Region.setDomApi = setDomApi;
 // Region Methods
 // --------------
 
-// Ensure it can trigger events with Backbone.Events
-_.extend(Region.prototype, Backbone.Events, CommonMixin, {
+_.extend(Region.prototype, CommonMixin, {
   Dom: DomApi,
 
   cidPrefix: 'mnr',
@@ -406,9 +404,7 @@ _.extend(Region.prototype, Backbone.Events, CommonMixin, {
     this.stopListening();
 
     return this;
-  },
-
-  triggerMethod
+  }
 });
 
 export default Region;

--- a/src/view.js
+++ b/src/view.js
@@ -50,7 +50,7 @@ const View = Backbone.View.extend({
 
     this.delegateEntityEvents();
 
-    this._triggerEventOnBehaviors('initialize', this);
+    this._triggerEventOnBehaviors('initialize', this, options);
   },
 
   // Overriding Backbone.View's `setElement` to handle

--- a/test/unit/behavior.spec.js
+++ b/test/unit/behavior.spec.js
@@ -172,46 +172,31 @@ describe('Behavior', function() {
   });
 
   describe('behavior initialize', function() {
-    let behaviorSpies;
-    let behaviorOptions;
-    let initializeStub;
-    let FooView;
+    let behavior;
+    let view;
 
     beforeEach(function() {
-      behaviorOptions = {foo: 'bar'};
-      initializeStub = this.sinon.stub();
-
-      behaviorSpies = {
-        foo: Behavior.extend({
-          initialize: initializeStub
-        })
-      };
-
-      FooView = View.extend({
-        behaviors: [_.extend({}, behaviorOptions, {behaviorClass: behaviorSpies.foo})]
+      const TestBehavior = Behavior.extend({
+        initialize: this.sinon.stub()
       });
+
+      view = new View();
+
+      behavior = new TestBehavior({ foo: 'bar' }, view);
     });
 
     it('should have a cidPrefix', function() {
-      /* eslint-disable no-unused-vars */
-      const fooView = new FooView();
-      const fooBehavior = new behaviorSpies.foo();
-
-      expect(fooBehavior.cidPrefix).to.equal('mnb');
+      expect(behavior.cidPrefix).to.equal('mnb');
     });
 
     it('should have a cid', function() {
-      /* eslint-disable no-unused-vars */
-      const fooView = new FooView();
-      const fooBehavior = new behaviorSpies.foo();
-
-      expect(fooBehavior.cid).to.exist;
+      expect(behavior.cid).to.exist;
     });
 
     it('should call initialize when a behavior is created', function() {
-      const fooView = new FooView();
-
-      expect(initializeStub).to.have.been.calledOnce.and.calledWithMatch(behaviorOptions, fooView);
+      expect(behavior.initialize)
+        .to.have.been.calledOnce
+        .and.calledWith({ foo: 'bar' }, view);
     });
   });
 
@@ -681,12 +666,6 @@ describe('Behavior', function() {
       fooModel.set('bar', 'baz');
 
       expect(listenToChangeStub).not.to.have.been.calledOnce;
-    });
-
-    it('should still be bound to "on" on destroy', function() {
-      fooView.triggerMethod('foo');
-
-      expect(onFooStub).to.have.been.calledOnce;
     });
   });
 

--- a/test/unit/collection-view/collection-view.spec.js
+++ b/test/unit/collection-view/collection-view.spec.js
@@ -110,11 +110,11 @@ describe('CollectionView', function() {
     it('should trigger `initialize` on the behaviors', function() {
       this.sinon.stub(MyCollectionView.prototype, '_triggerEventOnBehaviors');
 
-      const myCollectionView = new MyCollectionView();
+      const myCollectionView = new MyCollectionView({ foo: 'bar' });
 
       // _triggerEventOnBehaviors comes from Behaviors mixin
       expect(myCollectionView._triggerEventOnBehaviors)
-        .to.be.calledOnce.and.calledWith('initialize', myCollectionView);
+        .to.be.calledOnce.and.calledWith('initialize', myCollectionView, { foo: 'bar' });
     });
   });
 

--- a/test/unit/mixins/behaviors.spec.js
+++ b/test/unit/mixins/behaviors.spec.js
@@ -470,15 +470,15 @@ describe('Behaviors Mixin', function() {
       behaviorsInstance._initBehaviors();
     });
 
-    it('should invoke unbindUIElements', function() {
-      behaviorsInstance._triggerEventOnBehaviors('foo', 'bar');
+    it('should invoke events', function() {
+      behaviorsInstance._triggerEventOnBehaviors('foo', 'view', 'options');
 
       expect(FooBehavior.prototype.onFoo)
         .to.have.been.calledOnce
-        .and.calledWith('bar');
+        .and.calledWith('view', 'options');
       expect(BarBehavior.prototype.onFoo)
         .to.have.been.calledOnce
-        .and.calledWith('bar');
+        .and.calledWith('view', 'options');
     });
   });
 });

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -2,9 +2,6 @@ describe('layoutView', function() {
   'use strict';
 
   beforeEach(function() {
-    const BBView = Backbone.View.extend();
-    _.extend(BBView.prototype, Marionette.BackboneViewMixin);
-
     this.layoutViewManagerTemplateFn = _.template('<div id="regionOne"></div><div id="regionTwo"></div>');
     this.template = function() {
       return '<span class=".craft"></span><h1 id="#a-fun-game"></h1>';

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -326,11 +326,11 @@ describe('item view', function() {
     it('should trigger `initialize` on the behaviors', function() {
       this.sinon.stub(View.prototype, '_triggerEventOnBehaviors');
 
-      const myView = new View();
+      const myView = new View({ foo: 'bar' });
 
       // _triggerEventOnBehaviors comes from Behaviors mixin
       expect(myView._triggerEventOnBehaviors)
-        .to.be.calledOnce.and.calledWith('initialize', myView);
+        .to.be.calledOnce.and.calledWith('initialize', myView, { foo: 'bar' });
     });
   });
 


### PR DESCRIPTION
I wasn't planning on making additional code changes apart from the spec work, but one rabbit trail led to another and I figured we may not want to introduce a new API that might be replaced soon.  

Partially resolves https://github.com/marionettejs/backbone.marionette/issues/2508

~~Renames `BackboneViewMixin` to `Marionette.Events`.  Still works for Bb Views but also sets up the potential for the rest of #2508 in v5.~~

Perhaps the biggest change is that this moves the behavior event proxy to the behavior.  This should be a perf improvement for `triggerMethod` in general.. particularly when no behaviors are applied.  I'm not sure the perf differences on the behaviors themselves.


