### PR TITLE
Preventing showing of shown view in a region

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -499,6 +499,8 @@ const CollectionView = Backbone.View.extend({
       view._isAttached = false;
       view.triggerMethod('detach', view);
     }
+
+    view._isShown = false;
   },
 
   // Override this method to change how the collectionView detaches a child view
@@ -538,8 +540,8 @@ const CollectionView = Backbone.View.extend({
 
     _.each(views, view => {
       renderView(view);
-      // corresponds that this view is not a pre-rendered one
-      view._attachedTo = true;
+      // corresponds that view is shown in a Region or CollectionView
+      view._isShown = true;
       this.Dom.appendContents(elBuffer, view.el, {_$contents: view.$el});
     });
 
@@ -645,6 +647,14 @@ const CollectionView = Backbone.View.extend({
   addChildView(view, index, options = {}) {
     if (!view || view._isDestroyed) {
       return view;
+    }
+
+    if (view._isShown) {
+      throw new MarionetteError({
+        name: classErrorName,
+        message: 'View is already shown in a Region or CollectionView',
+        url: 'marionette.collectionview.html#region-viewAlreadyShown'
+      });
     }
 
     if (_.isObject(index)) {

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -538,6 +538,8 @@ const CollectionView = Backbone.View.extend({
 
     _.each(views, view => {
       renderView(view);
+      // corresponds that this view is not a pre-rendered one
+      view._attachedTo = true;
       this.Dom.appendContents(elBuffer, view.el, {_$contents: view.$el});
     });
 

--- a/src/region.js
+++ b/src/region.js
@@ -300,13 +300,12 @@ _.extend(Region.prototype, CommonMixin, {
     delete this.currentView;
 
     if (!view._isDestroyed) {
-      view._isShown = false;
-
       if (shouldDestroy) {
         this.removeView(view);
       } else {
         this._detachView(view);
       }
+      view._isShown = false;
       this._stopChildViewEvents(view);
     }
 

--- a/src/region.js
+++ b/src/region.js
@@ -71,11 +71,11 @@ _.extend(Region.prototype, CommonMixin, {
 
     if (view === this.currentView) { return this; }
 
-    if (view._isAttached && view._attachedTo) {
+    if (view._isShown) {
       throw new MarionetteError({
         name: classErrorName,
-        message: 'A "view" can be attached to the DOM only if it prerendered on backend',
-        url: 'marionette.collectionview.html#region-showAttachedView'
+        message: 'View is already shown in a Region or CollectionView',
+        url: 'marionette.collectionview.html#region-viewAlreadyShown'
       });
     }
 
@@ -146,8 +146,8 @@ _.extend(Region.prototype, CommonMixin, {
       view.triggerMethod('attach', view);
     }
 
-    //corresponds that view is not a pre-rendered one
-    view._attachedTo = true;
+    //corresponds that view is shown in a marionette Region or CollectionView
+    view._isShown = true;
 
   },
 
@@ -300,6 +300,8 @@ _.extend(Region.prototype, CommonMixin, {
     delete this.currentView;
 
     if (!view._isDestroyed) {
+      view._isShown = false;
+
       if (shouldDestroy) {
         this.removeView(view);
       } else {

--- a/src/region.js
+++ b/src/region.js
@@ -71,6 +71,14 @@ _.extend(Region.prototype, CommonMixin, {
 
     if (view === this.currentView) { return this; }
 
+    if (view._isAttached && view._attachedTo) {
+      throw new MarionetteError({
+        name: classErrorName,
+        message: 'A "view" can be attached to the DOM only if it prerendered on backend',
+        url: 'marionette.collectionview.html#region-showAttachedView'
+      });
+    }
+
     this._isSwappingView = !!this.currentView;
 
     this.triggerMethod('before:show', this, view, options);
@@ -137,6 +145,10 @@ _.extend(Region.prototype, CommonMixin, {
       view._isAttached = true;
       view.triggerMethod('attach', view);
     }
+
+    //corresponds that view is not a pre-rendered one
+    view._attachedTo = true;
+
   },
 
   _ensureElement(options = {}) {

--- a/test/unit/collection-view/collection-view-children.spec.js
+++ b/test/unit/collection-view/collection-view-children.spec.js
@@ -421,6 +421,21 @@ describe('CollectionView Children', function() {
         expect(myCollectionView.addChildView).to.have.returned(destroyedView);
       });
     });
+
+    describe('when called with showed view', function() {
+      let anotherCollectionView;
+
+      beforeEach(function() {
+        anotherCollectionView = new MyCollectionView();
+        addView = new View({ template: _.noop });
+        anotherCollectionView.addChildView(addView);
+      });
+
+      it('should throw an error', function() {
+        expect(myCollectionView.addChildView.bind(myCollectionView, addView)).to.throw();
+      });
+    });
+
   });
 
   describe('#detachChildView', function() {
@@ -627,9 +642,9 @@ describe('CollectionView Children', function() {
 
         describe('when attaching another childview at the end', function() {
           let anotherView;
-
+          let AnotherView;
           beforeEach(function() {
-            const AnotherView = View.extend({
+            AnotherView = View.extend({
               template: _.noop,
               onBeforeAttach: this.sinon.stub(),
               onAttach: this.sinon.stub()
@@ -661,7 +676,7 @@ describe('CollectionView Children', function() {
 
             // Only true if not maintaining collection sort
             myCollectionView.sortWithCollection = false;
-            myCollectionView.addChildView(anotherView);
+            myCollectionView.addChildView(new AnotherView());
             const callArgs = myCollectionView.attachHtml.args[0];
             const attachHtmlEls = callArgs[0];
             expect($(attachHtmlEls).children()).to.have.lengthOf(1);

--- a/test/unit/collection-view/collection-view-children.spec.js
+++ b/test/unit/collection-view/collection-view-children.spec.js
@@ -8,6 +8,7 @@ import ChildViewContainer from '../../../src/child-view-container';
 import View from '../../../src/view';
 import Region from '../../../src/region';
 
+
 describe('CollectionView Children', function() {
   const collection = new Backbone.Collection([
     { id: 1 },
@@ -434,8 +435,32 @@ describe('CollectionView Children', function() {
       it('should throw an error', function() {
         expect(myCollectionView.addChildView.bind(myCollectionView, addView)).to.throw();
       });
+
     });
 
+    describe('when adding detached view', function() {
+      let anotherCollectionView;
+      let region;
+      beforeEach(function() {
+        anotherCollectionView = new MyCollectionView();
+        this.setFixtures('<div id="region"></div>');
+        region = new Region({ el: '#region' });
+        addView = new View({ template: _.noop });
+      });
+
+      it('should not throw an error if view was detached from CollectionView',function() {
+        anotherCollectionView.addChildView(addView);
+        anotherCollectionView.detachChildView(addView);
+        expect(myCollectionView.addChildView.bind(myCollectionView, addView)).to.not.throw();
+      });
+
+      it('should not throw an error if view was detached from Region',function() {
+        region.show(addView);
+        region.detachView(addView);
+        expect(myCollectionView.addChildView.bind(myCollectionView, addView)).to.not.throw();
+      });
+
+    });
   });
 
   describe('#detachChildView', function() {
@@ -461,6 +486,7 @@ describe('CollectionView Children', function() {
       expect(myCollectionView.removeChildView)
         .to.have.been.calledOnce.and.calledWith(detachView, { shouldDetach: true });
     });
+
   });
 
   describe('#removeChildView', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -499,10 +499,6 @@ describe('region', function() {
       testView = new View({ el: '#view' });
     });
 
-    it('should not throw an error if view is a prerendered one', function() {
-      expect(region.show.bind(region, testView)).to.not.throw();
-    });
-
     it('should throw an error if view is attached in another region', function() {
       anotherRegion.show(testView);
       expect(region.show.bind(region, testView)).to.throw();

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -341,8 +341,6 @@ describe('region', function() {
         $parentEl = region.$el.parent();
         regionHtml = $parentEl.html();
         region.replaceElement = true;
-        //have to redefine view, because its already in a region and can not be tested
-        view = new MyView();
         region.show(view);
       });
 
@@ -494,11 +492,11 @@ describe('region', function() {
     let collectionView;
 
     beforeEach(function() {
-      this.setFixtures('<div id="reg1"></div><div id="reg2"></div><div id="cv"></div><div id="view"></div>')
+      this.setFixtures('<div id="reg1"></div><div id="reg2"></div><div id="cv"></div><div id="view">content</div>')
       region = new Region({ el: '#reg1' });
       anotherRegion = new Region({ el: '#reg2' });
       collectionView = new CollectionView({ el: '#cv' });
-      testView = new View({ el: '#view', template: _.noop });
+      testView = new View({ el: '#view' });
     });
 
     it('should not throw an error if view is a prerendered one', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -492,6 +492,7 @@ describe('region', function() {
     let region;
     let anotherRegion;
     let collectionView;
+
     beforeEach(function() {
       this.setFixtures('<div id="reg1"></div><div id="reg2"></div><div id="cv"></div><div id="view"></div>')
       region = new Region({ el: '#reg1' });
@@ -501,21 +502,19 @@ describe('region', function() {
     });
 
     it('should not throw an error if view is a prerendered one', function() {
-      expect(region.show.bind(region, testView)).to.not.throw;
+      expect(region.show.bind(region, testView)).to.not.throw();
     });
 
     it('should throw an error if view is attached in another region', function() {
       anotherRegion.show(testView);
-      expect(region.show.bind(region, testView)).to.throw;
+      expect(region.show.bind(region, testView)).to.throw();
     });
 
     it('should throw an error if view is attached in a collection view', function() {
       collectionView
         .render()
         .addChildView(testView);
-
-      expect(region.show.bind(region, testView)).to.throw;
-
+      expect(region.show.bind(region, testView)).to.throw();
     });
 
   });

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -3,6 +3,7 @@ import Backbone from 'backbone';
 import Events from '../../src/mixins/events';
 import Region from '../../src/region';
 import View from '../../src/view';
+import CollectionView from '../../src/collection-view';
 
 describe('region', function() {
   'use strict';
@@ -340,6 +341,8 @@ describe('region', function() {
         $parentEl = region.$el.parent();
         regionHtml = $parentEl.html();
         region.replaceElement = true;
+        //have to redefine view, because its already in a region and can not be tested
+        view = new MyView();
         region.show(view);
       });
 
@@ -482,6 +485,39 @@ describe('region', function() {
         expect(region.removeView).not.to.have.been.called;
       });
     });
+  });
+
+  describe('when showing an attached view', function() {
+    let testView;
+    let region;
+    let anotherRegion;
+    let collectionView;
+    beforeEach(function() {
+      this.setFixtures('<div id="reg1"></div><div id="reg2"></div><div id="cv"></div><div id="view"></div>')
+      region = new Region({ el: '#reg1' });
+      anotherRegion = new Region({ el: '#reg2' });
+      collectionView = new CollectionView({ el: '#cv' });
+      testView = new View({ el: '#view', template: _.noop });
+    });
+
+    it('should not throw an error if view is a prerendered one', function() {
+      expect(region.show.bind(region, testView)).to.not.throw;
+    });
+
+    it('should throw an error if view is attached in another region', function() {
+      anotherRegion.show(testView);
+      expect(region.show.bind(region, testView)).to.throw;
+    });
+
+    it('should throw an error if view is attached in a collection view', function() {
+      collectionView
+        .render()
+        .addChildView(testView);
+
+      expect(region.show.bind(region, testView)).to.throw;
+
+    });
+
   });
 
   describe('when showing nested views', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -482,6 +482,7 @@ describe('region', function() {
       it('should not call removeView', function() {
         expect(region.removeView).not.to.have.been.called;
       });
+
     });
   });
 
@@ -511,6 +512,33 @@ describe('region', function() {
       expect(region.show.bind(region, testView)).to.throw();
     });
 
+  });
+
+  describe('when showing detached view', function() {
+    let collectionView;
+    let anotherRegion;
+    let region;
+    let view;
+
+    beforeEach(function() {
+      this.setFixtures('<div id="region"></div><div id="another-region"></div>');
+      collectionView = new CollectionView();
+      region = new Region({ el: '#region' });
+      anotherRegion = new Region({ el: '#another-region' });
+      view = new View({ template: _.noop });
+    });
+
+    it('should not throw an error if a view was detached from CollectionView',function() {
+      collectionView.addChildView(view);
+      collectionView.detachChildView(view);
+      expect(region.show.bind(region, view)).to.not.throw();
+    });
+
+    it('should not throw an error if a view was detached from Region',function() {
+      anotherRegion.show(view);
+      anotherRegion.detachView(view);
+      expect(region.show.bind(region, view)).to.not.throw();
+    });
   });
 
   describe('when showing nested views', function() {

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -450,8 +450,9 @@ describe('layoutView', function() {
 
       this.sinon.spy(this.layoutView.getRegion('regionOne'), 'empty');
       this.view = new BBView();
-      this.view.destroy = function() { };
+      this.view.destroy = function() {};
       this.layoutView.getRegion('regionOne').show(this.view);
+
       this.layoutView.render();
       this.layoutView.getRegion('regionOne').show(this.view);
       this.region = this.layoutView.getRegion('regionOne');

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -450,9 +450,8 @@ describe('layoutView', function() {
 
       this.sinon.spy(this.layoutView.getRegion('regionOne'), 'empty');
       this.view = new BBView();
-      this.view.destroy = function() {};
+      this.view.destroy = function() { };
       this.layoutView.getRegion('regionOne').show(this.view);
-
       this.layoutView.render();
       this.layoutView.getRegion('regionOne').show(this.view);
       this.region = this.layoutView.getRegion('regionOne');


### PR DESCRIPTION
### Proposed changes
 - Its possible now to show one view in multiple regions and this can lead to unexpected behavior. 
 - This fix checks if a view prerendered on the backend or somewhere else and if the view is Attached and not prerendered then error occurs

Link to the issue:
https://codepen.io/dimatabu/pen/bzVbvY?editors=1010

note:
throwed error contains unexistent url to the documentation and should be fixed