### PR TITLE
Do not call lintspaces when linting js files

### DIFF
--- a/gulp/linting.js
+++ b/gulp/linting.js
@@ -12,8 +12,6 @@ function onError() {
 function lint(files) {
   return gulp.src(files)
     .pipe(plumber())
-    .pipe(lintspaces({editorconfig: '.editorconfig'}))
-    .pipe(lintspaces.reporter())
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failOnError())
@@ -21,7 +19,7 @@ function lint(files) {
 }
 
 function isFixed(file) {
-	return file.eslint && file.eslint.fixed;
+  return file.eslint && file.eslint.fixed;
 }
 
 function lintFix(folder) {


### PR DESCRIPTION
### Proposed changes
 - eslint provides all features of lintspaces and much more.

lintspaces is just slowing down the build