### PR TITLE
Add common view specs

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -709,8 +709,8 @@ const CollectionView = Backbone.View.extend({
       return;
     }
 
-    view._shouldDisableEvents = this.monitorViewEvents === false;
-    destroyView(view);
+    const shouldDisableEvents = this.monitorViewEvents === false;
+    destroyView(view, shouldDisableEvents);
   },
 
   // called by ViewMixin destroy

--- a/src/common/view.js
+++ b/src/common/view.js
@@ -8,24 +8,27 @@ export function renderView(view) {
   }
 
   view.render();
+  view._isRendered = true;
 
   if (!view.supportsRenderLifecycle) {
-    view._isRendered = true;
     view.triggerMethod('render', view);
   }
 }
 
-export function destroyView(view) {
+export function destroyView(view, disableDetachEvents) {
   if (view.destroy) {
+    // Attach flag for public destroy function internal check
+    view._disableDetachEvents = disableDetachEvents;
     view.destroy();
     return;
   }
 
+  // Destroy for non-Marionette Views
   if (!view.supportsDestroyLifecycle) {
     view.triggerMethod('before:destroy', view);
   }
 
-  const shouldTriggerDetach = view._isAttached && !view._shouldDisableEvents;
+  const shouldTriggerDetach = view._isAttached && !disableDetachEvents;
 
   if (shouldTriggerDetach) {
     view.triggerMethod('before:detach', view);

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -112,7 +112,7 @@ const ViewMixin = {
   // Handle destroying the view and its children.
   destroy(options) {
     if (this._isDestroyed) { return this; }
-    const shouldTriggerDetach = this._isAttached && !this._shouldDisableEvents;
+    const shouldTriggerDetach = this._isAttached && !this._disableDetachEvents;
 
     this.triggerMethod('before:destroy', this, options);
     if (shouldTriggerDetach) {

--- a/src/region.js
+++ b/src/region.js
@@ -315,8 +315,7 @@ _.extend(Region.prototype, Backbone.Events, CommonMixin, {
       return view;
     }
 
-    view._shouldDisableEvents = this._shouldDisableMonitoring();
-    destroyView(view);
+    destroyView(view, this._shouldDisableMonitoring());
     return view;
   },
 

--- a/test/unit/common/view.spec.js
+++ b/test/unit/common/view.spec.js
@@ -1,0 +1,212 @@
+import Backbone from 'backbone';
+
+import { renderView, destroyView } from '../../../src/common/view';
+
+describe('common view methods', function() {
+  let view;
+
+  beforeEach(function() {
+    view = new Backbone.View();
+    view.triggerMethod = this.sinon.stub();
+  });
+
+  describe('#renderView', function() {
+    beforeEach(function() {
+      view.render = this.sinon.stub();
+    });
+
+    describe('when render lifecycle is supported', function() {
+      beforeEach(function() {
+        view.supportsRenderLifecycle = true;
+        renderView(view);
+      });
+
+      it('should call render', function() {
+        expect(view.render).to.be.calledOnce;
+      });
+
+      it('should not trigger events', function() {
+        expect(view.triggerMethod).to.not.be.called;
+      });
+
+      describe('when view is rendered twice', function() {
+        it('should call not call render again', function() {
+          renderView(view);
+
+          expect(view.render)
+            .to.have.been.calledOnce
+            .to.not.have.been.calledTwice;
+        });
+      });
+    });
+
+    describe('when render lifecycle is not supported', function() {
+      beforeEach(function() {
+        view.supportsRenderLifecycle = false;
+        renderView(view);
+      });
+
+      it('should trigger before:render', function() {
+        expect(view.triggerMethod).to.be.calledWith('before:render', view);
+      });
+
+      it('should call render', function() {
+        expect(view.render).to.be.calledOnce;
+      });
+
+      it('should trigger render', function() {
+        expect(view.triggerMethod)
+          .to.be.calledWith('render', view);
+      });
+
+      describe('when view is rendered twice', function() {
+        it('should call not call render again', function() {
+          renderView(view);
+
+          expect(view.render)
+            .to.have.been.calledOnce
+            .to.not.have.been.calledTwice;
+        });
+      });
+    });
+  });
+
+  describe('#destroyView', function() {
+    beforeEach(function() {
+      this.sinon.spy(view, 'remove');
+    });
+
+    describe('when view has a native destroy method', function() {
+      beforeEach(function() {
+        view.destroy = this.sinon.stub();
+        destroyView(view, 'foo');
+      });
+
+      it('should call the view destroy', function() {
+        expect(view.destroy).to.be.calledOnce;
+      });
+
+      it('should not call view remove', function() {
+        expect(view.remove).to.not.be.called;
+      });
+
+      it('should not trigger events', function() {
+        expect(view.triggerMethod).to.not.be.called;
+      });
+
+      // Internal only test
+      it('should attach shouldDisableEvents flag to the view', function() {
+        expect(view._disableDetachEvents).to.equal('foo');
+      });
+    });
+
+    describe('when destroy lifecycle is supported', function() {
+      beforeEach(function() {
+        view.supportsDestroyLifecycle = true;
+        destroyView(view);
+      });
+
+      it('should remove the view', function() {
+        expect(view.remove).to.be.calledOnce;
+      });
+
+      it('should not trigger destroy events', function() {
+        expect(view.triggerMethod)
+          .to.not.be.calledWith('before:destroy', view)
+          .and.not.calledWith('destroy', view);
+      });
+
+      // Internal test
+      it('should mark the view destroyed', function() {
+        expect(view._isDestroyed).to.be.true;
+      });
+    });
+
+    describe('when destroy lifecycle is not supported', function() {
+      beforeEach(function() {
+        view.supportsDestroyLifecycle = false;
+        destroyView(view);
+      });
+
+      it('should trigger before:destroy event', function() {
+        expect(view.triggerMethod).to.be.calledWith('before:destroy', view)
+      });
+
+      it('should remove the view', function() {
+        expect(view.remove).to.be.calledOnce;
+      });
+
+      it('should trigger destroy event', function() {
+        expect(view.triggerMethod).to.be.calledWith('destroy', view)
+      });
+
+      // Internal test
+      it('should mark the view destroyed', function() {
+        expect(view._isDestroyed).to.be.true;
+      });
+    });
+
+    // _isAttached is internal Mn flag added by Region or CollectionView
+    describe('when view is attached', function() {
+      beforeEach(function() {
+        view._isAttached = true;
+      });
+
+      describe('when disabling events', function() {
+        beforeEach(function() {
+          destroyView(view, true);
+        });
+
+        it('should not trigger detach events', function() {
+          expect(view.triggerMethod)
+            .to.not.be.calledWith('before:detach', view)
+            .and.not.calledWith('detach', view);
+        });
+      });
+
+      describe('when not disabling events', function() {
+        beforeEach(function() {
+          destroyView(view, false);
+        });
+
+        it('should trigger before:detach event', function() {
+          expect(view.triggerMethod).to.be.calledWith('before:detach', view);
+        });
+
+        it('should trigger detach event', function() {
+          expect(view.triggerMethod).to.be.calledWith('detach', view);
+        });
+      });
+    });
+
+    describe('when view is not attached', function() {
+      beforeEach(function() {
+        view._isAttached = false;
+      });
+
+      describe('when disabling events', function() {
+        beforeEach(function() {
+          destroyView(view, true);
+        });
+
+        it('should not trigger detach events', function() {
+          expect(view.triggerMethod)
+            .to.not.be.calledWith('before:detach', view)
+            .and.not.calledWith('detach', view);
+        });
+      });
+
+      describe('when not disabling events', function() {
+        beforeEach(function() {
+          destroyView(view, false);
+        });
+
+        it('should not trigger detach events', function() {
+          expect(view.triggerMethod)
+            .to.not.be.calledWith('before:detach', view)
+            .and.not.calledWith('detach', view);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This work adds a unit spec file for the common view methods.

I believe to have fixed a bug with rendering backbone views not setting the `_isRendered` flag unless the view had `supportsRenderLifecycle`

I also reduced the need for `_disableDetachEvents` to be attached to the view and brought it much closer to it's need in `view.destroy` which also made it easier to test.

What I haven't done is look for if/where this functionality is being tested in other files.  Hopefully that will come out in some sequent unit clean up