### PR TITLE
typo fix in marionette functions doc

### DIFF
--- a/docs/marionette.functions.md
+++ b/docs/marionette.functions.md
@@ -184,8 +184,8 @@ var Model = Bb.Model.extend({
 
 var model1 = new Model(); // => "bar"
 
-var foo;
-var model2 = new Model({}, { foo: foo }); // => "bar"
+var f;
+var model2 = new Model({}, { foo: f }); // => "bar"
 ```
 
 [Live example](https://jsfiddle.net/marionettejs/2ddk28ap/)


### PR DESCRIPTION
f is mentioned in the text, plus using foo would confuse the user anyway

### Proposed changes
 -
 -
 -

Link to the issue:
