### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/dom.interactions.md
+++ b/docs/dom.interactions.md
@@ -122,7 +122,7 @@ As when passing a string reference to a view method, the `events` attribute
 passes in the `event` as the argument to the function called.
 
 **Note** Backbone `events` are delegated to the view's `el`. This means that
-events with a dom node selector will be handled for the view and any decendants.
+events with a dom node selector will be handled for the view and any descendants.
 So if you attach a child with the same selector as the parent event handler, the
 parent will handle the event for both views.
 

--- a/docs/events.class.md
+++ b/docs/events.class.md
@@ -214,7 +214,7 @@ The `MnObject` class triggers [Destroy Events](#destroy-and-beforedestroy-events
 
 These events fire before (`before:add:region`) and after (`add:region`) a region is added to a view.
 This event handler will receive the view instance, the region name string, and the region instance as
-event arguments. The region is fully instantated for both events.
+event arguments. The region is fully instantiated for both events.
 
 ### `remove:region` and `before:remove:region` events
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -120,7 +120,7 @@ core of `onEvent` Binding.
 
 The major difference between `Backbone.trigger` and `triggerMethod` is
 that `triggerMethod` can fire specially named events on the instance. For
-example, a view that has been rendered will iternally fire `view.triggerMethod('render')`
+example, a view that has been rendered will internally fire `view.triggerMethod('render')`
 and call `onRender` - providing a handy way to add behavior to your views.
 
 Determining what method an event will call is easy, we will outline this with an

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -898,7 +898,7 @@ cv.removeComparator({ preventRender: true });
 
 By default the `CollectionView` will maintain a sorted collection's order
 in the DOM. This behavior can be disabled by specifying `{sortWithCollection: false}`
-on initialize or on the view definiton.
+on initialize or on the view definition.
 
 ```javascript
 import Backbone from 'backbone';

--- a/docs/upgrade-v3-v4.md
+++ b/docs/upgrade-v3-v4.md
@@ -48,7 +48,7 @@ One of the required changes is to explicitly define the `childView` when impleme
    Even better explictly define the proxies via `childViewEvents` and `childViewTriggers`.
 
 #### Marionette global instance is not attached to Backbone global instance
- * **Old behavior:** Marionette could be acessed using `Backbone.Marionette`
+ * **Old behavior:** Marionette could be accessed using `Backbone.Marionette`
  * **New behavior:** Marionette is not attached to `Backbone` global instance
  * **Reason:** Support named exports
  * **Remedy:** Import Marionette classes directly or use global Marionette instance (when using as a standalone script)

--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -56,7 +56,7 @@ For more information on instanting a view with pre-rendered DOM see: [Prerendere
 
 ### Using `setElement`
 
-`Backbone.View` allows the user to change the view's `el` after instantiaton using
+`Backbone.View` allows the user to change the view's `el` after instantiation using
 [`setElement`](http://backbonejs.org/#View-setElement). This method can be used in Marionette
 as well, but should be done with caution. `setElement` will redelegate view events, but it will
 essentially ignore children of the view, whether through `regions` or through `children` and the

--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -150,7 +150,7 @@ versions).
 ### Backbone.EventBinder is now obsolete
 
 With Backbone v0.9.9, the Backbone.EventBinder pre-requisite is now
-osbsolete. It will be kept around for backward compatibility with
+obsolete. It will be kept around for backward compatibility with
 older versions of Marionette and Backbone, but it is no longer used
 by Marionette directly. Unless you have a significant investment in
 its use, you should discontinue its use when ugprading to Marionette


### PR DESCRIPTION
There are small typos in:
- docs/dom.interactions.md
- docs/events.class.md
- docs/events.md
- docs/marionette.collectionview.md
- docs/upgrade-v3-v4.md
- docs/view.lifecycle.md
- upgradeGuide.md

Fixes:
- Should read `obsolete` rather than `osbsolete`.
- Should read `internally` rather than `iternally`.
- Should read `instantiation` rather than `instantiaton`.
- Should read `instantiated` rather than `instantated`.
- Should read `descendants` rather than `decendants`.
- Should read `definition` rather than `definiton`.
- Should read `accessed` rather than `acessed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md