### PR TITLE
Allow for use of Underscore 1.9.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "backbone": "~1.3.3",
-    "underscore": ">= 1.8.3 < 2"
+    "underscore": ">= 1.8.3 <= 1.9.x"
   },
   "devDependencies": {
     "babel-core": "6.25.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "backbone": "~1.3.3",
-    "underscore": "~1.8.3"
+    "underscore": ">= 1.8.3 < 2"
   },
   "devDependencies": {
     "babel-core": "6.25.0",
@@ -89,6 +89,6 @@
     "sinon": "1.17.6",
     "sinon-chai": "2.8.0",
     "uglify-js": "^3.0.27",
-    "underscore": "1.8 - 1.8.3"
+    "underscore": "1.8.3 - 1.9.x"
   }
 }


### PR DESCRIPTION
### Proposed changes
 - Use underscore >= 1.83 < 2 as a peer dependency.

Underscore.js 1.9.1 has been released, but currently the peer dependency set in Marionette limits Underscore.js to 1.8.3. The new version only contains additions and improvements, with seemingly no breaking changes: https://underscorejs.org/#changelog. Backbone lists its underscore dependency as >= 1.8.3: https://github.com/jashkenas/backbone/blob/master/package.json#L16, so it seems like Marionette should handle the update with no issues. All of the tests seem to pass with 1.9.1.

This update would allow for projects using the updated version of Underscore.js without having Marionette require a separate, older version.