### PR TITLE
Add jsnext:main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://marionettejs.com/",
   "main": "lib/backbone.marionette.js",
   "module": "lib/backbone.marionette.esm.js",
+  "jsnext:main": "lib/backbone.marionette.esm.js",
   "sideEffects": false,
   "keywords": [
     "backbone",


### PR DESCRIPTION
### Proposed changes
 - Add jsnext:main field to package.json pointing to esm build. 

Some IDE like WebStorm does not recognize module field but recognize jsnext:main. This prevents proper autocomplete and source code following
