### PR TITLE
Export default for backwards compatibility

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -6,11 +6,42 @@ patterns etc.
 
 ## Documentation Index
 
+* [Using ES6 Modules](#using-es6-modules)
 * [Class-based Inheritance](#class-based-inheritance)
   * [Value Attributes](#value-attributes)
   * [Functions Returning Values](#functions-returning-values)
   * [Binding Attributes on Instantiation](#binding-attributes-on-instantiation)
 * [Common Marionette Functionality](./common.md)
+
+## Using ES6 Modules
+
+Marionette still supports using the library via an inline script.
+
+```html
+<script src="./backbone.marionette.js"></script>
+<script>new Marionette.View({ el: 'body' });</script>
+```
+
+The recommended solution is to choose a solution like a [package manager](./installation.md)
+to allow for ES6 module importing of the library. The best way to import is using name imports.
+
+```javascript
+import { View } from 'backbone.marionette';
+import * as Mn from 'backbone.marionette';
+
+new View({ el: 'body' });
+new Mn.Application();
+```
+
+However to support backwards compatibility Marionette exports all of its classes and
+functions on a default object. This default export may be removed in a future version of
+Marionette and it is recommend to migrate to a named imports.
+
+```javascript
+import Marionette from 'backbone.marionette';
+
+new Marionette.Application();
+```
 
 ## Class-based Inheritance
 

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -143,4 +143,3 @@ Display a `View` instance in the region attached to the Application. This runs t
 Return the view currently being displayed in the Application's attached
 `region`. If the Application is not currently displaying a view, this method
 returns `undefined`.
-

--- a/docs/marionette.mnobject.md
+++ b/docs/marionette.mnobject.md
@@ -12,6 +12,7 @@
 * [Unique Client ID](#unique-client-id)
 * [Destroying a MnObject](#destroying-a-mnobject)
 * [Basic Use](#basic-use)
+* [Backwards Compatibility](#backwards-compatibility)
 
 ## Instantiating a MnObject
 
@@ -126,4 +127,18 @@ selections.listenTo(selections, 'select', function(key, item){
 });
 
 selections.select('toy', Truck);
+```
+
+## Backwards Compatibility
+
+In versions previous to v4, `MnObject` was simply named `Object`. This naming is still supported
+via the default export of the library, but should be considered **deprecated** and is scheduled for
+removal in an upcoming version.
+
+
+```javascript
+import { MnObject } from 'backbone.marionette';
+import Marionette from 'backbone.marionette';
+
+console.log(MnObject === Marionette.Object === Marionette.MnObject); // true
 ```

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -37,7 +37,8 @@ function generateBundle(bundle) {
     sourceMapFile: 'backbone.marionette.js',
     banner: banner,
     footer: 'this && this.Marionette && (this.Mn = this.Marionette);',
-    globals: rollupGlobals
+    globals: rollupGlobals,
+    exports: 'named'
   });
 }
 

--- a/src/backbone.marionette.js
+++ b/src/backbone.marionette.js
@@ -1,4 +1,4 @@
-import {version} from '../package.json';
+import {version as VERSION} from '../package.json';
 
 import proxy from './utils/proxy';
 import extend from './utils/extend';
@@ -70,5 +70,22 @@ export {
   Events,
   extend,
   DomApi,
-  version as VERSION
+  VERSION
+};
+
+export default {
+  View,
+  CollectionView,
+  MnObject,
+  Object: MnObject,
+  Region,
+  Behavior,
+  Application,
+  isEnabled,
+  setEnabled,
+  monitorViewEvents,
+  Events,
+  extend,
+  DomApi,
+  VERSION
 };

--- a/test/unit/backbone.marionette.spec.js
+++ b/test/unit/backbone.marionette.spec.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 
 import * as Mn from '../../src/backbone.marionette';
+import Marionette from '../../src/backbone.marionette';
 
 import {version} from '../../package.json';
 
@@ -46,6 +47,33 @@ describe('backbone.marionette', function() {
       it(`should have named export ${ key }`, function() {
         expect(Mn[key]).to.equal(val);
       });
+    });
+  });
+
+  describe('Default Export', function() {
+    const namedExports = {
+      View,
+      CollectionView,
+      MnObject,
+      Region,
+      Behavior,
+      Application,
+      isEnabled,
+      setEnabled,
+      monitorViewEvents,
+      Events,
+      extend,
+      DomApi,
+    };
+
+    _.each(namedExports, (val, key) => {
+      it(`should have key ${ key }`, function() {
+        expect(Marionette[key]).to.equal(val);
+      });
+    });
+
+    it('should have key Object', function() {
+      expect(Marionette.Object).to.equal(MnObject);
     });
   });
 


### PR DESCRIPTION
Including adding `Object` to the default export

I tried a slicker way what had a circular import, but it didn't like that.