### PR TITLE
Use ownerdocument for document element

### DIFF
--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -269,7 +269,7 @@ const CollectionView = Backbone.View.extend({
   setElement() {
     Backbone.View.prototype.setElement.apply(this, arguments);
 
-    this._isAttached = this.Dom.hasEl(document.documentElement, this.el);
+    this._isAttached = this._isElAttached();
 
     return this;
   },

--- a/src/common/monitor-view-events.js
+++ b/src/common/monitor-view-events.js
@@ -27,7 +27,6 @@ function shouldTriggerDetach(view) {
 }
 
 function shouldDetach(view) {
-  if (!shouldTriggerDetach(view)) { return false; }
   view._isAttached = false;
   return true;
 }

--- a/src/config/dom.js
+++ b/src/config/dom.js
@@ -21,6 +21,11 @@ export default {
     return document.createDocumentFragment();
   },
 
+  // Returns the document element for a given DOM element
+  getDocumentEl(el) {
+    return el.ownerDocument.documentElement;
+  },
+
   // Lookup the `selector` string
   // Selector may also be a DOM element
   // Returns an array-like object of nodes

--- a/src/config/dom.js
+++ b/src/config/dom.js
@@ -35,8 +35,8 @@ export default {
 
   // Finds the `selector` string with the el
   // Returns an array-like object of nodes
-  findEl(el, selector, _$el = getEl(el)) {
-    return _$el.find(selector);
+  findEl(el, selector) {
+    return getEl(el).find(selector);
   },
 
   // Returns true if the el contains the node childEl

--- a/src/mixins/view.js
+++ b/src/mixins/view.js
@@ -26,6 +26,10 @@ import DomApi from '../config/dom';
 const ViewMixin = {
   Dom: DomApi,
 
+  _isElAttached() {
+    return !!this.el && this.Dom.hasEl(this.Dom.getDocumentEl(this.el), this.el);
+  },
+
   supportsRenderLifecycle: true,
   supportsDestroyLifecycle: true,
 

--- a/src/region.js
+++ b/src/region.js
@@ -127,9 +127,13 @@ _.extend(Region.prototype, CommonMixin, {
     return this._parentView && this._parentView.monitorViewEvents === false;
   },
 
-  _attachView(view, options = {}) {
-    const shouldTriggerAttach = !view._isAttached && this.Dom.hasEl(document.documentElement, this.el) && !this._shouldDisableMonitoring();
-    const shouldReplaceEl = typeof options.replaceElement === 'undefined' ? !!_.result(this, 'replaceElement') : !!options.replaceElement;
+  _isElAttached() {
+    return this.Dom.hasEl(this.Dom.getDocumentEl(this.el), this.el);
+  },
+
+  _attachView(view, { replaceElement } = {}) {
+    const shouldTriggerAttach = !view._isAttached && this._isElAttached() && !this._shouldDisableMonitoring();
+    const shouldReplaceEl = typeof replaceElement === 'undefined' ? !!_.result(this, 'replaceElement') : !!replaceElement;
 
     if (shouldTriggerAttach) {
       view.triggerMethod('before:attach', view);
@@ -146,9 +150,8 @@ _.extend(Region.prototype, CommonMixin, {
       view.triggerMethod('attach', view);
     }
 
-    //corresponds that view is shown in a marionette Region or CollectionView
+    // Corresponds that view is shown in a marionette Region or CollectionView
     view._isShown = true;
-
   },
 
   _ensureElement(options = {}) {
@@ -230,7 +233,7 @@ _.extend(Region.prototype, CommonMixin, {
   },
 
   _replaceEl(view) {
-    // always restore the el to ensure the regions el is present before replacing
+    // Always restore the el to ensure the regions el is present before replacing
     this._restoreEl();
 
     view.on('before:destroy', this._restoreEl, this);

--- a/src/region.js
+++ b/src/region.js
@@ -389,9 +389,7 @@ _.extend(Region.prototype, CommonMixin, {
   reset(options) {
     this.empty(options);
 
-    if (this.$el) {
-      this.el = this._initEl;
-    }
+    this.el = this._initEl;
 
     delete this.$el;
     return this;

--- a/src/view.js
+++ b/src/view.js
@@ -60,7 +60,7 @@ const View = Backbone.View.extend({
     Backbone.View.prototype.setElement.apply(this, arguments);
 
     this._isRendered = this.Dom.hasContents(this.el);
-    this._isAttached = this.Dom.hasEl(document.documentElement, this.el);
+    this._isAttached = this._isElAttached();
 
     if (this._isRendered) {
       this.bindUIElements();

--- a/test/unit/collection-view/collection-view.spec.js
+++ b/test/unit/collection-view/collection-view.spec.js
@@ -264,9 +264,9 @@ describe('CollectionView', function() {
       const myCollectionView = new CollectionView();
       const bBSetElement = this.sinon.spy(Backbone.View.prototype, 'setElement');
 
-      myCollectionView.setElement(1,2,3,4);
+      myCollectionView.setElement('#foo',2,3,4);
 
-      expect(bBSetElement).to.be.calledWith(1,2,3,4);
+      expect(bBSetElement).to.be.calledWith('#foo',2,3,4);
     });
 
     it('should return the collectionView instance', function() {

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -406,24 +406,20 @@ describe('region', function() {
 
         beforeEach(function() {
           MyView2 = View.extend({
-            events: {
-              'click': function() {}
-            },
             template: _.template('some different content'),
-            destroy: function() {},
-            onBeforeShow: function() {},
-            onShow: function() {
-              $(this.el).addClass('onShowClass');
-            },
-            onBeforeRender: function() {},
+            onAttach: this.sinon.stub()
           });
 
           view2 = new MyView2();
-          region.show(view2, showOptions);
+          region.show(view2, { replaceElement: true });
         });
 
         it('should append the view HTML to the parent "el"', function() {
           expect($parentEl).to.contain.$html(view2.$el.html());
+        });
+
+        it('should trigger attach events', function() {
+          expect(view2.onAttach).to.be.calledOnce;
         });
       });
     });


### PR DESCRIPTION
Resolves https://github.com/marionettejs/backbone.marionette/issues/3640

~~While working on this I found a bug where showing a view in a region with `replaceElement: true` that already had a view will not get the `attach` events because the event checks the region's `el`.  So this also checks against the replaced view's el as a fix, but I need to add a test case to cover this logic branch.~~

[ ] Tests for replaceElement attached issue