### PR TITLE
Region calls empty if there is a currentView

### DIFF
--- a/src/region.js
+++ b/src/region.js
@@ -76,7 +76,7 @@ _.extend(Region.prototype, CommonMixin, {
     this.triggerMethod('before:show', this, view, options);
 
     // Assume an attached view is already in the region for pre-existing DOM
-    if (!view._isAttached) {
+    if (this.currentView || !view._isAttached) {
       this.empty(options);
     }
 

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -577,7 +577,7 @@ describe('region', function() {
 
       _.extend(MyView.prototype, Events);
 
-      this.setFixtures('<div id="region"></div><div id="pre-rendered"></div>');
+      this.setFixtures('<div id="region"></div><div id="pre-rendered">content</div>');
 
       view1 = new MyView();
       view2 = new MyView();
@@ -596,7 +596,7 @@ describe('region', function() {
     it('should call "empty" even if a new view is attached to the DOM', function() {
 
       this.sinon.spy(region, 'empty');
-      const preRenderedView = new View({ el: '#pre-rendered', template: _.template('some content') });
+      const preRenderedView = new View({ el: '#pre-rendered' });
 
       region.show(preRenderedView);
       expect(region.empty).to.have.been.called;

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -572,7 +572,7 @@ describe('region', function() {
           $(this.el).html('some content');
         },
 
-        destroy: function() {},
+        destroy: function() {}
       });
 
       _.extend(MyView.prototype, Events);
@@ -581,7 +581,7 @@ describe('region', function() {
 
       view1 = new MyView();
       view2 = new MyView();
-      region = new MyRegion({});
+      region = new MyRegion();
 
       this.sinon.spy(view1, 'destroy');
 
@@ -596,7 +596,7 @@ describe('region', function() {
     it('should call "empty" even if a new view is attached to the DOM', function() {
 
       this.sinon.spy(region, 'empty');
-      const preRenderedView = new View({ el: '#pre-rendered', template: _.noop});
+      const preRenderedView = new View({ el: '#pre-rendered', template: _.template('some content') });
 
       region.show(preRenderedView);
       expect(region.empty).to.have.been.called;

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -572,16 +572,16 @@ describe('region', function() {
           $(this.el).html('some content');
         },
 
-        destroy: function() {}
+        destroy: function() {},
       });
 
       _.extend(MyView.prototype, Events);
 
-      this.setFixtures('<div id="region"></div>');
+      this.setFixtures('<div id="region"></div><div id="pre-rendered"></div>');
 
       view1 = new MyView();
       view2 = new MyView();
-      region = new MyRegion();
+      region = new MyRegion({});
 
       this.sinon.spy(view1, 'destroy');
 
@@ -593,9 +593,19 @@ describe('region', function() {
       expect(view1.destroy).to.have.been.called;
     });
 
+    it('should call "empty" even if a new view is attached to the DOM', function() {
+
+      this.sinon.spy(region, 'empty');
+      const preRenderedView = new View({ el: '#pre-rendered', template: _.noop});
+
+      region.show(preRenderedView);
+      expect(region.empty).to.have.been.called;
+    });
+
     it('should reference the new view as the current view', function() {
       expect(region.currentView).to.equal(view2);
     });
+
   });
 
   describe('when a view is already shown and showing the same one', function() {
@@ -642,6 +652,7 @@ describe('region', function() {
     it('should not call "render" on the view', function() {
       expect(view.render).not.to.have.been.called;
     });
+
   });
 
   describe('when a Mn view is already shown but destroyed externally', function() {


### PR DESCRIPTION
### Proposed changes
 - Adding check for existence of currentView for calling empty
If a region has currentView and going to show a new view with enabled `_isAttached` then it will not clean up current view.

Link to the issue:
https://codepen.io/dimatabu/pen/NoqBBV?editors=1010