### PR TITLE
Prevent sort/filter when adding with an index

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -642,12 +642,19 @@ const CollectionView = Backbone.View.extend({
       this.render();
     }
 
+    const hasIndex = (typeof index !== 'undefined');
+
     // Only cache views if added to the end
-    if (!index || index >= this._children.length) {
+    if (!hasIndex || index >= this._children.length) {
       this._addedViews = [view];
     }
     this._addChild(view, index);
-    this.sort();
+
+    if (hasIndex) {
+      this._renderChildren();
+    } else {
+      this.sort();
+    }
 
     return view;
   },
@@ -722,7 +729,8 @@ const CollectionView = Backbone.View.extend({
     if (this.monitorViewEvents === false) {
       this.Dom.detachContents(this.el, this.$el);
     }
-    _.each(this._children._views, this._removeChildView.bind(this));
+
+    this._removeChildViews(this._children._views);
 
     // After all children have been destroyed re-init the container
     this._children._init();


### PR DESCRIPTION
Fixes https://github.com/marionettejs/backbone.marionette/issues/3594

This work also lessens the need for https://github.com/marionettejs/backbone.marionette/issues/3593

Essentially if you're adding a view at a defined index, it skips sort and filter.  This is a small but important change.  It allows the following:
```js
// will re-sort and re-filter
myCollectionView.addChildView(new MyView());

// won't re-sort or re-filter
myCollectionView.addChildView(new MyView(), 0); 
myCollectionView.addChildView(new MyView(), 5); 
myCollectionView.addChildView(new MyView(), myCollectionView.children.length); 
```
The user will still need to handle the added views for any subsequent sort or filter, but before this change if a user wanted to insert a view at a particular location they'd either have to temporarily disable sorting and filtering or adding at the index was not useful since sorting and filtering were going to occur anyways.  It's worth noting that by default the CollectionView sorts by the `collection` so the `addChildView` index currently appears to not work by default until the sorting was fully understood.

This also makes something like `_.each(viewsArray, view => { myCv.addChildView(view, this.children.length); });` more reasonable as it won't re-sort / re-filter for each view.  Supporting an array could still be moderately more performant, by potentially utilizing a single append, but seemingly less important, particularly if children are added on the collectionview render prior to the collectionview's insertion in the DOM.

There's also one trivial change removing the `_.each` duplication by reusing `_removeChildViews`

I think this should be included with v4 as it could be considered breaking.  It doesn't need to make the alpha release necessarily.  @marionettejs/marionette-core 