### PR TITLE
feat(collection-view): reorder children in place

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+### Next
+
+#### Features
+* Added `DomApi.insertContents` for adapter-level child insertion and moves.
+* `CollectionView` now moves existing child elements in place when only their order changes.
+
 ### v4.1.3 [view commit logs](https://github.com/marionettejs/backbone.marionette/compare/v4.1.2...v4.1.3)
 
 #### Fixes

--- a/docs/dom.api.md
+++ b/docs/dom.api.md
@@ -27,7 +27,7 @@ const elIsAttached = this.Dom.hasEl(this.Dom.getDocumentEl(this.el), this.el);
 
 ### `getEl(selector)`
 
-Lookup the `selector` string withing the DOM. The `selector` may also be a DOM element.
+Lookup the `selector` string within the DOM. The `selector` may also be a DOM element.
 It should return an array-like object of the node.
 
 ### `findEl(el, selector)`
@@ -60,6 +60,13 @@ functions, this only takes a literal string for its second argument.
 
 Takes the DOM node `el` and appends the DOM node `contents` to the end of the
 element's contents.
+
+### `insertContents(parent, child, beforeNode)`
+
+Inserts the DOM node `child` into `parent` before the DOM node `beforeNode`.
+If `beforeNode` is `null` or `undefined`, `child` is appended to the end.
+When `child` is already in `parent`, this moves the existing node instead of
+creating a replacement.
 
 ### `hasContents(el)`
 

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -271,6 +271,9 @@ is the expected container for the children which by default equates
 to the view's `el` unless a [`childViewContainer`](#defining-the-childViewContainer)
 is set.
 
+`attachHtml` is called on initial render and on full re-render. It is not called
+when only the order of existing children changes.
+
 ### Destroying All `children`
 
 `CollectionView` implements a `destroy` method which automatically
@@ -773,6 +776,15 @@ will trigger.
 By default the `CollectionView` will maintain a sorted collection's order
 in the DOM. This behavior can be disabled by specifying `{sortWithCollection: false}`
 on initialize.
+
+A sort that only changes the order of existing child views moves those views in
+place with the DOM API's [`insertContents`](./dom.api.md#insertcontentsparent-child-beforenode).
+This avoids rebuilding the child buffer and preserves state on the existing
+child elements, including focus and scroll position.
+
+The in-place path is skipped when filtering changes which children are shown or
+when children are added or removed. Those cases continue to use the full buffer
+path and call `attachHtml`.
 
 ### Defining the `viewComparator`
 

--- a/src/collection-view.js
+++ b/src/collection-view.js
@@ -160,6 +160,7 @@ const CollectionView = Backbone.View.extend({
 
     this.children._remove(view);
     this._children._remove(view);
+    this._filterChangedMembership = true;
 
     this.triggerMethod('remove:child', this, view);
   },
@@ -191,6 +192,7 @@ const CollectionView = Backbone.View.extend({
     this._setupChildView(view);
     this._children._add(view, index);
     this.children._add(view, index);
+    this._filterChangedMembership = true;
 
     this.triggerMethod('add:child', this, view);
   },
@@ -396,13 +398,17 @@ const CollectionView = Backbone.View.extend({
   },
 
   _filterChildren() {
-    if (!this._children.length) { return; }
+    if (!this._children.length) {
+      this._filterChangedMembership = false;
+      return;
+    }
 
     const viewFilter = this._getFilter();
 
     if (!viewFilter) {
       const shouldReset = this.children.length !== this._children.length;
 
+      this._filterChangedMembership = this._filterChangedMembership || shouldReset;
       this.children._set(this._children._views, shouldReset);
 
       return;
@@ -423,6 +429,7 @@ const CollectionView = Backbone.View.extend({
     this._detachChildren(detachViews);
 
     // reset children
+    this._filterChangedMembership = this._filterChangedMembership || detachViews.length > 0 || attachViews.length !== this.children.length;
     this.children._set(attachViews, true);
 
     this.triggerMethod('filter', this, attachViews, detachViews);
@@ -527,11 +534,20 @@ const CollectionView = Backbone.View.extend({
     } else {
       this._destroyEmptyView();
 
-      const els = this._getBuffer(views);
+      if (
+        this._isRendered &&
+        !this._addedViews &&
+        !this._filterChangedMembership
+      ) {
+        this._reorderInPlace(views);
+      } else {
+        const els = this._getBuffer(views);
 
-      this._attachChildren(els, views);
+        this._attachChildren(els, views);
+      }
     }
 
+    this._filterChangedMembership = false;
     delete this._addedViews;
 
     this.triggerMethod('render:children', this, views);
@@ -572,8 +588,26 @@ const CollectionView = Backbone.View.extend({
 
   // Override this method to do something other than `.append`.
   // You can attach any HTML at this point including the els.
+  // Called on initial render and on full re-render. Not called when only
+  // the order of existing children changes.
   attachHtml(els, $container) {
     this.Dom.appendContents($container[0], els, {_$el: $container});
+  },
+
+  _reorderInPlace(views) {
+    const container = this.$container[0];
+    let prev = null;
+
+    _.each(views, view => {
+      const el = view.el;
+      const expectedNext = prev ? prev.nextSibling : container.firstChild;
+
+      if (el !== expectedNext) {
+        this.Dom.insertContents(container, el, expectedNext);
+      }
+
+      prev = el;
+    });
   },
 
   isEmpty() {

--- a/src/config/dom.js
+++ b/src/config/dom.js
@@ -95,6 +95,12 @@ export default {
     _$el.append(_$contents);
   },
 
+  // Insert the DOM node `child` into `parent` before the DOM node `beforeNode`.
+  // If `beforeNode` is null or undefined, append `child` to the end.
+  insertContents(parent, child, beforeNode) {
+    parent.insertBefore(child, beforeNode || null);
+  },
+
   // Does the el have child nodes
   hasContents(el) {
     return !!el && el.hasChildNodes();

--- a/test/unit/collection-view/collection-view-sorting.spec.js
+++ b/test/unit/collection-view/collection-view-sorting.spec.js
@@ -393,4 +393,194 @@ describe('CollectionView - Sorting', function() {
       expect(myCollectionView.removeComparator).to.have.returned(myCollectionView);
     });
   });
+
+  describe('reorder in place', function() {
+    let myCollectionView;
+
+    function renderCollectionView(options = {}) {
+      myCollectionView = new MyCollectionView(_.extend({
+        collection
+      }, options));
+
+      myCollectionView.render();
+      return myCollectionView;
+    }
+
+    function sortCollection(sortKey = 'sort') {
+      collection.comparator = sortKey;
+      collection.sort();
+    }
+
+    it('should move children in place when only the order changes', function() {
+      renderCollectionView();
+
+      this.sinon.spy(myCollectionView.Dom, 'insertContents');
+      this.sinon.spy(myCollectionView.Dom, 'appendContents');
+      this.sinon.spy(myCollectionView.Dom, 'detachEl');
+      this.sinon.spy(myCollectionView.Dom, 'detachContents');
+      this.sinon.spy(myCollectionView.Dom, 'replaceEl');
+      this.sinon.spy(myCollectionView.Dom, 'setContents');
+      this.sinon.spy(myCollectionView.Dom, 'swapEl');
+      this.sinon.spy(myCollectionView, 'attachHtml');
+
+      sortCollection();
+
+      expect(myCollectionView.Dom.insertContents).to.have.been.called;
+      expect(myCollectionView.attachHtml).to.not.have.been.called;
+      expect(myCollectionView.Dom.appendContents).to.not.have.been.called;
+      expect(myCollectionView.Dom.detachEl).to.not.have.been.called;
+      expect(myCollectionView.Dom.detachContents).to.not.have.been.called;
+      expect(myCollectionView.Dom.replaceEl).to.not.have.been.called;
+      expect(myCollectionView.Dom.setContents).to.not.have.been.called;
+      expect(myCollectionView.Dom.swapEl).to.not.have.been.called;
+      expect(myCollectionView.$el.text()).to.equal(sortText);
+    });
+
+    it('should use the buffer path when filtering changes membership', function() {
+      renderCollectionView({
+        viewFilter(view) {
+          return view.model.get('visible') !== false;
+        }
+      });
+
+      this.sinon.spy(myCollectionView.Dom, 'insertContents');
+      this.sinon.spy(myCollectionView, 'attachHtml');
+
+      collection.at(0).set('visible', false);
+      sortCollection();
+
+      expect(myCollectionView.attachHtml).to.have.been.calledOnce;
+      expect(myCollectionView.Dom.insertContents).to.not.have.been.called;
+    });
+
+    it('should use the buffer path when sorting after adding a child', function() {
+      collection.comparator = 'sort';
+      renderCollectionView();
+
+      this.sinon.spy(myCollectionView.Dom, 'insertContents');
+      this.sinon.spy(myCollectionView, 'attachHtml');
+
+      collection.add({ index: 5, sort: 0, altSort: 6 }, { sort: true });
+
+      expect(myCollectionView.attachHtml).to.have.been.calledOnce;
+      expect(myCollectionView.Dom.insertContents).to.not.have.been.called;
+    });
+
+    it('should preserve focused child elements when sorting', function() {
+      const InputView = View.extend({
+        tagName: 'li',
+        template: _.template('<input value="<%- index %>">')
+      });
+
+      const InputCollectionView = CollectionView.extend({
+        tagName: 'ul',
+        childView: InputView
+      });
+
+      myCollectionView = new InputCollectionView({ collection });
+      myCollectionView.render();
+      this.setFixtures(myCollectionView.el);
+
+      const focusedInput = myCollectionView.children.findByIndex(0).$('input')[0];
+      focusedInput.focus();
+
+      sortCollection();
+
+      expect(document.activeElement).to.equal(focusedInput);
+    });
+
+    it('should preserve child scroll state when sorting', function() {
+      const ScrollingView = View.extend({
+        tagName: 'li',
+        template: _.template('<div class="scrolling" style="height: 10px; overflow: auto;"><div style="height: 100px;"></div></div>')
+      });
+
+      const ScrollingCollectionView = CollectionView.extend({
+        tagName: 'ul',
+        childView: ScrollingView
+      });
+
+      myCollectionView = new ScrollingCollectionView({ collection });
+      myCollectionView.render();
+
+      const scrollingEl = myCollectionView.children.findByIndex(0).$('.scrolling')[0];
+      scrollingEl.scrollTop = 20;
+
+      sortCollection();
+
+      expect(scrollingEl.scrollTop).to.equal(20);
+    });
+
+    it('should preserve child element identity when sorting', function() {
+      renderCollectionView();
+
+      const childView = myCollectionView.children.findByIndex(0);
+      const childEl = childView.el;
+
+      sortCollection();
+
+      expect(childView.el).to.equal(childEl);
+    });
+
+    it('should not reconnect custom elements when sorting', function() {
+      if (!window.customElements) {
+        this.skip();
+      }
+
+      const tagName = `mn-reorder-${ _.uniqueId() }`;
+      const lifecycle = {
+        connected: 0,
+        disconnected: 0
+      };
+
+      class ReorderElement extends HTMLElement {
+        connectedCallback() {
+          lifecycle.connected++;
+        }
+
+        disconnectedCallback() {
+          lifecycle.disconnected++;
+        }
+      }
+
+      window.customElements.define(tagName, ReorderElement);
+
+      const CustomElementView = View.extend({
+        tagName,
+        template: false
+      });
+
+      const CustomElementCollectionView = CollectionView.extend({
+        childView: CustomElementView
+      });
+
+      myCollectionView = new CustomElementCollectionView({ collection });
+      myCollectionView.render();
+      this.setFixtures(myCollectionView.el);
+
+      expect(lifecycle.connected).to.equal(collection.length);
+      expect(lifecycle.disconnected).to.equal(0);
+
+      sortCollection();
+
+      expect(lifecycle.connected).to.equal(collection.length);
+      expect(lifecycle.disconnected).to.equal(0);
+    });
+
+    it('should use the configured Dom.insertContents override', function() {
+      const insertContents = this.sinon.spy(function(parent, child, beforeNode) {
+        parent.insertBefore(child, beforeNode || null);
+      });
+      const CustomDomCollectionView = MyCollectionView.extend();
+      CustomDomCollectionView.setDomApi({ insertContents });
+
+      myCollectionView = new CustomDomCollectionView({ collection });
+      myCollectionView.render();
+
+      sortCollection();
+
+      expect(insertContents).to.have.been.called;
+      expect(myCollectionView.$el.text()).to.equal(sortText);
+    });
+  });
 });

--- a/test/unit/config/dom.js
+++ b/test/unit/config/dom.js
@@ -262,6 +262,45 @@ describe('DomApi', function() {
     });
   });
 
+  describe('#insertContents', function() {
+    let domEl;
+    let first;
+    let second;
+    let third;
+
+    beforeEach(function() {
+      this.setFixtures('<div id="foo"><div id="first"></div><div id="second"></div></div>');
+      domEl = $('#foo')[0];
+      first = $('#first')[0];
+      second = $('#second')[0];
+      third = $('<div id="third"></div>')[0];
+    });
+
+    it('should append the contents when beforeNode is null', function() {
+      DomApi.insertContents(domEl, third);
+
+      expect(domEl.lastChild).to.equal(third);
+    });
+
+    it('should insert the contents before a sibling', function() {
+      DomApi.insertContents(domEl, third, second);
+
+      expect(domEl.children[1]).to.equal(third);
+    });
+
+    it('should move contents within the same parent', function() {
+      const observer = new window.MutationObserver(this.sinon.spy());
+      observer.observe(domEl, { childList: true });
+
+      DomApi.insertContents(domEl, second, first);
+      observer.disconnect();
+
+      expect(domEl.children[0]).to.equal(second);
+      expect(domEl.children[1]).to.equal(first);
+      expect(domEl.children).to.have.lengthOf(2);
+    });
+  });
+
   describe('#hasContents', function() {
     it('should return true when el has contents', function() {
       this.setFixtures('<div id="foo">Existing Html</div>');

--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -3,6 +3,18 @@
 Upgrade information for newer versions are available in the changelog or upgrade guides
 found on [marionettejs.com](http://marionettejs.com/docs/current).
 
+## Future 4.x
+
+### CollectionView child reordering
+
+`CollectionView` sorts that only reorder existing children now move the existing
+child elements with `DomApi.insertContents` instead of rebuilding the child
+buffer.
+
+This preserves element state such as focus and scroll position during pure
+reorders. It also means `CollectionView#attachHtml` is not called for those
+pure reorder renders.
+
 ## v2.x - v3.0.0
 A lot of changes were made between v2 and v3. Please see the
 [upgrade guide on the website](http://marionettejs.com/docs/v3.0.0/upgrade-v2-v3.html)


### PR DESCRIPTION
## What
- Add `DomApi.insertContents(parent, child, beforeNode)` as the DOM adapter primitive for inserting or moving an existing child before a sibling.
- Update `CollectionView` pure reorder renders to move existing child elements in place instead of rebuilding through the buffer path.
- Document the reorder behavior, `attachHtml` impact, DOM API addition, upgrade note, and changelog entry.

## Why
Pure reorder renders currently detach and reattach child elements through the buffer path. That resets DOM-owned state such as focused inputs, scroll positions, animation state, observer state, and custom element lifecycle behavior. Moving existing children with `insertBefore` preserves that state while keeping add/remove/filter membership changes on the existing full render path.

## Scope
Impacted areas:
- `CollectionView` child rendering for order-only collection changes.
- DOM adapter API via `insertContents`.
- CollectionView and DOM API documentation.
- Unit tests for reorder behavior and direct DOM primitive behavior.

Intentionally not changed:
- Add/remove/filter membership changes still use the existing buffer attach path.
- No generated `lib/` build artifacts are included in this branch.

## Deployment Impact
No app form redeploys apply for this repository. Consumers need the normal Marionette package release/update path to receive the behavior change.

## Testing
- Ran focused Marionette lint for the edited source and test files:
  `./node_modules/.bin/eslint src/config/dom.js src/config/features.js src/collection-view.js test/unit/config/dom.js test/unit/collection-view/collection-view-sorting.spec.js`
- Ran focused Marionette unit tests:
  `node ./node_modules/mocha/bin/_mocha --config ./test/.mocharc.json test/unit/config/dom.js test/unit/collection-view/collection-view-sorting.spec.js`
  Result: `1055 passing, 1 pending`
- Built Marionette with `npm run build`, manually copied the built package into an app consuming `backbone.marionette`, and verified the copied build contained `insertContents` and `_reorderInPlace`.