### PR TITLE
Add filteredChildren container to CollectionView

### DIFF
--- a/src/child-view-container.js
+++ b/src/child-view-container.js
@@ -43,20 +43,22 @@ _.extend(Container.prototype, {
   // cid (and model itself). Additionally it stores
   // the view by index in the _views array
   _add(view, index = this._views.length) {
-    const viewCid = view.cid;
-
-    // store the view
-    this._viewsByCid[viewCid] = view;
-
-    // index it by model
-    if (view.model) {
-      this._indexByModel[view.model.cid] = viewCid;
-    }
+    this._addViewIndexes(view);
 
     // add to end by default
     this._views.splice(index, 0, view);
 
     this._updateLength();
+  },
+
+  _addViewIndexes(view) {
+    // store the view
+    this._viewsByCid[view.cid] = view;
+
+    // index it by model
+    if (view.model) {
+      this._indexByModel[view.model.cid] = view;
+    }
   },
 
   // Sort (mutate) and return the array of the child views.
@@ -83,12 +85,20 @@ _.extend(Container.prototype, {
   },
 
   // Replace array contents without overwriting the reference.
-  _set(views) {
+  // Should not add/remove views
+  _set(views, shouldReset) {
     this._views.length = 0;
 
     this._views.push.apply(this._views, views.slice(0));
 
-    this._updateLength();
+    if (shouldReset) {
+      this._viewsByCid = {};
+      this._indexByModel = {};
+
+      _.each(views, this._addViewIndexes.bind(this));
+
+      this._updateLength();
+    }
   },
 
   // Swap views by index
@@ -112,11 +122,8 @@ _.extend(Container.prototype, {
   },
 
   // Find a view by the `cid` of the model that was attached to it.
-  // Uses the model's `cid` to find the view `cid` and
-  // retrieve the view using it.
   findByModelCid(modelCid) {
-    const viewCid = this._indexByModel[modelCid];
-    return this.findByCid(viewCid);
+    return this._indexByModel[modelCid];
   },
 
   // Find a view by index.

--- a/test/unit/child-view-container.spec.js
+++ b/test/unit/child-view-container.spec.js
@@ -14,7 +14,7 @@ describe('#ChildViewContainer', function() {
         new Backbone.View({ id: 1 }),
         new Backbone.View({ id: 2 }),
         new Backbone.View({ id: 3 })
-      ]);
+      ], true);
     });
 
     it('should be able to map over list', function() {
@@ -33,7 +33,7 @@ describe('#ChildViewContainer', function() {
         new Backbone.View(),
         new Backbone.View(),
         new Backbone.View()
-      ]);
+      ], true);
 
       container._init();
     });
@@ -45,7 +45,7 @@ describe('#ChildViewContainer', function() {
     });
 
     it('should update length to 0', function() {
-      expect(container.length).to.equal(0);
+      expect(container).to.have.lengthOf(0);
     });
   });
 
@@ -76,7 +76,7 @@ describe('#ChildViewContainer', function() {
       });
 
       it('should update the size of the chidren', function() {
-        expect(container.length).to.equal(1);
+        expect(container).to.have.lengthOf(1);
       })
     });
 
@@ -119,7 +119,7 @@ describe('#ChildViewContainer', function() {
           new Backbone.View(),
           new Backbone.View(),
           new Backbone.View()
-        ]);
+        ], true);
 
         container._add(view, 3);
 
@@ -137,6 +137,7 @@ describe('#ChildViewContainer', function() {
     let container;
     let views;
     let originalViews;
+    let originalView;
 
     beforeEach(function() {
       views = [
@@ -151,22 +152,36 @@ describe('#ChildViewContainer', function() {
       container._add(new Backbone.View());
 
       originalViews = container._views;
-
-      container._set(views);
+      originalView = container._views[0];
     });
 
     it('should replace the contents of _views', function() {
+      container._set(views);
       expect(container._views[0]).to.equal(views[0]);
     });
 
     it('should keep the _views array reference', function() {
+      container._set(views);
       expect(container._views).to.equal(originalViews);
     });
 
-    it('should update the container length', function() {
-      expect(container.length).to.equal(2);
-    });
+    describe('when resetting', function() {
+      beforeEach(function() {
+        container._set(views, true);
+      });
 
+      it('should not have an old view', function() {
+        expect(container.hasView(originalView)).to.be.false;
+      });
+
+      it('should have a new view', function() {
+        expect(container.hasView(views[0])).to.be.true;
+      });
+
+      it('should update the length', function() {
+        expect(container).to.have.lengthOf(2);
+      });
+    });
   });
 
   describe('#_remove', function() {
@@ -189,7 +204,7 @@ describe('#ChildViewContainer', function() {
           new Backbone.View(),
           new Backbone.View(),
           new Backbone.View()
-        ]);
+        ], true);
 
         container._add(view, 1);
 
@@ -197,7 +212,7 @@ describe('#ChildViewContainer', function() {
       });
 
       it('should update the size of the children', function() {
-        expect(container.length).to.equal(4);
+        expect(container).to.have.lengthOf(4);
       });
 
       it('should remove the index by model', function() {
@@ -230,7 +245,7 @@ describe('#ChildViewContainer', function() {
           new Backbone.View(),
           new Backbone.View(),
           new Backbone.View()
-        ]);
+        ], true);
 
         container._add(view, 1);
 
@@ -238,7 +253,7 @@ describe('#ChildViewContainer', function() {
       });
 
       it('should update the size of the children', function() {
-        expect(container.length).to.equal(4);
+        expect(container).to.have.lengthOf(4);
       });
 
       it('should remove the index', function() {
@@ -266,13 +281,13 @@ describe('#ChildViewContainer', function() {
           new Backbone.View(),
           new Backbone.View(),
           new Backbone.View()
-        ]);
+        ], true);
 
         container._remove(view);
       });
 
       it('should not remove a view from the container', function() {
-        expect(container.length).to.equal(4);
+        expect(container).to.have.lengthOf(4);
       });
     });
   });

--- a/test/unit/collection-view/collection-view-children.spec.js
+++ b/test/unit/collection-view/collection-view-children.spec.js
@@ -36,6 +36,10 @@ describe('CollectionView Children', function() {
     it('should instantiate the children container', function() {
       expect(myCollectionView.children).to.be.instanceOf(ChildViewContainer);
     });
+
+    it('should instantiate the children container', function() {
+      expect(myCollectionView.children).to.be.instanceOf(ChildViewContainer);
+    });
   });
 
   describe('when rendering a CollectionView', function() {
@@ -48,13 +52,8 @@ describe('CollectionView Children', function() {
       myCollectionView.onBeforeAddChild = this.sinon.stub();
       myCollectionView.onAddChild = this.sinon.stub();
 
-      this.sinon.spy(myCollectionView.children, '_init');
       this.sinon.spy(myCollectionView.children, '_add');
       myCollectionView.render();
-    });
-
-    it('should reinit the children container', function() {
-      expect(myCollectionView.children._init).to.have.been.calledOnce;
     });
 
     it('should add children to match the collection', function() {
@@ -110,6 +109,15 @@ describe('CollectionView Children', function() {
       });
 
       it('should swap the children', function() {
+        this.sinon.spy(collectionView.children, '_swap');
+
+        collectionView.swapChildViews(view1, view2);
+
+        expect(collectionView.children._swap).to.have.been.calledOnce
+          .and.calledWith(view1, view2);
+      });
+
+      it('should swap the filtered children', function() {
         this.sinon.spy(collectionView.children, '_swap');
 
         collectionView.swapChildViews(view1, view2);
@@ -649,6 +657,7 @@ describe('CollectionView Children', function() {
       myCollectionView.onBeforeDestroyChildren = this.sinon.stub();
       myCollectionView.onDestroyChildren = this.sinon.stub();
 
+      this.sinon.spy(myCollectionView.children, '_init');
       myCollectionView.render();
     });
 
@@ -663,6 +672,11 @@ describe('CollectionView Children', function() {
       myCollectionView.destroy();
       expect(myCollectionView.onBeforeDestroyChildren)
         .to.be.calledOnce.and.calledWith(myCollectionView);
+    });
+
+    it('should reinit the children container', function() {
+      myCollectionView.destroy();
+      expect(myCollectionView.children._init).to.be.calledOnce;
     });
 
     it('should trigger "destroy:children"', function() {

--- a/test/unit/collection-view/collection-view-data.spec.js
+++ b/test/unit/collection-view/collection-view-data.spec.js
@@ -80,20 +80,8 @@ describe('CollectionView Data', function() {
         myCollectionView.collection.add({ id: 5 });
       });
 
-      it('should not call the sort method', function() {
-        expect(myCollectionView.sort).to.not.have.been.called;
-      });
-
-      describe('when the collection changes but the length does not', function() {
-        beforeEach(function() {
-          const models = _.take(collection.models, 3);
-          models.push(new Backbone.Model({ id: 4 }));
-          collection.set(models);
-        });
-
-        it('should not call the sort method', function() {
-          expect(myCollectionView.sort).to.not.have.been.called;
-        });
+      it('should only sort once', function() {
+        expect(myCollectionView.sort).to.have.been.calledOnce;
       });
     });
 

--- a/test/unit/collection-view/collection-view-empty.spec.js
+++ b/test/unit/collection-view/collection-view-empty.spec.js
@@ -297,8 +297,7 @@ describe('CollectionView -  Empty', function() {
       });
 
       it('should call isEmpty', function() {
-        // Once for render and once for filter
-        expect(myCollectionView.isEmpty).to.be.calledTwice;
+        expect(myCollectionView.isEmpty).to.be.calledOnce;
       });
 
       it('should not show the emptyView', function() {
@@ -370,7 +369,7 @@ describe('CollectionView -  Empty', function() {
       });
 
       it('should call isEmpty', function() {
-        expect(myCollectionView.isEmpty).to.be.calledOnce.and.calledWith(false);
+        expect(myCollectionView.isEmpty).to.be.calledOnce;
       });
 
       it('should not show the emptyView', function() {
@@ -390,7 +389,7 @@ describe('CollectionView -  Empty', function() {
       });
 
       it('should call isEmpty', function() {
-        expect(myCollectionView.isEmpty).to.be.calledOnce.and.calledWith(true);
+        expect(myCollectionView.isEmpty).to.be.calledOnce;
       });
 
       it('should show the emptyView', function() {

--- a/test/unit/collection-view/collection-view-sorting.spec.js
+++ b/test/unit/collection-view/collection-view-sorting.spec.js
@@ -298,8 +298,10 @@ describe('CollectionView - Sorting', function() {
         expect(myCollectionView.onBeforeSort).to.not.have.been.called;
       });
 
-      it('should not render the children', function() {
-        expect(myCollectionView.onRenderChildren).to.not.have.been.called;
+      it('should render no children', function() {
+        expect(myCollectionView.onRenderChildren)
+          .to.have.been.calledOnce
+          .and.calledWith(myCollectionView, []);
       });
 
       it('should return the collectionView', function() {
@@ -390,40 +392,5 @@ describe('CollectionView - Sorting', function() {
     it('should return the collectionView instance', function() {
       expect(myCollectionView.removeComparator).to.have.returned(myCollectionView);
     });
-  });
-
-  describe('#isEmpty', function() {
-    describe('when isEmpty is true', function() {
-      it('should not sort', function() {
-        const EmptyCollectionView = MyCollectionView.extend({
-          isEmpty: _.constant(true)
-        });
-
-        const myCollectionView = new EmptyCollectionView({
-          collection
-        });
-
-        myCollectionView.render();
-
-        expect(myCollectionView.onSort).to.not.have.been.called;
-      });
-    });
-
-    describe('when isEmpty is false', function() {
-      it('should not sort', function() {
-        const NotEmptyCollectionView = MyCollectionView.extend({
-          isEmpty: _.constant(false)
-        });
-
-        const myCollectionView = new NotEmptyCollectionView({
-          collection
-        });
-
-        myCollectionView.render();
-
-        expect(myCollectionView.onSort).to.have.been.calledOnce;
-      });
-    });
-
   });
 });

--- a/test/unit/collection-view/collection-view-viewmixin.spec.js
+++ b/test/unit/collection-view/collection-view-viewmixin.spec.js
@@ -163,11 +163,8 @@ describe('CollectionView - ViewMixin', function() {
       collectionView._removeChildren();
     });
 
-    // Since the collectionView is destroyed we
-    // don't need to worry about emptying the children
-    it('should not empty the children', function() {
-
-      expect(collectionView.children.length).to.equal(2);
+    it('should empty the children', function() {
+      expect(collectionView.children).to.have.lengthOf(0);
     });
 
     it('should have destroyed all of the children', function() {


### PR DESCRIPTION
Fixes #3580

Besides this bug, the ability to understand what views are currently not filtered out has been a semi-regular request.

This does add an extra container, but I don't think it should cost that much.  I intend to run this against the js-framework-benchmark to see how it affects thing, but I don't think it'll be bad.

The big question I _think_ is in the naming..  I'm not sure `filteredChildren` makes sense as a public API?  In context it kinda does..  _however_ one alternate option is to name _this_ container to `children` and make the current `children` private.  I don't _really_ know a use-case for needing both attached and detached children.

I could see arguments either way.

@marionettejs/marionette-core ?

This needs more tests and docs